### PR TITLE
Ignore stat error when no hidden files in directory

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -665,9 +665,9 @@ export default class IBMiContent {
     }
 
     if (fileListResult.code !== 0) {
-      //Filter out the error occurring when is stat is run on an empty directory
+      //Filter out the errors occurring when stat is run on a directory with no hidden or regular files
       const errors = fileListResult.stderr.split("\n")
-        .filter(e => !e.toLowerCase().includes("cannot stat '*'"))
+        .filter(e => !e.toLowerCase().includes("cannot stat '*'") && !e.toLowerCase().includes("cannot stat '.*'"))
         .filter(Tools.distinct);
 
       if (errors.length) {


### PR DESCRIPTION
### Changes

This PR will fix the old error of `stat` complaining `cannot stat '.*'` by adding a filter for it - like the already filtered error `cannot stat '*'`.

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
