### PR TITLE
Ability to launch remote debug

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -6,7 +6,7 @@ import IBMiContent from "./api/IBMiContent";
 import { Storage } from "./api/Storage";
 const path = require(`path`);
 
-const CompileTools = require(`./api/CompileTools`);
+const CompileTools = require(`./api/actions/CompileTools`);
 
 import { Terminal } from './api/Terminal';
 const Deployment = require(`./api/Deployment`);

--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -508,8 +508,12 @@ module.exports = class CompileTools {
               port,
             };
 
-            this.launchRemoteDebug(debugConfig);
-            variables[`&PORT`] = String(port);
+            try {
+              this.launchRemoteDebug(debugConfig);
+              variables[`&PORT`] = String(port);
+            } catch (e) {
+              vscode.window.showErrorMessage(e.message || e)
+            }
           }
 
           command = this.replaceValues(command, variables);
@@ -658,6 +662,8 @@ module.exports = class CompileTools {
     }
 
     if (commandString) {
+
+      vscode.window.createTerminal()
 
       const commands = commandString.split(`\n`).filter(command => command.trim().length > 0);
 

--- a/src/api/Deployment.js
+++ b/src/api/Deployment.js
@@ -3,7 +3,7 @@ const path = require(`path`);
 const vscode = require(`vscode`);
 
 const {default: IBMi} = require(`./IBMi`);
-const CompileTools = require(`./CompileTools`);
+const CompileTools = require(`./actions/CompileTools`);
 
 
 const { ConnectionConfiguration } = require(`./Configuration`);

--- a/src/api/Terminal.ts
+++ b/src/api/Terminal.ts
@@ -207,6 +207,7 @@ export namespace Terminal {
           const buffer = Buffer.from(data);
 
           if (buffer[0] === 3) {
+            channel.stdin.write(data);
             writeEmitter.fire(`Ending terminal\r\n`);
             endEmitter.fire(0);
           }

--- a/src/api/actions/CompileTools.js
+++ b/src/api/actions/CompileTools.js
@@ -471,21 +471,25 @@ module.exports = class CompileTools {
           command = this.replaceValues(command, variables);
 
           if (action.debug) {
+            if (action.environment === `pase`) {
             /** @type {RemoteDebugConfig} */
-            const debugConfig = {
-              type: action.debug,
-              remoteRoot: config.homeDirectory,
-              address: connection.currentHost,
-              workspace: workspaceFolder,
-              port,
-            };
+              const debugConfig = {
+                type: action.debug,
+                remoteRoot: config.homeDirectory,
+                address: connection.currentHost,
+                workspace: workspaceFolder,
+                port,
+              };
 
-            try {
-              await backgroundPaseTask(connection, `cd ${config.homeDirectory} && ${command}`)
-              await launchRemoteDebug(debugConfig);
+              try {
+                await backgroundPaseTask(connection, `cd ${config.homeDirectory} && ${command}`)
+                await launchRemoteDebug(debugConfig);
               
-            } catch (e) {
-              vscode.window.showErrorMessage(e.message || e);
+              } catch (e) {
+                vscode.window.showErrorMessage(e.message || e);
+              }
+            } else {
+              vscode.window.showErrorMessage(`Debug mode only supports running commands in the pase environment.`);
             }
 
           } else {

--- a/src/api/actions/CompileTools.js
+++ b/src/api/actions/CompileTools.js
@@ -482,8 +482,11 @@ module.exports = class CompileTools {
               };
 
               try {
-                await backgroundPaseTask(connection, `cd ${config.homeDirectory} && ${command}`)
-                await launchRemoteDebug(debugConfig);
+                const timeOut = action.debug === `node` ? 200 : 3000;
+                await backgroundPaseTask(connection, `cd ${config.homeDirectory} && ${command}`);
+                setTimeout(() => {
+                  launchRemoteDebug(debugConfig);
+                }, timeOut);
               
               } catch (e) {
                 vscode.window.showErrorMessage(e.message || e);

--- a/src/api/actions/debug.ts
+++ b/src/api/actions/debug.ts
@@ -34,7 +34,8 @@ export function launchRemoteDebug(config: RemoteDebugConfig) {
           "remoteRoot": config.remoteRoot // To current working directory ~/project1
         }
       ],
-      "justMyCode": true
+      "stopOnEntry": true,
+      "justMyCode": false
     })
     break;
   

--- a/src/api/actions/debug.ts
+++ b/src/api/actions/debug.ts
@@ -1,0 +1,43 @@
+import { debug } from "vscode";
+
+export function launchRemoteDebug(config: RemoteDebugConfig) {
+  /** @type {WorkspaceFolder} */
+  const workspace = config.workspace;
+
+  switch (config.type) {
+  case `node`:
+    return debug.startDebugging(workspace, {
+      type: `node`,
+      name: `Node.js Attach`,
+      request: `attach`,
+      localRoot: workspace.uri.fsPath,
+      address: config.address,
+      port: config.port,
+      remoteRoot: config.remoteRoot,
+      skipFiles: [
+        `<node_internals>/**`
+      ]
+    });
+
+  case `python`:
+    return debug.startDebugging(workspace, {
+      "name": `Python: Attach`,
+      "type": `python`,
+      "request": `attach`,
+      "connect": {
+        "host": config.address,
+        "port": config.port
+      },
+      "pathMappings": [
+        {
+          "localRoot": workspace.uri.fsPath, // Maps C:\Users\user1\project1
+          "remoteRoot": config.remoteRoot // To current working directory ~/project1
+        }
+      ],
+      "justMyCode": true
+    })
+    break;
+  
+  default:
+  }
+}

--- a/src/api/actions/debug.ts
+++ b/src/api/actions/debug.ts
@@ -16,7 +16,11 @@ export function launchRemoteDebug(config: RemoteDebugConfig) {
       remoteRoot: config.remoteRoot,
       skipFiles: [
         `<node_internals>/**`
-      ]
+      ],
+      restart: {
+        delay: 500,
+        maxAttempts: 3
+      }
     });
 
   case `python`:
@@ -35,7 +39,7 @@ export function launchRemoteDebug(config: RemoteDebugConfig) {
         }
       ],
       "stopOnEntry": true,
-      "justMyCode": false
+      "justMyCode": false,
     })
     break;
   

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -29,7 +29,7 @@ type DeployResult = false | DeploySuccessData;
 interface DeploySuccessData {workspace: number, remoteRoot: string}
 
 interface RemoteDebugConfig {
-  type: "node";
+  type: "node"|"python";
   /** @type {vscode.WorkspaceFolder} */
   workspace: any;
   address: string;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -45,7 +45,7 @@ interface Action {
   extensions: string[];
   deployFirst?: boolean;
   postDownload?: string[];
-  debug?: "node"
+  debug?: "node"|"python"
 }
 
 interface ConnectionData {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,4 @@
 
-
 interface StandardIO {
   onStdout?: (data: Buffer) => void;
   onStderr?: (data: Buffer) => void;
@@ -26,6 +25,18 @@ interface MemberParts {
   basename: string|undefined;
 }
 
+type DeployResult = false | DeploySuccessData;
+interface DeploySuccessData {workspace: number, remoteRoot: string}
+
+interface RemoteDebugConfig {
+  type: "node";
+  /** @type {vscode.WorkspaceFolder} */
+  workspace: any;
+  address: string;
+  port: number;
+  remoteRoot: string;
+}
+
 interface Action {
   name: string;
   command: string;
@@ -34,6 +45,7 @@ interface Action {
   extensions: string[];
   deployFirst?: boolean;
   postDownload?: string[];
+  debug?: "node"
 }
 
 interface ConnectionData {

--- a/src/schemas/LocalLanguageActions.ts
+++ b/src/schemas/LocalLanguageActions.ts
@@ -211,5 +211,15 @@ export const LocalLanguageActions: Record<string, Action[]> = {
       "deployFirst": true,
       "debug": "node"
     }
+  ],
+  "Python": [
+    {
+      extensions: [`GLOBAL`],
+      name: `Deploy Python and debug`,
+      command: `python -m debugpy --listen 0.0.0.0:&PORT --wait-for-client -m &RELATIVEPATH`,
+      environment: `pase`,
+      deployFirst: true,
+      debug: "python"
+    }
   ]
 }

--- a/src/schemas/LocalLanguageActions.ts
+++ b/src/schemas/LocalLanguageActions.ts
@@ -190,5 +190,26 @@ export const LocalLanguageActions: Record<string, Action[]> = {
         ".logs/output.log"
       ]
     }
+  ],
+  "Node.js": [
+    {
+      "extensions": [
+        "GLOBAL"
+      ],
+      "name": "npm install",
+      "command": "npm i",
+      "environment": "pase",
+      "deployFirst": true
+    },
+    {
+      "extensions": [
+        "GLOBAL"
+      ],
+      "name": "Deploy Node.js and debug",
+      "command": "node --inspect-brk=0.0.0.0:&PORT index.js",
+      "environment": "pase",
+      "deployFirst": true,
+      "debug": "node"
+    }
   ]
 }

--- a/src/schemas/LocalLanguageActions.ts
+++ b/src/schemas/LocalLanguageActions.ts
@@ -216,7 +216,7 @@ export const LocalLanguageActions: Record<string, Action[]> = {
     {
       extensions: [`GLOBAL`],
       name: `Deploy Python and debug`,
-      command: `python -m debugpy --listen 0.0.0.0:&PORT --wait-for-client -m &RELATIVEPATH`,
+      command: `python -m debugpy --listen 0.0.0.0:&PORT --wait-for-client &RELATIVEPATH`,
       environment: `pase`,
       deployFirst: true,
       debug: "python"

--- a/src/schemas/LocalLanguageActions.ts
+++ b/src/schemas/LocalLanguageActions.ts
@@ -216,7 +216,7 @@ export const LocalLanguageActions: Record<string, Action[]> = {
     {
       extensions: [`GLOBAL`],
       name: `Deploy Python and debug`,
-      command: `python -m debugpy --listen 0.0.0.0:&PORT --wait-for-client &RELATIVEPATH`,
+      command: `source ~/envs/debug/bin/activate && python -m debugpy --listen 0.0.0.0:&PORT --wait-for-client &RELATIVEPATH`,
       environment: `pase`,
       deployFirst: true,
       debug: "python"

--- a/src/schemas/actions.json
+++ b/src/schemas/actions.json
@@ -71,6 +71,16 @@
               "type": "string",
               "title": "Relative path."
             }
+          },
+          "debug": {
+            "$id": "#/actions/items/anyOf/0/properties/debug",
+            "type": "string",
+            "title": "Remote Debug",
+            "description": "Which environment should start debugging.",
+            "default": "node",
+            "enum": [
+              "node"
+            ]
           }
         },
         "additionalProperties": true

--- a/src/schemas/actions.json
+++ b/src/schemas/actions.json
@@ -79,7 +79,8 @@
             "description": "Which environment should start debugging.",
             "default": "node",
             "enum": [
-              "node"
+              "node",
+              "python"
             ]
           }
         },


### PR DESCRIPTION
### Changes

This will automatically launch the remote debugger with default configuration.

* Adds new property to `actions.json` to specify which environment they are debugging.
   * `debug: "node"|"python"`
* Adds new environment variable, `&PORT`, which is just a random number between 40000-50000.
* Additional default Actions for Node.js and Python
* https://halcyon-tech.github.io/docs/#/pages/debugging/index

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
