### PR TITLE
IFS browser enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -2233,12 +2233,12 @@
 				},
 				{
 					"command": "code-for-ibmi.moveIFSShortcutDown",
-					"when": "view == ifsBrowser && viewItem == shortcut",
+					"when": "view == ifsBrowser && viewItem =~ /^shortcut.*$/",
 					"group": "inline"
 				},
 				{
 					"command": "code-for-ibmi.moveIFSShortcutUp",
-					"when": "view == ifsBrowser && viewItem == shortcut",
+					"when": "view == ifsBrowser && viewItem =~ /^shortcut.*$/",
 					"group": "inline"
 				},
 				{
@@ -2253,22 +2253,22 @@
 				},
 				{
 					"command": "code-for-ibmi.deleteIFS",
-					"when": "view == ifsBrowser",
+					"when": "view == ifsBrowser && !(viewItem =~ /^.*_protected$/)",
 					"group": "2_ifsStuff@4"
 				},
 				{
 					"command": "code-for-ibmi.moveIFS",
-					"when": "view == ifsBrowser",
+					"when": "view == ifsBrowser && !(viewItem =~ /^.*_protected$/)",
 					"group": "2_ifsStuff@2"
 				},
 				{
 					"command": "code-for-ibmi.copyIFS",
-					"when": "view == ifsBrowser",
+					"when": "view == ifsBrowser && !(viewItem =~ /^.*_protected$/)",
 					"group": "2_ifsStuff@2"
 				},
 				{
 					"command": "code-for-ibmi.createDirectory",
-					"when": "view == ifsBrowser && viewItem == directory",
+					"when": "view == ifsBrowser && viewItem =~ /^directory.*$/",
 					"group": "2_ifsStuff@2"
 				},
 				{
@@ -2278,47 +2278,47 @@
 				},
 				{
 					"command": "code-for-ibmi.createStreamfile",
-					"when": "view == ifsBrowser && viewItem == directory",
+					"when": "view == ifsBrowser && viewItem =~ /^directory.*$/",
 					"group": "2_ifsStuff@1"
 				},
 				{
 					"command": "code-for-ibmi.searchIFS",
-					"when": "view == ifsBrowser && viewItem == directory",
+					"when": "view == ifsBrowser && viewItem =~ /^directory.*$/",
 					"group": "3_ifsStuff@1"
 				},
 				{
 					"command": "code-for-ibmi.addIFSShortcut",
-					"when": "view == ifsBrowser && viewItem == directory",
+					"when": "view == ifsBrowser && viewItem =~ /^directory.*$/",
 					"group": "3_ifsStuff@2"
 				},
 				{
 					"command": "code-for-ibmi.changeWorkingDirectory",
-					"when": "view == ifsBrowser && viewItem == directory",
+					"when": "view == ifsBrowser && viewItem =~ /^directory.*$/",
 					"group": "3_ifsStuff@3"
 				},
 				{
 					"command": "code-for-ibmi.createDirectory",
-					"when": "view == ifsBrowser && viewItem == shortcut",
+					"when": "view == ifsBrowser && viewItem =~ /^shortcut.*$/",
 					"group": "2_ifsStuff@2"
 				},
 				{
 					"command": "code-for-ibmi.createStreamfile",
-					"when": "view == ifsBrowser && viewItem == shortcut",
+					"when": "view == ifsBrowser && viewItem =~ /^shortcut.*$/",
 					"group": "2_ifsStuff@1"
 				},
 				{
 					"command": "code-for-ibmi.searchIFS",
-					"when": "view == ifsBrowser && viewItem == shortcut",
+					"when": "view == ifsBrowser && viewItem =~ /^shortcut.*$/",
 					"group": "3_ifsStuff@1"
 				},
 				{
 					"command": "code-for-ibmi.removeIFSShortcut",
-					"when": "view == ifsBrowser && viewItem == shortcut",
+					"when": "view == ifsBrowser && viewItem =~ /^shortcut.*$/",
 					"group": "3_ifsStuff@2"
 				},
 				{
 					"command": "code-for-ibmi.changeWorkingDirectory",
-					"when": "view == ifsBrowser && viewItem == shortcut",
+					"when": "view == ifsBrowser && viewItem =~ /^shortcut.*$/",
 					"group": "3_ifsStuff@3"
 				},
 				{
@@ -2333,12 +2333,12 @@
 				},
 				{
 					"command": "code-for-ibmi.moveIFSShortcutToTop",
-					"when": "view == ifsBrowser && viewItem == shortcut",
+					"when": "view == ifsBrowser && viewItem =~ /^shortcut.*$/",
 					"group": "5_ifsStuff@2"
 				},
 				{
 					"command": "code-for-ibmi.moveIFSShortcutToBottom",
-					"when": "view == ifsBrowser && viewItem == shortcut",
+					"when": "view == ifsBrowser && viewItem =~ /^shortcut.*$/",
 					"group": "5_ifsStuff@3"
 				},
 				{
@@ -2348,12 +2348,12 @@
 				},
 				{
 					"command": "code-for-ibmi.uploadStreamfile",
-					"when": "view == ifsBrowser && viewItem == directory",
+					"when": "view == ifsBrowser && viewItem =~ /^directory.*$/",
 					"group": "3_ifsTransfer@2"
 				},
 				{
 					"command": "code-for-ibmi.setDeployLocation",
-					"when": "view == ifsBrowser && viewItem == directory && workspaceFolderCount >= 1",
+					"when": "view == ifsBrowser && viewItem =~ /^directory.*$/ && workspaceFolderCount >= 1",
 					"group": "3_ifsTransfer@3"
 				},
 				{

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -12,6 +12,8 @@ import { instance, setSearchResults } from "../instantiate";
 import { t } from "../locale";
 import { BrowserItem, BrowserItemParameters, FocusOptions, IFSFile, WithPath } from "../typings";
 
+const Protected_dirs = /^(\/|\/QOpenSys|\/QSYS\.LIB|\/QDLS|\/QOPT|\/QNTC|\/QFileSvr\.400|\/bin|\/dev|\/home|\/tmp|\/usr|\/var)$/i;
+
 class IFSBrowser implements vscode.TreeDataProvider<BrowserItem> {
   private readonly emitter = new vscode.EventEmitter<BrowserItem | BrowserItem[] | undefined | null | void>();
   readonly onDidChangeTreeData = this.emitter.event;
@@ -137,7 +139,7 @@ class IFSDirectoryItem extends IFSItem {
   constructor(file: IFSFile, parent?: IFSDirectoryItem) {
     super(file, { state: vscode.TreeItemCollapsibleState.Collapsed, parent })
 
-    this.contextValue = "directory";
+    this.contextValue = `directory${ Protected_dirs.test(this.file.path) ? `_protected` : ``}`;
     this.iconPath = vscode.ThemeIcon.Folder;
   }
 
@@ -165,7 +167,7 @@ class IFSShortcutItem extends IFSDirectoryItem {
   constructor(readonly shortcut: string) {
     super({ name: shortcut, path: shortcut, type: "directory" })
 
-    this.contextValue = "shortcut";
+    this.contextValue = `shortcut${ Protected_dirs.test(this.path) ? `_protected` : ``}`;
     this.iconPath = new vscode.ThemeIcon("folder-library");
   }
 }

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -12,7 +12,7 @@ import { instance, setSearchResults } from "../instantiate";
 import { t } from "../locale";
 import { BrowserItem, BrowserItemParameters, FocusOptions, IFSFile, WithPath } from "../typings";
 
-const Protected_dirs = /^(\/|\/QOpenSys|\/QSYS\.LIB|\/QDLS|\/QOPT|\/QNTC|\/QFileSvr\.400|\/bin|\/dev|\/home|\/tmp|\/usr|\/var)$/i;
+const PROTECTED_DIRS = /^(\/|\/QOpenSys|\/QSYS\.LIB|\/QDLS|\/QOPT|\/QNTC|\/QFileSvr\.400|\/bin|\/dev|\/home|\/tmp|\/usr|\/var)$/i;
 
 class IFSBrowser implements vscode.TreeDataProvider<BrowserItem> {
   private readonly emitter = new vscode.EventEmitter<BrowserItem | BrowserItem[] | undefined | null | void>();
@@ -139,7 +139,7 @@ class IFSDirectoryItem extends IFSItem {
   constructor(file: IFSFile, parent?: IFSDirectoryItem) {
     super(file, { state: vscode.TreeItemCollapsibleState.Collapsed, parent })
 
-    this.contextValue = `directory${ Protected_dirs.test(this.file.path) ? `_protected` : ``}`;
+    this.contextValue = `directory${PROTECTED_DIRS.test(this.file.path) ? `_protected` : ``}`;
     this.iconPath = vscode.ThemeIcon.Folder;
   }
 
@@ -167,7 +167,7 @@ class IFSShortcutItem extends IFSDirectoryItem {
   constructor(readonly shortcut: string) {
     super({ name: shortcut, path: shortcut, type: "directory" })
 
-    this.contextValue = `shortcut${ Protected_dirs.test(this.path) ? `_protected` : ``}`;
+    this.contextValue = `shortcut${ PROTECTED_DIRS.test(this.path) ? `_protected` : ``}`;
     this.iconPath = new vscode.ThemeIcon("folder-library");
   }
 }

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -303,9 +303,12 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
       const connection = instance.getConnection();
       const config = instance.getConfig();
       if (connection && config) {
+        const value = `${node?.path || config.homeDirectory}/`;
+        const selectStart = value.length + 1;
         const fullName = await vscode.window.showInputBox({
           prompt: t(`ifsBrowser.createDirectory.prompt`),
-          value: node?.path || config.homeDirectory
+          value: value,
+          valueSelection: [selectStart, selectStart]
         });
 
         if (fullName) {
@@ -327,9 +330,12 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
       const config = instance.getConfig();
       const connection = instance.getConnection();
       if (config && connection) {
+        const value = `${node?.path || config.homeDirectory}/`;
+        const selectStart = value.length + 1;
         const fullName = await vscode.window.showInputBox({
           prompt: t(`ifsBrowser.createStreamfile.prompt`),
-          value: node?.path || config.homeDirectory
+          value: value,
+          valueSelection: [selectStart, selectStart]
         });
 
         if (fullName) {

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -454,7 +454,8 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
         const homeDirectory = config.homeDirectory;
         const target = await vscode.window.showInputBox({
           prompt: t(`ifsBrowser.moveIFS.prompt`),
-          value: node.path
+          value: node.path,
+          valueSelection: [path.posix.dirname(node.path).length + 1, node.path.length]
         });
 
         if (target) {
@@ -483,7 +484,8 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
         const homeDirectory = config.homeDirectory;
         const target = await vscode.window.showInputBox({
           prompt: t(`ifsBrowser.copyIFS.prompt`),
-          value: node.path.endsWith(`/`) ? node.path.substring(0, node.path.length - 1) : node.path
+          value: node.path.endsWith(`/`) ? node.path.substring(0, node.path.length - 1) : node.path,
+          valueSelection: [path.posix.dirname(node.path).length + 1, node.path.length]
         });
 
         if (target) {


### PR DESCRIPTION
### Changes

This PR changes the IFS browser behavior in the following ways:
- When copying or moving an object, only the object name will be selected in the prompt for faster entering of new object name. Previously the full path was selected, which seemed a bit cumbersome.
- When creating a new directory or streamfile, the prompt is changed to not select the full path, but instead place the cursor after the path. This makes it faster to enter the name of the new directory or streamfile.
- A protection mechanism for vital IBM directories has been created. Now the following directories will not have the menu options for delete, copy or move:
  - /
  - /QOpenSys
  - /QSYS.LIB
  - /QDLS
  - /QOPT
  - /QNTC
  - /QFileSvr.400
  - /bin
  - /dev
  - /home
  - /tmp
  - /usr
  - /var

The PR will make it faster working with objects in the IFS and increase the security when working in the IFS.

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
* [x] **for feature PRs**: PR only includes one feature enhancement.
