### PR TITLE
Fix variable assignment order in CompileTools.ts

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -246,9 +246,9 @@ export namespace CompileTools {
                         const branch = repo.state.HEAD?.name;
 
                         if (branch) {
+                          variables.set(`&BRANCHLIB`, getBranchLibraryName(branch));
                           variables.set(`&BRANCH`, branch);
                           variables.set(`{branch}`, branch);
-                          variables.set(`&BRANCHLIB`, getBranchLibraryName(branch));
                         }
                       }
                     } catch (e) {


### PR DESCRIPTION
### Changes

Because `BRANCH` was before `BRANCHLIB`, I was getting the incorrect value in `BRANCHLIB` as `&BRANCHLIB` was evaluating to `some/random/branchLIB`

### Checklist

* [x] have tested my change
