### PR TITLE
Feature to clear error on line edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -432,6 +432,11 @@
 					"default": true,
 					"description": "If enabled, objects will be sorted by object name. If disabled, objects will be sorted by object type (MI object type)."
 				},
+				"code-for-ibmi.clearDiagnosticOnEdit": {
+					"type": "boolean",
+					"default": false,
+					"description": "When lines with ILE diagnostics are edited, the diagnostic will be removed. Requires reload/restart if changed."
+				},
 				"code-for-ibmi.safeDeleteMode": {
 					"type": "boolean",
 					"default": false,


### PR DESCRIPTION
### Changes

Since it wasn't possible to move diagnostics as documents change, we've added a piece of code that will clear the error if the line it is on edited. This suggested came from a user.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
