### PR TITLE
Add code to escape member names when doing resolve

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -652,9 +652,13 @@ export default class IBMiContent {
 
   async memberResolve(member: string, files: QsysPath[]): Promise<IBMiMember | undefined> {
     // Escape names for shell
-    const fixed = files.map(f => ({name: f.name.replace(/([$\\])/g,'\\$1'), library: f.library.replace(/([$\\])/g,'\\$1')}));
-    const command = `for f in ${fixed.map(file => `/QSYS.LIB/${file.library.toUpperCase()}.LIB/${file.name.toUpperCase()}.FILE/${member.toUpperCase()}.MBR`).join(` `)}; do if [ -f $f ]; then echo $f; break; fi; done`;
+    const pathList = files
+      .map(file => `/QSYS.LIB/${file.library}.LIB/${file.name}.FILE/${member}.MBR`)
+      .join(` `)
+      .replace(/([$\\])/g,'\\$1')
+      .toUpperCase();
 
+    const command = `for f in ${pathList}; do if [ -f $f ]; then echo $f; break; fi; done`;
     const result = await this.ibmi.sendCommand({
       command,
     });

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -651,7 +651,9 @@ export default class IBMiContent {
   }
 
   async memberResolve(member: string, files: QsysPath[]): Promise<IBMiMember | undefined> {
-    const command = `for f in ${files.map(file => `/QSYS.LIB/${file.library.toUpperCase()}.LIB/${file.name.toUpperCase()}.FILE/${member.toUpperCase()}.MBR`).join(` `)}; do if [ -f $f ]; then echo $f; break; fi; done`;
+    // Escape names for shell
+    const fixed = files.map(f => ({name: f.name.replace(/([$\\])/g,'\\$1'), library: f.library.replace(/([$\\])/g,'\\$1')}));
+    const command = `for f in ${fixed.map(file => `/QSYS.LIB/${file.library.toUpperCase()}.LIB/${file.name.toUpperCase()}.FILE/${member.toUpperCase()}.MBR`).join(` `)}; do if [ -f $f ]; then echo $f; break; fi; done`;
 
     const result = await this.ibmi.sendCommand({
       command,


### PR DESCRIPTION
### Changes

Fixes issue where member resolves with dollar signs in the name (which sadly is very common) was not working because `$` is a special character in the shell.

Unit tests for `memberResolve` are continung to pass.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
