### PR TITLE
Optional passthrase when using SSH key in UI

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -74,6 +74,7 @@ export interface ConnectionData {
   username: string;
   password?: string;
   privateKey: string | null;
+  passphrase?: string;
   keepaliveInterval?: number;
 }
 

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -27,7 +27,9 @@ export class Login {
       .addParagraph(`Only provide either the password or a private key - not both.`)
       .addPassword(`password`, `Password`)
       .addCheckbox(`savePassword`, `Save Password`)
+      .addHorizontalRule()
       .addFile(`privateKey`, `Private Key`, `OpenSSH, RFC4716, or PPK formats are supported.`)
+      .addInput(`passphrase`, `Private key passphrase`)
       .addButtons(
         { id: `connect`, label: `Connect`, requiresValidation: true },
         { id: `saveExit`, label: `Save & Exit` }
@@ -54,7 +56,8 @@ export class Login {
               host: data.host,
               port: data.port,
               username: data.username,
-              privateKey: data.privateKey
+              privateKey: data.privateKey,
+              passphrase: data.passphrase.length > 0 ? data.passphrase : undefined
             });
 
             if (data.savePassword) context.secrets.store(`${data.name}_password`, `${data.password}`);

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -227,7 +227,9 @@ export class SettingsUI {
               .addInput(`username`, `Username`, undefined, { default: connection.username, minlength: 1 })
               .addParagraph(`Only provide either the password or a private key - not both.`)
               .addPassword(`password`, `Password`, `Only provide a password if you want to update an existing one or set a new one.`)
+              .addHorizontalRule()
               .addFile(`privateKey`, `Private Key${connection.privateKey ? ` (current: ${connection.privateKey})` : ``}`, `Only provide a private key if you want to update from the existing one or set one. OpenSSH, RFC4716, or PPK formats are supported.`)
+              .addInput(`passphrase`, `Private key passphrase`, undefined, {default: connection.passphrase})
               .addButtons({ id: `submitButton`, label: `Save`, requiresValidation: true })
               .loadPage<any>(`Login Settings: ${name}`);
 
@@ -245,6 +247,8 @@ export class SettingsUI {
               };
 
               delete data.password;
+
+              data.passphrase = data.passphrase.length > 0 ? data.passphrase : undefined;
 
               connection = {
                 ...connection,


### PR DESCRIPTION
### Changes

Fixes #472

Adds a passphrase input box into the Login settings and new connection window for when a private key and passphrase is used.

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
