### PR TITLE
Sanitize library names before running liblist command

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -771,9 +771,9 @@ export namespace CompileTools {
 
   function buildLiblistCommands(connection: IBMi, config: ILELibrarySettings): string[] {
     return [
-      `liblist -d ${connection.defaultUserLibraries.join(` `).replace(/\$/g, `\\$`)}`,
-      `liblist -c ${config.currentLibrary.replace(/\$/g, `\\$`)}`,
-      `liblist -a ${buildLibraryList(config).join(` `).replace(/\$/g, `\\$`)}`
+      `liblist -d ${Tools.sanitizeLibraryNames(connection.defaultUserLibraries).join(` `)}`,
+      `liblist -c ${Tools.sanitizeLibraryNames([config.currentLibrary])}`,
+      `liblist -a ${Tools.sanitizeLibraryNames(buildLibraryList(config)).join(` `)}`
     ];
   }
 }

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -401,8 +401,8 @@ export default class IBMiContent {
 
     const result = await this.ibmi.sendQsh({
       command: [
-        `liblist -d ` + this.ibmi.defaultUserLibraries.join(` `).replace(/\$/g, `\\$`),
-        ...newLibl.map(lib => `liblist -a ` + lib.replace(/\$/g, `\\$`))
+        `liblist -d ` + Tools.sanitizeLibraryNames(this.ibmi.defaultUserLibraries).join(` `),
+        ...newLibl.map(lib => `liblist -a ` + Tools.sanitizeLibraryNames([lib]))
       ].join(`; `)
     });
 

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -410,7 +410,7 @@ export default class IBMiContent {
       const lines = result.stderr.split(`\n`);
 
       lines.forEach(line => {
-        const badLib = newLibl.find(lib => line.includes(`ibrary ${lib} `));
+        const badLib = newLibl.find(lib => line.includes(`ibrary ${lib} `) || line.includes(`ibrary ${Tools.sanitizeLibraryNames([lib])} `));
 
         // If there is an error about the library, remove it
         if (badLib) badLibs.push(badLib);

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -211,13 +211,12 @@ export namespace Tools {
   }
 
   export function sanitizeLibraryNames(libraries: string[]): string[] {
-    //We have to reverse it because `liblist -a` adds the next item to the top always 
     return libraries
       .map(library => {
         // Escape any $ signs
-        library.replace(/\$/g, `\\$`);
+        library = library.replace(/\$/g, `\\$`);
         // Quote libraries starting with #
-        return library.startsWith(`#`) ? `"${library}"` : library;;
+        return library.startsWith(`#`) ? `"${library}"` : library;
       });
   }
 }

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -209,4 +209,15 @@ export namespace Tools {
   export function capitalize(text:string) {
     return text.charAt(0).toUpperCase() + text.slice(1);
   }
+
+  export function sanitizeLibraryNames(libraries: string[]): string[] {
+    //We have to reverse it because `liblist -a` adds the next item to the top always 
+    return libraries
+      .map(library => {
+        // Escape any $ signs
+        library.replace(/\$/g, `\\$`);
+        // Quote libraries starting with #
+        return library.startsWith(`#`) ? `"${library}"` : library;;
+      });
+  }
 }

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -239,6 +239,16 @@ export const ContentSuite: TestSuite = {
       assert.strictEqual(badLibs?.includes(`QSYSINC`), false);
     }},
 
+    {name: `Test validateLibraryList (sanitized)`, test: async () => {
+      const content = instance.getContent();
+  
+      const badLibs = await content?.validateLibraryList([`##BEEPBOOP`,`$BEEP$BOOP`,`QSYSINC`]);
+
+      assert.strictEqual(badLibs?.includes(`##BEEPBOOP`), true);
+      assert.strictEqual(badLibs?.includes(`$BEEP$BOOP`), true);
+      assert.strictEqual(badLibs?.includes(`QSYSINC`), false);
+    }},
+
     {name: `Test getFileList`, test: async () => {
       const content = instance.getContent();
   

--- a/src/testing/tools.ts
+++ b/src/testing/tools.ts
@@ -26,5 +26,12 @@ export const ToolsSuite: TestSuite = {
   
       assert.strictEqual(simplePath, `/myasp/MYLIB/DEVSRC/THINGY.MBR`);
     }},
+
+    {name: `sanitizeLibraryNames ($ and #)`, test: async () => {
+      const rawLibraryNames = [`QTEMP`, `#LIBRARY`, `My$lib`, `qsysinc`];
+      const sanitizedLibraryNames = Tools.sanitizeLibraryNames(rawLibraryNames);
+  
+      assert.deepStrictEqual(sanitizedLibraryNames, [`QTEMP`, `"#LIBRARY"`, `My\\$lib`, `qsysinc`]);
+    }},
   ]
 };

--- a/src/views/LibraryListView.ts
+++ b/src/views/LibraryListView.ts
@@ -3,7 +3,6 @@ import { ConnectionConfiguration, GlobalConfiguration } from "../api/Configurati
 import { instance } from "../instantiate";
 import { t } from "../locale";
 import { Library as LibraryListEntry } from "../typings";
-import { Tools } from "../api/Tools";
 
 export class LibraryListProvider implements vscode.TreeDataProvider<LibraryListNode>{
   private readonly _emitter: vscode.EventEmitter<LibraryListNode | undefined | null | void> = new vscode.EventEmitter();

--- a/src/views/LibraryListView.ts
+++ b/src/views/LibraryListView.ts
@@ -3,6 +3,7 @@ import { ConnectionConfiguration, GlobalConfiguration } from "../api/Configurati
 import { instance } from "../instantiate";
 import { t } from "../locale";
 import { Library as LibraryListEntry } from "../typings";
+import { Tools } from "../api/Tools";
 
 export class LibraryListProvider implements vscode.TreeDataProvider<LibraryListNode>{
   private readonly _emitter: vscode.EventEmitter<LibraryListNode | undefined | null | void> = new vscode.EventEmitter();
@@ -61,7 +62,10 @@ export class LibraryListProvider implements vscode.TreeDataProvider<LibraryListN
                 if (newLibrary !== currentLibrary) {
                   let newLibraryOK = true;
                   try {
-                    await connection.runCommand({ command: `CHGCURLIB ${newLibrary}` });
+                    const commandResult = await connection.runCommand({ command: `CHGCURLIB ${newLibrary}` });
+                    if (commandResult?.code != 0) {
+                      throw(t(`LibraryListView.addToLibraryList.invalidLib`, newLibrary));
+                    }
                   } catch (e) {
                     vscode.window.showErrorMessage(String(e));
                     newLibraryOK = false;


### PR DESCRIPTION
### Changes

This PR will fix the error described in issue #1672.
It will also fix errors in other library list commands:
- show an error when changing current library, if the new current library name starts with `#`
- don't allow non-existing libraries with name starting with `#` when changing the library list

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
