### PR TITLE
fix use of old vsce command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies & publishing tools
         run: |
           npm install
-          npm install -g vsce ovsx
+          npm install -g @vscode/vsce ovsx
       
       # - name: Bump version numbers
       #   run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
       - run: npm install
       - run: npm run lint
       
-      - run: npm install -g vsce
+      - run: npm install -g @vscode/vsce
       - name: Create build
         run: npm run package
         


### PR DESCRIPTION
### Changes
This PR address #1156 .
Renamed to use updated name for the vsce tool according to [VS Code November 2022 update](https://code.visualstudio.com/updates/v1_74#_renaming-of-vsce-to-vscodevsce)

I'm not sure how to test this since it is on the publishing side but hopefully its a good start.

Description of change here.

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
