### PR TITLE
Fixes/deployment_working_directory

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -89,6 +89,7 @@ export namespace CompileTools {
     const isProtected = uriOptions.readonly || config?.readOnlyMode;
         
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+    let remoteCwd = config?.homeDirectory || `.`;
 
     if (connection && config && content) {
       const extension = uri.path.substring(uri.path.lastIndexOf(`.`) + 1).toUpperCase();
@@ -130,9 +131,11 @@ export namespace CompileTools {
 
           let workspaceId: number | undefined = undefined;
           if (workspaceFolder && chosenAction.type === `file` && chosenAction.deployFirst) {
+
             const deployResult = await DeployTools.launchDeploy(workspaceFolder.index, method);
             if (deployResult !== undefined) {
-              workspaceId = deployResult;
+              workspaceId = deployResult.workspaceId;
+              remoteCwd = deployResult.remoteDirectory;
             } else {
               vscode.window.showWarningMessage(`Action "${chosenAction.name}" was cancelled.`);
               return false;
@@ -219,9 +222,10 @@ export namespace CompileTools {
                     variables.set(`&RELATIVEPATH`, relativePath);
 
                     // We need to make sure the remote path is posix
-                    const fullPath = path.posix.join(config.homeDirectory, relativePath);
+                    const fullPath = path.posix.join(remoteCwd, relativePath);
                     variables.set(`&FULLPATH`, fullPath);
                     variables.set(`{path}`, fullPath);
+                    variables.set(`&WORKDIR`, remoteCwd);
 
                     try {
                       const gitApi = Tools.getGitAPI();
@@ -242,7 +246,7 @@ export namespace CompileTools {
                   break;
 
                 case `streamfile`:
-                  const relativePath = path.posix.relative(config.homeDirectory, uri.path);
+                  const relativePath = path.posix.relative(remoteCwd, uri.path);
                   variables.set(`&RELATIVEPATH`, relativePath);
 
                   const fullName = uri.path;
@@ -321,10 +325,13 @@ export namespace CompileTools {
                     let problemsFetched = false;
 
                     try {
+                      writeEmitter.fire(`Running Action: ${chosenAction.name} (${new Date().toLocaleTimeString()})` + NEWLINE);
+
                       const commandResult = await runCommand(instance, {
                         title: chosenAction.name,
                         environment,
                         command,
+                        cwd: remoteCwd,
                         env: Object.fromEntries(variables),
                       }, writeEmitter);
 
@@ -361,7 +368,7 @@ export namespace CompileTools {
 
                       if (chosenAction.type === `file` && chosenAction.postDownload?.length) {
                         if (fromWorkspace) {
-                          const remoteDir = config.homeDirectory;
+                          const remoteDir = remoteCwd;
                           const localDir = fromWorkspace.uri;
 
                           const postDownloads: { type: vscode.FileType, localPath: string, remotePath: string }[] = [];
@@ -579,6 +586,9 @@ export namespace CompileTools {
           if (options.environment === `ile`) {
             writeEvent.fire(`Current library: ` + ileSetup.currentLibrary + NEWLINE);
             writeEvent.fire(`Library list: ` + ileSetup.libraryList.join(` `) + NEWLINE);
+          }
+          if (options.cwd) {
+            writeEvent.fire(`Working directory: ` + options.cwd + NEWLINE);
           }
           writeEvent.fire(`Commands:\n${commands.map(command => `\t${command}\n`).join(``)}` + NEWLINE);
         }

--- a/src/api/local/deployment.ts
+++ b/src/api/local/deployment.ts
@@ -195,6 +195,13 @@ export namespace Deployment {
       });
   }
 
+  export async function deleteFiles(parameters: DeploymentParameters, toDelete: string[]) {
+    if (toDelete.length) {
+      Deployment.deploymentLog.appendLine(`\nDeleted:\n\t${toDelete.join('\n\t')}\n`);
+      await Deployment.getConnection().sendCommand({ directory: parameters.remotePath, command: `rm -f ${toDelete.join(' ')}` });
+    }
+  }
+
   export async function sendCompressed(parameters: DeploymentParameters, files: vscode.Uri[], progress: vscode.Progress<{ message?: string }>) {
     const connection = getConnection();
     const localTarball = tmp.fileSync({ postfix: ".tar" });

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -414,14 +414,6 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
 
             if (deletionConfirmed) {
               try {
-                if(config.homeDirectory === node.path){
-                  const echoHome = await connection.sendCommand({ command: `echo $HOME` });
-                  if(echoHome.code === 0){
-                    config.homeDirectory = echoHome.stdout.trim();
-                    await ConnectionConfiguration.update(config);                    
-                    vscode.window.showInformationMessage(t('ifsBrowser.deleteIFS.default.home.dir', node.path, config.homeDirectory));
-                  }
-                }
                 const removeResult = await connection.sendCommand({ command: `rm -rf ${Tools.escapePath(node.path)}` })
                 if(removeResult.code === 0){
                   vscode.window.showInformationMessage(t(`ifsBrowser.deleteIFS.infoMessage`, node.path));


### PR DESCRIPTION
### Changes

* Adds `&WORKDIR` for local actions, which is the deployment directory and is not the same as `&HOME` (as they can be different)
* Fixes issue where remote working directory was being changes by deployment. It no longer does this and instead uses the deploy directory when running commands (and we added `&WORKDIR`)
* Cleanup 'compare' deploy API to have seperation of delete login (this will require a type change in the API)

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
