### PR TITLE
Remove URI query part when prompting for member comparison

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -146,10 +146,12 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
           uri = node.resourceUri;
         } else {
           const activeEditor = vscode.window.activeTextEditor;
-
+          const value = (activeEditor ? activeEditor.document.uri : selectedForCompare)
+            .with({ query: '' })
+            .toString();
           const compareWith = await vscode.window.showInputBox({
             prompt: `Enter the path to compare selected with`,
-            value: `${activeEditor ? activeEditor.document.uri.toString() : selectedForCompare.toString()}`,
+            value,
             title: `Compare with`
           })
 
@@ -256,7 +258,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
           vscode.window.showErrorMessage('Please connect to an IBM i first');
         }
       }
-      
+
       return false;
     }),
 


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/1584
This PR removes the query part of the URI shown when prompting for a source member to compare to.

### Checklist
* [x] have tested my change
