### PR TITLE
Fix goto file quickpick

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -198,7 +198,13 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       const listItems: vscode.QuickPickItem[] = list.map(item => ({ label: item }));
 
       const quickPick = vscode.window.createQuickPick();
-      quickPick.items = listItems;
+      quickPick.items = [
+        {
+          label: 'Cached',
+          kind: vscode.QuickPickItemKind.Separator
+        },
+        ...listItems
+      ];
       quickPick.canSelectMany = false;
       (quickPick as any).sortByLabel = false; // https://github.com/microsoft/vscode/issues/73904#issuecomment-680298036
       quickPick.placeholder = `Enter file path (format: LIB/SPF/NAME.ext (type '*' to search server) or /home/xx/file.txt)`;
@@ -217,22 +223,23 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
             label: String(row.SYSTEM_SCHEMA_NAME),
             description: String(row.SCHEMA_TEXT)
           }))
-
-          if (quickPick.value === ``) {
-            quickPick.items = [
-              {
-                label: 'Cached',
-                kind: vscode.QuickPickItemKind.Separator
-              },
-              ...listItems
-            ]
-          }
         });
       }
 
       let filteredItems: vscode.QuickPickItem[] = [];
 
       quickPick.onDidChangeValue(async () => {
+        if (quickPick.value === ``) {
+          quickPick.items = [
+            {
+              label: 'Cached',
+              kind: vscode.QuickPickItemKind.Separator
+            },
+            ...listItems
+          ];
+          filteredItems = [];
+        }
+
         // autosuggest
         if (config && config.enableSQL && (!quickPick.value.startsWith(`/`)) && quickPick.value.endsWith(`*`)) {
           const selectionSplit = quickPick.value.toUpperCase().split('/');

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -232,12 +232,6 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       let filteredItems: vscode.QuickPickItem[] = [];
 
       quickPick.onDidChangeValue(async () => {
-
-        // INJECT user values into proposed values
-        // if (!list.includes(quickPick.value.toUpperCase())) { 
-        //   quickPick.items = [quickPick.value.toUpperCase(), ...list].map(label => ({ label }));
-        // }
-
         // autosuggest
         if (config && config.enableSQL && (!quickPick.value.startsWith(`/`)) && quickPick.value.endsWith(`*`)) {
           const selectionSplit = quickPick.value.toUpperCase().split('/');
@@ -268,6 +262,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
 
             case 2:
               // Create cache
+              quickPick.busy = true;
               quickPick.items = [
                 {
                   label: LOADING_LABEL,
@@ -304,11 +299,13 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 },
                 ...listItems
               ]
+              quickPick.busy = false;
 
               break;
 
             case 3:
               // Create cache
+              quickPick.busy = true;
               quickPick.items = [
                 {
                   label: LOADING_LABEL,
@@ -347,6 +344,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 },
                 ...listItems
               ]
+              quickPick.busy = false;
 
               break;
 

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -173,6 +173,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(`code-for-ibmi.goToFileReadOnly`, async () => vscode.commands.executeCommand(`code-for-ibmi.goToFile`, true)),
     vscode.commands.registerCommand(`code-for-ibmi.goToFile`, async (readonly?: boolean) => {
       const LOADING_LABEL = `Please wait`;
+      const clearList = `$(trash) Clear list`;
+      const clearListArray = [{ label: ``, kind: vscode.QuickPickItemKind.Separator }, { label: clearList }];
       const storage = instance.getStorage();
       const content = instance.getContent();
       const config = instance.getConfig();
@@ -193,8 +195,6 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
         });
       });
 
-      list.push(`Clear list`);
-
       const listItems: vscode.QuickPickItem[] = list.map(item => ({ label: item }));
 
       const quickPick = vscode.window.createQuickPick();
@@ -203,7 +203,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
           label: 'Cached',
           kind: vscode.QuickPickItemKind.Separator
         },
-        ...listItems
+        ...listItems,
+        ...clearListArray
       ];
       quickPick.canSelectMany = false;
       (quickPick as any).sortByLabel = false; // https://github.com/microsoft/vscode/issues/73904#issuecomment-680298036
@@ -235,7 +236,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
               label: 'Cached',
               kind: vscode.QuickPickItemKind.Separator
             },
-            ...listItems
+            ...listItems,
+            ...clearListArray
           ];
           filteredItems = [];
         }
@@ -263,7 +265,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                   label: 'Cached',
                   kind: vscode.QuickPickItemKind.Separator
                 },
-                ...listItems
+                ...listItems,
+                ...clearListArray
               ]
 
               break;
@@ -305,7 +308,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                   label: 'Cached',
                   kind: vscode.QuickPickItemKind.Separator
                 },
-                ...listItems
+                ...listItems,
+                ...clearListArray
               ]
               quickPick.busy = false;
 
@@ -350,7 +354,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                   label: 'Cached',
                   kind: vscode.QuickPickItemKind.Separator
                 },
-                ...listItems
+                ...listItems,
+                ...clearListArray
               ]
               quickPick.busy = false;
 
@@ -377,7 +382,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 label: 'Cached',
                 kind: vscode.QuickPickItemKind.Separator
               },
-              ...listItems
+              ...listItems,
+              ...clearListArray
             ]
           }
           starRemoved = false;
@@ -387,7 +393,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       quickPick.onDidAccept(() => {
         const selection = quickPick.selectedItems[0].label;
         if (selection && selection !== LOADING_LABEL) {
-          if (selection === `Clear list`) {
+          if (selection === clearList) {
             storage!.setSourceList({});
             vscode.window.showInformationMessage(`Cleared list.`);
             quickPick.hide()

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -214,7 +214,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
         ).then(resultSetLibrary => {
           schemaItems = resultSetLibrary.map(row => ({
             label: String(row.SYSTEM_SCHEMA_NAME),
-            detail: String(row.SCHEMA_TEXT)
+            description: String(row.SCHEMA_TEXT)
           }))
 
           if (quickPick.value === ``) {
@@ -282,7 +282,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
 
               const listFile: vscode.QuickPickItem[] = resultSet.map(row => ({
                 label: selectionSplit[0] + '/' + String(row.SYSTEM_TABLE_NAME),
-                detail: String(row.TABLE_TEXT)
+                description: String(row.TABLE_TEXT)
               }))
 
               filteredItems = listFile.filter(file => file.label.startsWith(selectionSplit[0] + '/' + filterText));
@@ -327,7 +327,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
 
               const listMember = resultSet.map(row => ({
                 label: selectionSplit[0] + '/' + selectionSplit[1] + '/' + String(row.TABLE_PARTITION) + '.' + String(row.SOURCE_TYPE),
-                detail: String(row.PARTITION_TEXT)
+                description: String(row.PARTITION_TEXT)
               }))
 
               filteredItems = listMember.filter(member => member.label.startsWith(selectionSplit[0] + '/' + selectionSplit[1] + '/' + filterText));

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -177,6 +177,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       const content = instance.getContent();
       const config = instance.getConfig();
       const connection = instance.getConnection();
+      let starRemoved: boolean = false;
 
       if (!storage && !content) return;
       let list: string[] = [];
@@ -220,7 +221,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
           if (quickPick.value === ``) {
             quickPick.items = [
               {
-                label: 'Files',
+                label: 'Cached',
                 kind: vscode.QuickPickItemKind.Separator
               },
               ...listItems
@@ -252,7 +253,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 },
                 ...filteredItems,
                 {
-                  label: 'Files',
+                  label: 'Cached',
                   kind: vscode.QuickPickItemKind.Separator
                 },
                 ...listItems
@@ -294,7 +295,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 },
                 ...filteredItems,
                 {
-                  label: 'Files',
+                  label: 'Cached',
                   kind: vscode.QuickPickItemKind.Separator
                 },
                 ...listItems
@@ -339,7 +340,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 },
                 ...filteredItems,
                 {
-                  label: 'Files',
+                  label: 'Cached',
                   kind: vscode.QuickPickItemKind.Separator
                 },
                 ...listItems
@@ -354,10 +355,11 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
 
           // We remove the asterisk from the value so that the user can continue typing
           quickPick.value = quickPick.value.substring(0, quickPick.value.indexOf(`*`));
+          starRemoved = true;
 
         } else {
 
-          if (filteredItems.length > 0) {
+          if (filteredItems.length > 0 && !starRemoved) {
             quickPick.items = [
               {
                 label: 'Filter',
@@ -371,6 +373,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
               ...listItems
             ]
           }
+          starRemoved = false;
         }
       })
 

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -199,6 +199,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       const quickPick = vscode.window.createQuickPick();
       quickPick.items = listItems;
       quickPick.canSelectMany = false;
+      (quickPick as any).sortByLabel = false; // https://github.com/microsoft/vscode/issues/73904#issuecomment-680298036
       quickPick.placeholder = `Enter file path (format: LIB/SPF/NAME.ext (type '*' to search server) or /home/xx/file.txt)`;
 
       quickPick.show();


### PR DESCRIPTION
### Changes

This PR will fix some issue with the new search function in Go To File:
- The list label sort is disabled, since the list is already sorted when sent to UI.
- A progress bar will be shown when searching the server.
- The list is now more dense by showing text as description instead of detail.
- The labels are now shown correctly
- The list is now correctly changed to cached files when the value is cleared.
- The `Clear list` will always be shown, now with a separator line above and an icon in front.

### Checklist

* [x] have tested my change
* [x] eslint is not complaining
