### PR TITLE
Set the debug current library when debugging locally

### DIFF
--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -9,6 +9,7 @@ import * as server from "./server";
 import { copyFileSync } from "fs";
 import { instance } from "../../instantiate";
 import { getEnvConfig } from "../local/env";
+import { ILELibrarySettings } from "../CompileTools";
 
 const debugExtensionId = `IBM.ibmidebug`;
 
@@ -30,18 +31,39 @@ export async function initialize(context: ExtensionContext) {
     return debugclient !== undefined;
   }
 
-  const startDebugging = async (library: string, object: string) => {
+  const startDebugging = async (objectLibrary: string, objectName: string, workspaceFolder?: vscode.WorkspaceFolder) => {
     if (debugExtensionAvailable()) {
       const connection = instance.getConnection();
-      if (connection) {
+      const config = instance.getConfig();
+      if (connection && config) {
         if (connection.remoteFeatures[`startDebugService.sh`]) {
           const password = await getPassword();
+
+          const libraries: ILELibrarySettings = {
+            currentLibrary: config?.currentLibrary,
+            libraryList: config?.libraryList
+          };
+
+          // If we are debugging from a workspace, perhaps
+          // the user has a custom CURLIB and LIBL setup.
+          if (workspaceFolder) {
+            const env = await getEnvConfig(workspaceFolder);
+            if (env[`CURLIB`]) {
+              objectLibrary = env[`CURLIB`];
+              libraries.currentLibrary = env[`CURLIB`];
+            }
+
+            if (env[`LIBL`]) {
+              libraries.libraryList = env[`LIBL`].split(` `);
+            }
+          }
 
           if (password) {
             const debugOpts: DebugOptions = {
               password,
-              library: library,
-              object: object
+              library: objectLibrary,
+              object: objectName,
+              libraries
             };
 
             startDebug(instance, debugOpts);
@@ -95,16 +117,8 @@ export async function initialize(context: ExtensionContext) {
           qualifiedPath.object = streamfilePath.name;
           break;
         case `file`:
-          qualifiedPath.library = configuration.currentLibrary;
-          const workspace = vscode.workspace.getWorkspaceFolder(uri);
-          if (workspace) {
-            const env = await getEnvConfig(workspace);
-            if (env[`CURLIB`]) {
-              qualifiedPath.library = env[`CURLIB`]
-            }
-          }
-
           const localPath = path.parse(uri.path);
+          qualifiedPath.library = configuration.currentLibrary;
           qualifiedPath.object = localPath.name;
           break;
       }
@@ -176,10 +190,13 @@ export async function initialize(context: ExtensionContext) {
     vscode.commands.registerCommand(`code-for-ibmi.debug.activeEditor`, async () => {
       const activeEditor = vscode.window.activeTextEditor;
       if (activeEditor) {
+        // Get the workspace folder if one is available.
+        const workspaceFolder = [`member`, `streamfile`].includes(activeEditor.document.uri.scheme) ? undefined : vscode.workspace.getWorkspaceFolder(activeEditor.document.uri);
+
         const qualifiedObject = await getObjectFromUri(activeEditor.document.uri);
 
         if (qualifiedObject.library && qualifiedObject.object) {
-          startDebugging(qualifiedObject.library, qualifiedObject.object);
+          startDebugging(qualifiedObject.library, qualifiedObject.object, workspaceFolder);
         }
       }
     }),
@@ -410,6 +427,7 @@ interface DebugOptions {
   password: string;
   library: string;
   object: string;
+  libraries: ILELibrarySettings
 };
 
 export async function startDebug(instance: Instance, options: DebugOptions) {
@@ -465,7 +483,7 @@ export async function startDebug(instance: Instance, options: DebugOptions) {
       "ignoreCertificateErrors": !secure,
       "library": options.library.toUpperCase(),
       "program": options.object.toUpperCase(),
-      "startBatchJobCommand": `SBMJOB CMD(${currentCommand}) INLLIBL(${config?.libraryList.join(` `)}) CURLIB(${config?.currentLibrary}) JOBQ(QSYSNOMAX) MSGQ(*USRPRF)`,
+      "startBatchJobCommand": `SBMJOB CMD(${currentCommand}) INLLIBL(${options.libraries.libraryList.join(` `)}) CURLIB(${options.libraries.currentLibrary}) JOBQ(QSYSNOMAX) MSGQ(*USRPRF)`,
       "updateProductionFiles": updateProductionFiles,
       "trace": enableDebugTracing,
     };


### PR DESCRIPTION
### Changes

Set the default debug library to the CURLIB environment variable when debugging from local source.

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
