### PR TITLE
Use OS dependant function to get relative path

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -224,8 +224,15 @@ export namespace CompileTools {
 
                   if (fromWorkspace) {
                     baseDir = fromWorkspace.uri.path;
+                    
+                    if(process.platform === 'win32'){
+                      relativePath = path.win32.relative(baseDir, uri.path);
+                    }
+                    else{
+                      relativePath = path.posix.relative(baseDir, uri.path); 
+                    }
+                    relativePath = relativePath.split(path.sep).join(path.posix.sep);
 
-                    relativePath = path.posix.relative(baseDir, uri.path).split(path.sep).join(path.posix.sep);
                     variables.set(`&RELATIVEPATH`, relativePath);
 
                     // We need to make sure the remote path is posix

--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -213,30 +213,16 @@ export namespace CompileTools {
               evfeventInfo.object = name.toUpperCase();
               evfeventInfo.extension = ext;
 
-              let relativePath;
-              let fullPath
 
               switch (chosenAction.type) {
                 case `file`:
                   variables.set(`&LOCALPATH`, uri.fsPath);
-
-                  let baseDir = config.homeDirectory;
-
                   if (fromWorkspace) {
-                    baseDir = fromWorkspace.uri.path;
-                    
-                    if(process.platform === 'win32'){
-                      relativePath = path.win32.relative(baseDir, uri.path);
-                    }
-                    else{
-                      relativePath = path.posix.relative(baseDir, uri.path); 
-                    }
-                    relativePath = relativePath.split(path.sep).join(path.posix.sep);
-
+                    const relativePath = path.relative(fromWorkspace.uri.path, uri.path).split(path.sep).join(path.posix.sep);
                     variables.set(`&RELATIVEPATH`, relativePath);
 
                     // We need to make sure the remote path is posix
-                    fullPath = path.posix.join(config.homeDirectory, relativePath).split(path.sep).join(path.posix.sep);
+                    const fullPath = path.posix.join(config.homeDirectory, relativePath);
                     variables.set(`&FULLPATH`, fullPath);
                     variables.set(`{path}`, fullPath);
 
@@ -258,7 +244,7 @@ export namespace CompileTools {
                   break;
 
                 case `streamfile`:
-                  relativePath = path.posix.relative(config.homeDirectory, uri.fsPath).split(path.sep).join(path.posix.sep);
+                  const relativePath = path.posix.relative(config.homeDirectory, uri.path);
                   variables.set(`&RELATIVEPATH`, relativePath);
 
                   const fullName = uri.path;


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/1586

On Windows, there is sometimes a case difference in the path's drive letter. For example:
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/c1a611c8-e1f8-4a04-8ab5-b9875b45c6e5)

In my case, I could reproduce this by having two workspace folders in my workspace folders in my workspace and running a local action after opening a file from the Search results (like described in https://github.com/codefori/vscode-ibmi/issues/1586).

This PR simply checks the target platform and run the `path.win32.relative` function to get the relative path for local actions if running on Windows.

### Checklist
* [x] have tested my change