### PR TITLE
Environment variable to manage debug settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "code-for-ibmi",
-	"version": "2.2.1",
+	"version": "2.3.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "code-for-ibmi",
-			"version": "2.2.1",
+			"version": "2.3.1",
 			"license": "MIT",
 			"dependencies": {
 				"@bendera/vscode-webview-elements": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -855,13 +855,13 @@
 				"command": "code-for-ibmi.debug.setup.remote",
 				"title": "Setup Remote Certificates",
 				"category": "IBM i Debug",
-				"enablement": "code-for-ibmi:connected && code-for-ibmi:debugManaged == false"
+				"enablement": "code-for-ibmi:connected && code-for-ibmi:debugManaged != true"
 			},
 			{
 				"command": "code-for-ibmi.debug.setup.local",
 				"title": "Import Local Certificate",
 				"category": "IBM i Debug",
-				"enablement": "code-for-ibmi:connected && code-for-ibmi:debugManaged == false"
+				"enablement": "code-for-ibmi:connected && code-for-ibmi:debugManaged != true"
 			},
 			{
 				"command": "code-for-ibmi.debug.start",

--- a/package.json
+++ b/package.json
@@ -855,13 +855,13 @@
 				"command": "code-for-ibmi.debug.setup.remote",
 				"title": "Setup Remote Certificates",
 				"category": "IBM i Debug",
-				"enablement": "code-for-ibmi:connected"
+				"enablement": "code-for-ibmi:connected && code-for-ibmi:debugManaged == false"
 			},
 			{
 				"command": "code-for-ibmi.debug.setup.local",
 				"title": "Import Local Certificate",
 				"category": "IBM i Debug",
-				"enablement": "code-for-ibmi:connected"
+				"enablement": "code-for-ibmi:connected && code-for-ibmi:debugManaged == false"
 			},
 			{
 				"command": "code-for-ibmi.debug.start",

--- a/package.json
+++ b/package.json
@@ -867,13 +867,13 @@
 				"command": "code-for-ibmi.debug.start",
 				"title": "Start Debug Service",
 				"category": "IBM i Debug",
-				"enablement": "code-for-ibmi:connected"
+				"enablement": "code-for-ibmi:connected && code-for-ibmi:debugManaged != true"
 			},
 			{
 				"command": "code-for-ibmi.debug.stop",
 				"title": "Stop Debug Service",
 				"category": "IBM i Debug",
-				"enablement": "code-for-ibmi:connected"
+				"enablement": "code-for-ibmi:connected && code-for-ibmi:debugManaged != true"
 			},
 			{
 				"command": "code-for-ibmi.debug.activeEditor",

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -415,7 +415,11 @@ export async function startDebug(instance: Instance, options: DebugOptions) {
     secure = process.env[`DEBUG_CA_PATH`] ? true : false;
   } else {
     secure = config?.debugIsSecure || false;
-    process.env[`DEBUG_CA_PATH`] = secure ? certificates.getLocalCertPath(connection!) : undefined;
+    if (secure) {
+      process.env[`DEBUG_CA_PATH`] = certificates.getLocalCertPath(connection!);
+    } else {
+      delete process.env[`DEBUG_CA_PATH`];
+    }
   }
 
   const pathKey = options.library.trim() + `/` + options.object.trim();

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -418,6 +418,7 @@ export async function startDebug(instance: Instance, options: DebugOptions) {
     if (secure) {
       process.env[`DEBUG_CA_PATH`] = certificates.getLocalCertPath(connection!);
     } else {
+      // Environment variable must be deleted otherwise cert issues will happen
       delete process.env[`DEBUG_CA_PATH`];
     }
   }

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -381,6 +381,8 @@ export async function initialize(context: ExtensionContext) {
       }
     }
   });
+
+  vscode.commands.executeCommand(`setContext`, `code-for-ibmi:debugManaged`, isManaged());
 }
 
 interface DebugOptions {

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -4,6 +4,7 @@ import { ComplexTab, CustomUI, Section } from "../../api/CustomUI";
 import * as certificates from "../../api/debug/certificates";
 import { instance } from "../../instantiate";
 import { ConnectionData, Server } from '../../typings';
+import { isManaged } from "../../api/debug";
 
 const ENCODINGS = [`37`, `256`, `273`, `277`, `278`, `280`, `284`, `285`, `297`, `500`, `871`, `870`, `905`, `880`, `420`, `875`, `424`, `1026`, `290`, `win37`, `win256`, `win273`, `win277`, `win278`, `win280`, `win284`, `win285`, `win297`, `win500`, `win871`, `win870`, `win905`, `win880`, `win420`, `win875`, `win424`, `win1026`];
 
@@ -132,16 +133,20 @@ export class SettingsUI {
           debuggerTab
             .addInput(`debugPort`, `Debug port`, `Default secure port is <code>8005</code>. Tells the client which port the debug service is running on.`, { default: config.debugPort, minlength: 1, maxlength: 5, regexTest: `^\\d+$` })
             .addCheckbox(`debugUpdateProductionFiles`, `Update production files`, `Determines whether the job being debugged can update objects in production (<code>*PROD</code>) libraries.`, config.debugUpdateProductionFiles)
-            .addCheckbox(`debugEnableDebugTracing`, `Debug trace`, `Tells the debug service to send more data to the client. Only useful for debugging issues in the service. Not recommended for general debugging.`, config.debugEnableDebugTracing)
-            .addHorizontalRule()
-            .addCheckbox(`debugIsSecure`, `Debug securely`, `Tells the debug service to authenticate by server and client certificates. Ensure that the client certificate is imported when enabled.`, config.debugIsSecure)
-            .addInput(`debugCertDirectory`, `Certificate directory`, `This remote path is only used when starting the Debug Service and or for downloading an existing client certificate. This directory must be accessible to all users who wish to start the Debug Service (<code>debug_service.pfx</code>) or download an existing client certificate (<code>debug_service.crt</code>). Optionally, you can import one below.`, { default: config.debugCertDirectory });
+            .addCheckbox(`debugEnableDebugTracing`, `Debug trace`, `Tells the debug service to send more data to the client. Only useful for debugging issues in the service. Not recommended for general debugging.`, config.debugEnableDebugTracing);
 
-          const localCertExists = await certificates.checkLocalExists(connection);
+          if (!isManaged()) {
+            debuggerTab
+              .addHorizontalRule()
+              .addCheckbox(`debugIsSecure`, `Debug securely`, `Tells the debug service to authenticate by server and client certificates. Ensure that the client certificate is imported when enabled.`, config.debugIsSecure)
+              .addInput(`debugCertDirectory`, `Certificate directory`, `This remote path is only used when starting the Debug Service and or for downloading an existing client certificate. This directory must be accessible to all users who wish to start the Debug Service (<code>debug_service.pfx</code>) or download an existing client certificate (<code>debug_service.crt</code>). Optionally, you can import one below.`, { default: config.debugCertDirectory });
 
-          debuggerTab
-            .addParagraph(`<b>${localCertExists ? `Client certificate for server has been imported.` : `No local client certificate exists. Debugging securely will not function correctly.`}</b>` + ` To debug securely, Visual Studio Code needs access to a certificate to connect to the Debug Service. Each server can have unique certificates. This client certificate should exist at <code>${certificates.getLocalCertPath(connection)}</code>`)
-            .addButtons({ id: `import`, label: `Import new certificate` })
+            const localCertExists = await certificates.checkLocalExists(connection);
+
+            debuggerTab
+              .addParagraph(`<b>${localCertExists ? `Client certificate for server has been imported.` : `No local client certificate exists. Debugging securely will not function correctly.`}</b>` + ` To debug securely, Visual Studio Code needs access to a certificate to connect to the Debug Service. Each server can have unique certificates. This client certificate should exist at <code>${certificates.getLocalCertPath(connection)}</code>`)
+              .addButtons({ id: `import`, label: `Import new certificate` })
+          }
         } else if (connection) {
           debuggerTab.addParagraph('Enable the debug service to change these settings');
         } else {


### PR DESCRIPTION
### Changes

* Adds `DEBUG_MANAGED` variable, and when `true` will:
   1. Hide the certificate UI in the connection settings
   2. Control secure mode based on if `DEBUG_CA_PATH` environment variable is set
   3. Hide 'setup debug' commands
   4. Hide debug setup walkthrough (PR in a separate repo)

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
