### PR TITLE
Split Object browser's Refresh in two separate actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1376,6 +1376,12 @@
 				"icon": "$(refresh)"
 			},
 			{
+				"command": "code-for-ibmi.refreshObjectBrowserItem",
+				"enablement": "code-for-ibmi:connected",
+				"title": "Refresh",
+				"category": "IBM i"
+			},
+			{
 				"command": "code-for-ibmi.revealInObjectBrowser",
 				"enablement": "code-for-ibmi:connected",
 				"title": "Reveal Object Browser Item",
@@ -1782,6 +1788,10 @@
 				{
 					"command": "code-for-ibmi.revealInObjectBrowser",
 					"when": "never"
+				},
+				{
+					"command": "code-for-ibmi.refreshObjectBrowserItem",
+					"when": "never"
 				}
 			],
 			"view/title": [
@@ -2123,6 +2133,11 @@
 					"command": "code-for-ibmi.uploadAndReplaceMemberAsFile",
 					"when": "view == objectBrowser && viewItem == member",
 					"group": "3_memberTransfer@2"
+				},
+				{
+					"command": "code-for-ibmi.refreshObjectBrowserItem",
+					"when": "view == objectBrowser",
+					"group": "99_objectBrowserAction@1"
 				},
 				{
 					"command": "code-for-ibmi.moveIFSShortcutDown",

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -417,7 +417,9 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
       objectBrowser.autoRefresh();
     }),
 
-    vscode.commands.registerCommand(`code-for-ibmi.refreshObjectBrowser`, async (item?: BrowserItem) => {
+    vscode.commands.registerCommand(`code-for-ibmi.refreshObjectBrowser`, () => objectBrowser.refresh()),
+
+    vscode.commands.registerCommand(`code-for-ibmi.refreshObjectBrowserItem`, async (item: BrowserItem) => {
       objectBrowser.refresh(item);
     }),
 


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/1555

The `code-for-ibmi.refreshObjectBrowser` used to accept no parameter; after converting the Object Browser to TypeScript, that command was changed to accept a TreeItem in parameter, to allow finer refreshes. It turns out that the browsers selected item was always passed onto the command when the `Refresh` inline button was clicked.

This PR revert that change so the command behave as it used to (i.e. clicking on `Refresh` refreshes the entire browser.
It also adds a new `code-for-ibmi.refreshObjectBrowserItem` command that is dedicated to refreshing the browser selected item. A `Refresh` action has been added on every browser's item to enable refresh at every level.

![image](https://github.com/codefori/vscode-ibmi/assets/11096890/e5ed6f87-401a-4ccf-b9f3-a7ef4655a395)


### Checklist
* [x] have tested my change