### PR TITLE
Allow copy member from protected filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -2199,7 +2199,7 @@
 				},
 				{
 					"command": "code-for-ibmi.copyMember",
-					"when": "view == objectBrowser && viewItem == member",
+					"when": "view == objectBrowser && viewItem =~ /^member.*$/",
 					"group": "2_memberStuff@2"
 				},
 				{


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/1662
This makes the Copy member action available on protected filter's members.

### Checklist
* [x] have tested my change