### PR TITLE
Improvement to debug config UX to download client certificates

### DIFF
--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -71,7 +71,7 @@ export async function initialize(context: ExtensionContext) {
         } else {
           if (isManaged()) {
             vscode.window.showInformationMessage(`Looks like the Debug Service is not setup on this IBM i server. Please contact your system administrator.`);
-            
+
           } else {
             const openTut = await vscode.window.showInformationMessage(`Looks like you do not have the debug PTF installed. Do you want to see the Walkthrough to set it up?`, `Take me there`);
             if (openTut === `Take me there`) {
@@ -214,31 +214,38 @@ export async function initialize(context: ExtensionContext) {
         const ptfInstalled = debugPTFInstalled();
 
         if (ptfInstalled) {
-          const remoteExists = await certificates.checkRemoteExists(connection);
+          const remoteCertExists = await certificates.remoteServerCertExists(connection);
           let remoteCertsAreNew = false;
           let remoteCertsOk = false;
 
-          if (remoteExists) {
+          if (remoteCertExists) {
             vscode.window.showInformationMessage(`Certificates already exist on the server.`);
             remoteCertsOk = true;
-          } else {
-
           }
 
+          // This popup will show a message based on if the certificates exist or not
           const doSetup = await vscode.window.showInformationMessage(`Debug setup`, {
             modal: true,
-            detail: `${remoteExists
-              ? `Debug certificates already exist on this system! Running this setup will overwrite them, which will require the debug service to be restarted.`
-              : `Debug certificates are not setup on the system.`
+            detail: `${remoteCertExists
+              ? `Debug certificates already exist on this system! This will download the client certificates to enable secure debugging.`
+              : `Debug certificates are not setup on the system. This will generate the certificates and download them to your device.`
               } Continue with setup?`
           }, `Continue`);
 
           if (doSetup) {
             try {
-              await certificates.setup(connection);
-              vscode.window.showInformationMessage(`Certificates successfully generated on server.`);
-              remoteCertsOk = true;
-              remoteCertsAreNew = true;
+              // If the remote certs don't exist, generate them
+              if (!remoteCertExists) {
+                await certificates.setup(connection);
+                vscode.window.showInformationMessage(`Certificates successfully generated on server.`);
+                remoteCertsOk = true;
+                remoteCertsAreNew = true;
+              }
+
+              // Download the client certificates to the device if setup correctly.
+              if (remoteCertsOk) {
+                vscode.commands.executeCommand(`code-for-ibmi.debug.setup.local`);
+              }
             } catch (e: any) {
               vscode.window.showErrorMessage(e.message || e);
             }
@@ -265,40 +272,48 @@ export async function initialize(context: ExtensionContext) {
         if (ptfInstalled) {
           let localCertsOk = false;
           if (connection.config!.debugIsSecure) {
-            const selection = await vscode.window.showInformationMessage(
-              `Client certificate`,
-              {
-                modal: true,
-                detail: `To debug securely, a client certificate needs to be imported.`
-              },
-              `Import certificate`
-            );
 
-            if (selection === `Import certificate`) {
-              const selectedFile = await vscode.window.showOpenDialog({
-                canSelectFiles: true,
-                canSelectFolders: false,
-                canSelectMany: false,
-                title: `Select client certificate`
-              });
+            try {
+              const remoteClientCertExists = await certificates.remoteClientCertExists(connection);
 
-              if (selectedFile && selectedFile.length === 1) {
-                try {
-                  copyFileSync(selectedFile[0].fsPath, certificates.getLocalCertPath(connection));
-                  localCertsOk = true;
-                  vscode.window.showInformationMessage(`Certificate imported.`);
-                } catch (e) {
-                  vscode.window.showErrorMessage(`Failed to import local certificate.`);
+              // If the client certificate exists on the server, download it
+              if (remoteClientCertExists) {
+                await certificates.downloadClientCert(connection);
+                localCertsOk = true;
+                vscode.window.showInformationMessage(`Debug dertificate downloaded from the server.`);
+
+              } else {
+                const doImport = await vscode.window.showInformationMessage(`Debug setup`, {
+                  modal: true,
+                  detail: `The client certificate is not setup on the server. Would you like to import a cetificate from your device?`
+                }, `Yes`, `No`);
+
+                if (doImport === `Yes`) {
+                  const selectedFile = await vscode.window.showOpenDialog({
+                    canSelectFiles: true,
+                    canSelectFolders: false,
+                    canSelectMany: false,
+                    title: `Select debug client certificate`
+                  });
+
+                  if (selectedFile && selectedFile.length === 1) {
+                    copyFileSync(selectedFile[0].fsPath, certificates.getLocalCertPath(connection));
+                    localCertsOk = true;
+                    vscode.window.showInformationMessage(`Certificate imported.`);
+                  }
                 }
               }
+            } catch (e) {
+              vscode.window.showErrorMessage(`Failed to work with debug client certificate. See Code for IBM i logs.`);
             }
           } else {
-            vscode.window.showWarningMessage(`Certificates can only be imported when secure mode is enabled.`, `Open configuration`).then(result => {
+            vscode.window.showInformationMessage(`Import of debug client certificate skipped as not required in current mode.`, `Open configuration`).then(result => {
               if (result === `Open configuration`) {
                 vscode.commands.executeCommand(`code-for-ibmi.showAdditionalSettings`, undefined, `Debugger`);
               }
             });
           }
+
           if (localCertsOk) {
             vscode.commands.executeCommand(`setContext`, localCertContext, true);
           }
@@ -313,13 +328,11 @@ export async function initialize(context: ExtensionContext) {
       if (connection) {
         const ptfInstalled = debugPTFInstalled();
         if (ptfInstalled) {
-          const remoteExists = await certificates.checkRemoteExists(connection);
+          const remoteExists = await certificates.remoteServerCertExists(connection);
           if (remoteExists) {
-
             vscode.window.withProgress({ location: vscode.ProgressLocation.Notification }, async (progress) => {
 
               let startupService = false;
-
 
               progress.report({ increment: 33, message: `Checking if service is already running.` });
               const existingDebugService = await server.getRunningJob(connection.config?.debugPort || "8005", instance.getContent()!);
@@ -386,13 +399,13 @@ export async function initialize(context: ExtensionContext) {
       vscode.commands.executeCommand(`setContext`, ptfContext, true);
 
       if (!isManaged()) {
-        const remoteCertsExist = await certificates.checkRemoteExists(connection);
+        const remoteCertsExist = await certificates.remoteServerCertExists(connection);
 
         if (remoteCertsExist) {
           vscode.commands.executeCommand(`setContext`, remoteCertContext, true);
 
           if (connection.config!.debugIsSecure) {
-            const localCertsExists = await certificates.checkLocalExists(connection);
+            const localCertsExists = await certificates.localClientCertExists(connection);
 
             if (localCertsExists) {
               vscode.commands.executeCommand(`setContext`, localCertContext, true);
@@ -402,18 +415,15 @@ export async function initialize(context: ExtensionContext) {
           }
         } else {
           const existingDebugService = await server.getRunningJob(connection.config?.debugPort || "8005", instance.getContent()!);
-          if (existingDebugService) {
-            const openSettings = await vscode.window.showInformationMessage(`Looks like the Debug Service is already running, but couldn't find the certificates in the configuration location.`, `Open settings`);
-            if (openSettings === `Open settings`) {
-              // Open directory to the debugger tab
-              vscode.commands.executeCommand(`code-for-ibmi.showAdditionalSettings`, undefined, `Debugger`);
-            }
+          
+          const openTut = await vscode.window.showInformationMessage(`${
+            existingDebugService ? 
+            `Looks like the Debug Service was started by an external service. This may impact your VS Code experience.` : 
+            `Looks like you have the debug PTF but don't have it configured.`
+          } Do you want to see the Walkthrough to set it up?`, `Take me there`);
 
-          } else {
-            const openTut = await vscode.window.showInformationMessage(`Looks like you have the debug PTF installed. Do you want to see the Walkthrough to set it up?`, `Take me there`);
-            if (openTut === `Take me there`) {
-              vscode.commands.executeCommand(`workbench.action.openWalkthrough`, `halcyontechltd.vscode-ibmi-walkthroughs#code-ibmi-debug`);
-            }
+          if (openTut === `Take me there`) {
+            vscode.commands.executeCommand(`workbench.action.openWalkthrough`, `halcyontechltd.vscode-ibmi-walkthroughs#code-ibmi-debug`);
           }
         }
       }
@@ -422,6 +432,13 @@ export async function initialize(context: ExtensionContext) {
 
   vscode.commands.executeCommand(`setContext`, `code-for-ibmi:debugManaged`, isManaged());
 }
+
+function ValidateIPaddress(ipaddress: string) {  
+  if (/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(ipaddress)) {  
+    return (true)  
+  }
+  return (false)  
+}  
 
 interface DebugOptions {
   password: string;

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -285,7 +285,7 @@ export async function initialize(context: ExtensionContext) {
               } else {
                 const doImport = await vscode.window.showInformationMessage(`Debug setup`, {
                   modal: true,
-                  detail: `The client certificate is not setup on the server. Would you like to import a cetificate from your device?`
+                  detail: `The client certificate is not setup on the server. Would you like to import a certificate from your device?`
                 }, `Yes`, `No`);
 
                 if (doImport === `Yes`) {

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -280,7 +280,7 @@ export async function initialize(context: ExtensionContext) {
               if (remoteClientCertExists) {
                 await certificates.downloadClientCert(connection);
                 localCertsOk = true;
-                vscode.window.showInformationMessage(`Debug dertificate downloaded from the server.`);
+                vscode.window.showInformationMessage(`Debug certificate downloaded from the server.`);
 
               } else {
                 const doImport = await vscode.window.showInformationMessage(`Debug setup`, {

--- a/src/api/debug/server.ts
+++ b/src/api/debug/server.ts
@@ -25,7 +25,7 @@ export async function startup(connection: IBMi) {
 
   const password = encryptResult.stdout;
 
-  const keystorePath = certificates.getKeystorePath(connection);
+  const keystorePath = certificates.getRemoteServerCertPath(connection);
 
   connection.sendCommand({
     command: `${MY_JAVA_HOME} DEBUG_SERVICE_KEYSTORE_PASSWORD="${password}" DEBUG_SERVICE_KEYSTORE_FILE="${keystorePath}" /QOpenSys/usr/bin/nohup "${path.posix.join(directory, `startDebugService.sh`)}"`

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -141,7 +141,7 @@ export class SettingsUI {
               .addCheckbox(`debugIsSecure`, `Debug securely`, `Tells the debug service to authenticate by server and client certificates. Ensure that the client certificate is imported when enabled.`, config.debugIsSecure)
               .addInput(`debugCertDirectory`, `Certificate directory`, `This remote path is only used when starting the Debug Service and or for downloading an existing client certificate. This directory must be accessible to all users who wish to start the Debug Service (<code>debug_service.pfx</code>) or download an existing client certificate (<code>debug_service.crt</code>). Optionally, you can import one below.`, { default: config.debugCertDirectory });
 
-            const localCertExists = await certificates.checkLocalExists(connection);
+            const localCertExists = await certificates.localClientCertExists(connection);
 
             debuggerTab
               .addParagraph(`<b>${localCertExists ? `Client certificate for server has been imported.` : `No local client certificate exists. Debugging securely will not function correctly.`}</b>` + ` To debug securely, Visual Studio Code needs access to a certificate to connect to the Debug Service. Each server can have unique certificates. This client certificate should exist at <code>${certificates.getLocalCertPath(connection)}</code>`)


### PR DESCRIPTION
### Changes

I realised today while helping a user out that even after VS Code configures the certificates for both the server and client, it never imports the client certificates automatically from the server.

This change will now not only do that, but also improves the wording so that the server certificates cannot be overridden when they have already been created (as it only needs to happen once for the entire system)

Also, this PR adds a warning when trying to debug securely when connecting to the IBM i with an IP address. A hostname is basically required for secure debugging right now because of the way the certificates are setup. This will hopefully be resolved in a future PR.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
