### PR TITLE
Temporary view with button to enable library list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1031,6 +1031,12 @@
 				"icon": "$(file-binary)"
 			},
 			{
+				"command": "code-for-ibmi.userLibraryList.enable",
+				"enablement": "code-for-ibmi:connected",
+				"title": "Force Enable User Library List",
+				"category": "IBM i"
+			},
+			{
 				"command": "code-for-ibmi.addToLibraryList",
 				"enablement": "code-for-ibmi:connected",
 				"title": "Add to Library List",
@@ -1574,6 +1580,12 @@
 					"when": "code-for-ibmi:connected && code-for-ibmi:libraryListDisabled !== true"
 				},
 				{
+					"id": "libraryListViewDisabled",
+					"name": "User Library List",
+					"when": "code-for-ibmi:connected && code-for-ibmi:libraryListDisabled == true",
+					"visibility": "collapsed"
+				},
+				{
 					"id": "objectBrowser",
 					"name": "Object Browser",
 					"when": "code-for-ibmi:connected && code-for-ibmi:objectBrowserDisabled !== true"
@@ -1625,6 +1637,10 @@
 				}
 			],
 			"commandPalette": [
+				{
+					"command": "code-for-ibmi.userLibraryList.enable",
+					"when": "never"
+				},
 				{
 					"command": "code-for-ibmi.connectTo",
 					"when": "code-for-ibmi:hasPreviousConnection"
@@ -2320,6 +2336,10 @@
 			{
 				"view": "connectionBrowser",
 				"contents": "No connection found.\n[Connect to an IBM i](command:code-for-ibmi.connect)"
+			},
+			{
+				"view": "libraryListViewDisabled",
+				"contents": "The User Library List is currently disabled. This happens when another extension wants to manage the library list.\n[Force Enable](command:code-for-ibmi.userLibraryList.enable)"
 			}
 		]
 	},

--- a/src/views/LibraryListView.ts
+++ b/src/views/LibraryListView.ts
@@ -1,4 +1,4 @@
-import vscode from "vscode";
+import vscode, { commands } from "vscode";
 import { ConnectionConfiguration, GlobalConfiguration } from "../api/Configuration";
 import { instance } from "../instantiate";
 import { t } from "../locale";
@@ -10,6 +10,10 @@ export class LibraryListProvider implements vscode.TreeDataProvider<LibraryListN
 
   constructor(context: vscode.ExtensionContext) {
     context.subscriptions.push(
+      vscode.commands.registerCommand(`code-for-ibmi.userLibraryList.enable`, () => {
+        commands.executeCommand(`setContext`, `code-for-ibmi:libraryListDisabled`, false);
+      }),
+      
       vscode.commands.registerCommand(`code-for-ibmi.refreshLibraryListView`, async () => {
         this.refresh();
       }),


### PR DESCRIPTION
### Changes

We had a user who was giving a workshop but the User Library List was being disabled by Project Explorer even though they were not using it.

This PR adds a temporary view when the User Library List is disabled with a button that allows them to enable it for this session.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
