### PR TITLE
Change invalid QCCSID text

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -649,7 +649,7 @@ export default class IBMi {
 
               if (this.config.enableSQL && this.qccsid === 65535) {
                 this.config.enableSQL = false;
-                vscode.window.showErrorMessage(`QCCSID is set to 65535. Disabling SQL support.`);
+                vscode.window.showErrorMessage(`QCCSID is set to 65535. Using fallback methods to access the IBM i file systems.`);
               }
 
               progress.report({


### PR DESCRIPTION
### Changes

Change error text when 65535. This aligns better with the Db2 for i extension, which works even if the QCCSID is 65535.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
