### PR TITLE
Improvement/member_resolves

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -89,6 +89,7 @@ export default class IBMi {
       sort: undefined,
       'GENCMDXML.PGM': undefined,
       'GETNEWLIBL.PGM': undefined,
+      'GETMBR.PGM': undefined,
       'QZDFMDB2.PGM': undefined,
       'startDebugService.sh': undefined,
       attr: undefined,
@@ -557,7 +558,7 @@ export default class IBMi {
           remoteApps.push(
             {
               path: `/QSYS.lib/${this.config.tempLibrary.toUpperCase()}.lib/`,
-              names: [`GENCMDXML.PGM`, `GETNEWLIBL.PGM`],
+              names: [`GENCMDXML.PGM`, `GETNEWLIBL.PGM`, `GETMBR.PGM`],
               specific: `GE*.PGM`
             }
           );

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -22,6 +22,7 @@ import { initGetNewLibl } from "./languages/clle/getnewlibl";
 import { SEUColorProvider } from "./languages/general/SEUColorProvider";
 import { Action, DeploymentMethod, QsysFsOptions } from "./typings";
 import { refreshDiagnosticsFromServer } from './api/errors/diagnostics';
+import { initGetMbr } from './languages/clle/getmbr';
 
 export let instance: Instance;
 
@@ -412,6 +413,7 @@ async function onConnected(context: vscode.ExtensionContext) {
   }
 
   initGetNewLibl(instance);
+  initGetMbr(instance);
 
   // Enable the profile view if profiles exist.
   vscode.commands.executeCommand(`setContext`, `code-for-ibmi:hasProfiles`, (config?.connectionProfiles || []).length > 0);

--- a/src/languages/clle/getmbr.ts
+++ b/src/languages/clle/getmbr.ts
@@ -21,6 +21,8 @@ export async function initGetMbr(instance: Instance) {
     await connection.remoteCommand(
       `CRTBNDCL PGM(${tempLib}/GETMBR) SRCFILE(${tempLib}/QTOOLS) DBGVIEW(*SOURCE) TEXT('vscode-ibmi member resolver')`
     );
+
+    connection.remoteFeatures[`GETMBR.PGM`] = `${config.tempLibrary}.GETMBR`;
   }
 }
 
@@ -32,13 +34,14 @@ function getSource() {
     `DCL VAR(&LIB) TYPE(*CHAR) LEN(10)`,
     `DCL VAR(&EXT) TYPE(*CHAR) LEN(10)`,
     `DCL VAR(&MSG) TYPE(*CHAR) LEN(50)`,
-  ``,
+    `dcl &NL *char 1 value( x'25' )`,
+    ``,
     `RTVMBRD FILE(*LIBL/&SRCPF) MBR(&NAME) RTNLIB(&LIB) SRCTYPE(&EXT)`,
     `CHGVAR VAR(&MSG) VALUE( +`,
     `  &LIB *TCAT '/' *TCAT +`,
     `  &SRCPF *TCAT '/' *TCAT +`,
     `  &NAME *TCAT '.' *TCAT +`,
-    `  &EXT +`,
+    `  &EXT *TCAT &NL +`,
     `)`,
     `CALLPRC PRC('printf') PARM(&MSG)`,
     `ENDPGM`,

--- a/src/languages/clle/getmbr.ts
+++ b/src/languages/clle/getmbr.ts
@@ -1,0 +1,46 @@
+import Instance from "../../api/Instance";
+
+export async function initGetMbr(instance: Instance) {
+  const connection = instance.getConnection();
+  const config = instance.getConfig();
+
+  // Check if the remote library list tool is installed
+  if (connection && config && !connection.remoteFeatures[`GETMBR.PGM`]) {
+    // Time to install our new library list fetcher program
+    const content = instance.getContent()!;
+  
+    const tempLib = config.tempLibrary;
+  
+    try {
+      await connection.remoteCommand(`CRTSRCPF ${tempLib}/QTOOLS`, undefined)
+    } catch (e) {
+      //It may exist already so we just ignore the error
+    }
+  
+    await content.uploadMemberContent(undefined, tempLib, `QTOOLS`, `GETMBR`, getSource());
+    await connection.remoteCommand(
+      `CRTBNDCL PGM(${tempLib}/GETMBR) SRCFILE(${tempLib}/QTOOLS) DBGVIEW(*SOURCE) TEXT('vscode-ibmi member resolver')`
+    );
+  }
+}
+
+function getSource() {
+  return [
+    `PGM PARM(&SRCPF &NAME)`,
+    `DCL VAR(&SRCPF) TYPE(*CHAR) LEN(10)`,
+    `DCL VAR(&NAME) TYPE(*CHAR) LEN(10)`,
+    `DCL VAR(&LIB) TYPE(*CHAR) LEN(10)`,
+    `DCL VAR(&EXT) TYPE(*CHAR) LEN(10)`,
+    `DCL VAR(&MSG) TYPE(*CHAR) LEN(50)`,
+  ``,
+    `RTVMBRD FILE(*LIBL/&SRCPF) MBR(&NAME) RTNLIB(&LIB) SRCTYPE(&EXT)`,
+    `CHGVAR VAR(&MSG) VALUE( +`,
+    `  &LIB *TCAT '/' *TCAT +`,
+    `  &SRCPF *TCAT '/' *TCAT +`,
+    `  &NAME *TCAT '.' *TCAT +`,
+    `  &EXT +`,
+    `)`,
+    `CALLPRC PRC('printf') PARM(&MSG)`,
+    `ENDPGM`,
+  ].join(`\n`);
+}

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -59,6 +59,18 @@ export const ContentSuite: TestSuite = {
       });
     }},
 
+    {name: `Test memberResolveLibraryList with bad libraries`, test: async () => {
+      const content = instance.getContent();
+      const config = instance.getConfig();
+
+      const member = await content?.memberResolveLibraryList(`MATH`, `H`, {
+        libraryList: [`SYSTOOLS`, `QSYS2`, `QIWS`],
+        currentLibrary: config?.currentLibrary!
+      });
+
+      assert.deepStrictEqual(member, undefined);
+    }},
+
     {name: `Test memberResolveLibraryList with bad name`, test: async () => {
       const content = instance.getContent();
       const config = instance.getConfig();

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -40,6 +40,37 @@ export const ContentSuite: TestSuite = {
       assert.deepStrictEqual(member, undefined);
     }},
 
+    {name: `Test memberResolveLibraryList`, test: async () => {
+      const content = instance.getContent();
+      const config = instance.getConfig();
+
+      const member = await content?.memberResolveLibraryList(`MATH`, `H`, {
+        libraryList: [`SYSTOOLS`, `QSYSINC`],
+        currentLibrary: config?.currentLibrary!
+      });
+
+      assert.deepStrictEqual(member, {
+        asp: undefined,
+        library: `QSYSINC`,
+        file: `H`,
+        name: `MATH`,
+        extension: `C`,
+        basename: `MATH.C`
+      });
+    }},
+
+    {name: `Test memberResolveLibraryList with bad name`, test: async () => {
+      const content = instance.getContent();
+      const config = instance.getConfig();
+
+      const member = await content?.memberResolveLibraryList(`BOOP`, `H`, {
+        libraryList: [`SYSTOOLS`, `QSYSINC`],
+        currentLibrary: config?.currentLibrary!
+      });
+
+      assert.deepStrictEqual(member, undefined);
+    }},
+
     {name: `Test objectResolve .FILE`, test: async () => {
       const content = instance.getContent();
   


### PR DESCRIPTION
### Changes

This adds an additional member resolve API, which will eventually deprecate the previous `memberResolves` API. This API depends on a brand new CL, which will inhherit the user profile iASP, which the current API does not.

I also created tests for this new API.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
