### PR TITLE
Additional privateKey prop to allow private key strings

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -72,6 +72,7 @@ export interface ConnectionData {
   port: number;
   username: string;
   password?: string;
+  privateKey?: string;
   privateKeyPath?: string;
   keepaliveInterval?: number;
 }


### PR DESCRIPTION
### Changes

This will allow a `privateKey` property on `ConnectionData`, which allows the content of the private key to be passed in, instead of solely just the path to the key.

No UI changes needed as this is a requirement for the connection API.

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
