### PR TITLE
Fixed runAction command not working on objects

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -250,7 +250,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
             }
           }
 
-          if (canRun && [`member`, `streamfile`, `file`].includes(uri.scheme)) {
+          if (canRun && [`member`, `streamfile`, `file`, `object`].includes(uri.scheme)) {
             return await CompileTools.runAction(instance, uri, action, method);
           }
         }


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/1622
The `object` URI scheme was not part of the test allowing to call `CompileTools.runAction` in the `runAction` command.

### Checklist
* [x] have tested my change