### PR TITLE
Fix deletion current directory and check error

### DIFF
--- a/src/locale/ids/da.ts
+++ b/src/locale/ids/da.ts
@@ -75,7 +75,7 @@ export const da: Locale = {
   'ifsBrowser.deleteIFS.infoMessage': `Slettede {0}.`,
   'ifsBrowser.deleteIFS.errorMessage': `Fejl ved sletning af streamfile! {0}`,
   'ifsBrowser.deleteIFS.cancelled': `Sletning afbrudt.`,
-  'ifsBrowser.deleteIFS.default.home.dir':'{0} was the working directory; it is now {1}.',
+  'ifsBrowser.deleteIFS.default.home.dir':'{0} var den aktuelle mappe; det er nu {1}.',
   'ifsBrowser.moveIFS.prompt': `Nyt navn`,
   'ifsBrowser.moveIFS.errorMessage': `Fejl ved flytning/omdøbning af {0}! {1}`,
   'ifsBrowser.moveIFS.renamed': `{0} blev omdøbt til {1}.`,

--- a/src/locale/ids/da.ts
+++ b/src/locale/ids/da.ts
@@ -75,6 +75,7 @@ export const da: Locale = {
   'ifsBrowser.deleteIFS.infoMessage': `Slettede {0}.`,
   'ifsBrowser.deleteIFS.errorMessage': `Fejl ved sletning af streamfile! {0}`,
   'ifsBrowser.deleteIFS.cancelled': `Sletning afbrudt.`,
+  'ifsBrowser.deleteIFS.default.home.dir':'{0} was the working directory; it is now {1}.',
   'ifsBrowser.moveIFS.prompt': `Nyt navn`,
   'ifsBrowser.moveIFS.errorMessage': `Fejl ved flytning/omdøbning af {0}! {1}`,
   'ifsBrowser.moveIFS.renamed': `{0} blev omdøbt til {1}.`,

--- a/src/locale/ids/en.ts
+++ b/src/locale/ids/en.ts
@@ -75,6 +75,7 @@ export const en: Locale = {
   'ifsBrowser.deleteIFS.infoMessage': `Deleted {0}.`,
   'ifsBrowser.deleteIFS.errorMessage': `Error deleting streamfile! {0}`,
   'ifsBrowser.deleteIFS.cancelled': `Deletion canceled.`,
+  'ifsBrowser.deleteIFS.default.home.dir':'{0} was the working directory; it is now {1}.',
   'ifsBrowser.moveIFS.prompt': `Name of new path`,
   'ifsBrowser.moveIFS.errorMessage': `Error renaming/moving {0}! {1}`,
   'ifsBrowser.moveIFS.renamed': `{0} was renamed to {1}.`,

--- a/src/locale/ids/fr.ts
+++ b/src/locale/ids/fr.ts
@@ -75,6 +75,7 @@ export const fr: Locale = {
   'ifsBrowser.deleteIFS.infoMessage': `{0} supprimé.`,
   'ifsBrowser.deleteIFS.errorMessage': `Erreur lors de la suppression du fichier! {0}`,
   'ifsBrowser.deleteIFS.cancelled': `Suppression annulée.`,
+  'ifsBrowser.deleteIFS.default.home.dir':'{0} était le répertoire de travail; c\'est désormais {1}.',
   'ifsBrowser.moveIFS.prompt': `Nouveau chemin`,
   'ifsBrowser.moveIFS.errorMessage': `Erreur lors du renommage/déplacement de {0}! {1}`,
   'ifsBrowser.moveIFS.renamed': `{0} a été renommé {1}.`,

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -422,8 +422,13 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
                     vscode.window.showInformationMessage(t('ifsBrowser.deleteIFS.default.home.dir', node.path, config.homeDirectory));
                   }
                 }
-                await connection.sendCommand({ command: `rm -rf ${Tools.escapePath(node.path)}` })                
-                vscode.window.showInformationMessage(t(`ifsBrowser.deleteIFS.infoMessage`, node.path));
+                const removeResult = await connection.sendCommand({ command: `rm -rf ${Tools.escapePath(node.path)}` })
+                if(removeResult.code === 0){
+                  vscode.window.showInformationMessage(t(`ifsBrowser.deleteIFS.infoMessage`, node.path));
+                }
+                else{
+                  throw removeResult.stderr;
+                }
                 if (GlobalConfiguration.get(`autoRefresh`)) {
                   ifsBrowser.refresh(node.parent);
                 }


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/1631
When running the `Delete Object` action from the IFS browser, if the target was the current directory (i.e. `config.homeDirectory`)  the command would fail and show a success message.

This PR fixes this issue by:
- [x] Setting `config.homeDirectory` to `$HOME`.
- [x] Showing a notification about the working directory being changed.
- [x] Show `stderr` if the rm command fails.

To reproduce the initial issue:
- Create a directory
- Set it as the Working Directory (right click action from the IFS Browser)
- Try to delete it

### Checklist
* [x] have tested my change