### PR TITLE
Use both hostname and ip address for debug service certificate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,3 +52,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@ThePrez](https://github.com/ThePrez)
 * [@BoykaZhu](https://github.com/BoykaZhu)
 * [@krka01](https://github.com/krka01)
+* [@william-xiang](https://github.com/william-xiang)

--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -2,12 +2,59 @@ import path from "path";
 import {promises as fs} from "fs";
 import * as os from "os";
 import IBMi from "../IBMi";
+import * as dns from 'dns';
+import {window} from "vscode";
 
 const pfxName = `debug_service.pfx`;
 const crtName = `debug_service.crt`;
 
 function getRemoteCertDirectory(connection: IBMi) {
   return connection.config?.debugCertDirectory!;
+}
+
+function resolveHostnameToIP(hostName: string): Promise<string | undefined> {
+  return new Promise<string | undefined>((resolve) => {
+    dns.lookup(hostName, (err, res) => {
+      if (err) {
+        resolve(undefined);
+      } else {
+        resolve(res);
+      }
+    });
+  });
+}
+
+async function getExtFileConent(host: string, connection: IBMi) {
+  const ipRegexExp = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/gi;
+  let hostname = undefined;
+  let ipAddr = undefined;
+
+  if (ipRegexExp.test(host)) {
+    ipAddr = host;
+    const hostnameResult = await connection.sendCommand({
+      command: `hostname`
+    });
+
+    if (hostnameResult.stdout) {
+      hostname = hostnameResult.stdout;
+    } else {
+      window.showWarningMessage(`Hostname cannot be retrieved from IBM i, certificate will be created only using the IP address!`);
+    }
+  } else {
+    hostname = host;
+    ipAddr = await resolveHostnameToIP(host);
+  }
+
+  let extFileContent;
+  if (hostname && ipAddr) {
+    extFileContent = `subjectAltName=DNS:${hostname},IP:${ipAddr}`;
+  } else if (hostname) {
+    extFileContent = `subjectAltName=DNS:${hostname}`;
+  } else {
+    extFileContent = `subjectAltName=IP:${ipAddr}`;
+  }
+
+  return extFileContent;
 }
 
 export function getKeystorePath(connection: IBMi) {
@@ -33,12 +80,14 @@ export async function checkRemoteExists(connection: IBMi) {
 
 export async function setup(connection: IBMi) {
   const host = connection.currentHost;
+  const extFileContent = await getExtFileConent(host, connection);
+
   const commands = [
     `openssl genrsa -out debug_service_ca.key 2048`,
     `openssl req -x509 -new -nodes -key debug_service_ca.key -sha256 -days 1825 -out debug_service_ca.pem -subj '/CN=${host}'`,
     `openssl genrsa -out debug_service.key 2048`,
     `openssl req -new -key debug_service.key -out debug_service.csr -subj '/CN=${host}'`,
-    `openssl x509 -req -in debug_service.csr -CA debug_service_ca.pem -CAkey debug_service_ca.key -CAcreateserial -out debug_service.crt -days 1095 -sha256`,
+    `openssl x509 -req -in debug_service.csr -CA debug_service_ca.pem -CAkey debug_service_ca.key -CAcreateserial -out debug_service.crt -days 1095 -sha256 -sha256 -req -extfile <(printf "${extFileContent}")`,
     `openssl pkcs12 -export -out debug_service.pfx -inkey debug_service.key -in debug_service.crt -password pass:${host}`
   ];
 


### PR DESCRIPTION
### Changes

Use both hostname and ip address when creating the debug service certificate, so users can use either one of them for connection. 

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
