### PR TITLE
New addtional default actions

### DIFF
--- a/src/api/local/LocalLanguageActions.ts
+++ b/src/api/local/LocalLanguageActions.ts
@@ -134,10 +134,20 @@ export const LocalLanguageActions: Record<string, Action[]> = {
       "extensions": [
         `GLOBAL`
       ],
-      "name": `Create Service Program (CRTSRVPGM)`,
+      "name": `Create Service Program (CRTSRVPGM EXPORT(*ALL))`,
       "command": `CRTSRVPGM SRVPGM(&CURLIB/&NAME) EXPORT(*ALL) BNDSRVPGM(*NONE) BNDDIR(*NONE) ACTGRP(*CALLER)`,
       environment: `ile`
     },
+    {
+      "extensions": [
+        "BND",
+        "BINDER"
+      ],
+      "deployFirst": true,
+      "name": "Create Service Program (CRTSRVPGM with source)",
+      "command": "CRTSRVPGM SRVPGM(&CURLIB/&NAME) SRCSTMF('&RELATIVEPATH') BNDSRVPGM(*NONE) BNDDIR(*NONE) ACTGRP(*CALLER)",
+      "environment": "ile"
+    }
   ],
   "GNU Make": [
     {
@@ -184,6 +194,32 @@ export const LocalLanguageActions: Record<string, Action[]> = {
       postDownload: [
         ".logs",
         ".evfevent"
+      ]
+    }
+  ],
+  "Source Orbit": [
+    {
+      "name": "Build current with Source Orbit 🔨",
+      "command": "so -bf make -s &RELATIVEPATH && /QOpenSys/pkgs/bin/gmake LIBL='&LIBLS' BIN_LIB=&CURLIB OPT=*EVENTF",
+      "environment": "pase",
+      "deployFirst": true,
+      "extensions": [
+        "GLOBAL"
+      ],
+      "postDownload": [
+        ".evfevent/"
+      ]
+    },
+    {
+      "name": "Build current with Source Orbit 🔨",
+      "command": "so -bf make && /QOpenSys/pkgs/bin/gmake LIBL='&LIBLS' BIN_LIB=&CURLIB OPT=*EVENTF",
+      "environment": "pase",
+      "deployFirst": true,
+      "extensions": [
+        "GLOBAL"
+      ],
+      "postDownload": [
+        ".evfevent/"
       ]
     }
   ]

--- a/src/api/local/LocalLanguageActions.ts
+++ b/src/api/local/LocalLanguageActions.ts
@@ -211,7 +211,7 @@ export const LocalLanguageActions: Record<string, Action[]> = {
       ]
     },
     {
-      "name": "Build current with Source Orbit 🔨",
+      "name": "Build entire project with Source Orbit 🔨",
       "command": "so -bf make && /QOpenSys/pkgs/bin/gmake LIBL='&LIBLS' BIN_LIB=&CURLIB OPT=*EVENTF",
       "environment": "pase",
       "deployFirst": true,


### PR DESCRIPTION
### Changes

Adds three new default actions:

1. Action to create a service program from source (binder source)
2. Build current source with Source Orbit
3. Build all source with Source Orbit

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
