### PR TITLE
Fix for issue 1600: Debug session does not start if the command default have been changed to MSGQ(*WRKSTN) for the SBMJOB command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,3 +51,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@richardm90](https://github.com/richardm90)
 * [@ThePrez](https://github.com/ThePrez)
 * [@BoykaZhu](https://github.com/BoykaZhu)
+* [@krka01](https://github.com/krka01)

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -429,7 +429,7 @@ export async function startDebug(instance: Instance, options: DebugOptions) {
       "ignoreCertificateErrors": !secure,
       "library": options.library.toUpperCase(),
       "program": options.object.toUpperCase(),
-      "startBatchJobCommand": `SBMJOB CMD(${currentCommand}) INLLIBL(${config?.libraryList.join(` `)}) CURLIB(${config?.currentLibrary}) JOBQ(QSYSNOMAX)`,
+      "startBatchJobCommand": `SBMJOB CMD(${currentCommand}) INLLIBL(${config?.libraryList.join(` `)}) CURLIB(${config?.currentLibrary}) JOBQ(QSYSNOMAX) MSGQ(*USRPRF)`,
       "updateProductionFiles": updateProductionFiles,
       "trace": enableDebugTracing,
     };


### PR DESCRIPTION
### Changes
Make sure the submit job command is called using MSGQ(*USRPRF) when starting a debug session.

Closes #1600

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
