### PR TITLE
Save password during connection via API

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,11 +63,15 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
       new ProfilesView(context)
     ),
     commands.registerCommand(`code-for-ibmi.connectDirect`,
-      async (connectionData: ConnectionData, reloadSettings = false): Promise<boolean> => {
+      async (connectionData: ConnectionData, reloadSettings = false, savePassword = false): Promise<boolean> => {
         const existingConnection = instance.getConnection();
 
         if (existingConnection) {
           return false;
+        }
+
+        if (savePassword && connectionData.password) {
+          context.secrets.store(`${connectionData.name}_password`, `${connectionData.password}`);
         }
 
         return (await new IBMi().connect(connectionData, undefined, reloadSettings)).success;


### PR DESCRIPTION
### Changes

Adds new parameter to the `connectDirect` API to store the password into the keystore. This is so the debugger doesn't prompt the user awhen using the API to connect.

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
