### PR TITLE
Remove extra echo line in the PASE terminal head

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,3 +50,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@edmundreinhardt](https://github.com/edmundreinhardt)
 * [@richardm90](https://github.com/richardm90)
 * [@ThePrez](https://github.com/ThePrez)
+* [@BoykaZhu](https://github.com/BoykaZhu)

--- a/src/api/Terminal.ts
+++ b/src/api/Terminal.ts
@@ -73,10 +73,13 @@ export namespace Terminal {
 
   async function createTerminal(connection: IBMi, terminalSettings: TerminalSettings) {
     const writeEmitter = new vscode.EventEmitter<string>();
+    const paseWelcomeMessage = 'echo "Terminal started. Thanks for using Code for IBM i"';
 
     const channel = await connection.client.requestShell();
     channel.stdout.on(`data`, (data: any) => {
-      writeEmitter.fire(String(data))
+      if (data.toString().trim().indexOf(paseWelcomeMessage) === -1) {
+        writeEmitter.fire(String(data));
+      }
     });
 
     const emulatorTerminal = vscode.window.createTerminal({
@@ -146,7 +149,7 @@ export namespace Terminal {
         `\n`
       ].join(` `));
     } else {
-      channel.stdin.write(`echo "Terminal started. Thanks for using Code for IBM i"\n`);
+      channel.stdin.write(`${paseWelcomeMessage}\n`);
     }
 
     instance.onEvent('disconnected', () => emulatorTerminal.dispose());


### PR DESCRIPTION
### Changes

In **Terminal.ts**, filter out the extra **echo** without printing it. Now the PASE terminal welcome message looks clearer.
![image](https://github.com/codefori/vscode-ibmi/assets/10293068/2846847a-45b9-4644-8902-595e3b3d3023)


### Checklist

* [x] have tested my change
* [ ] updated relevant documentation. 
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.


No doc points in https://codefori.github.io/docs/#/ need to be updated.

bz.