### PR TITLE
ASP support member lookup

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -681,14 +681,15 @@ export default class IBMiContent {
       .map(file => {
         const asp = file.asp || this.config.sourceASP;
         if (asp && asp.length > 0) {
-          return [`/${asp}/QSYS.LIB/${file.library}.LIB/${file.name}.FILE/${member}.MBR`, `/QSYS.LIB/${file.library}.LIB/${file.name}.FILE/${member}.MBR`].join(` `);
+          return [
+            Tools.qualifyPath(file.library, file.name, member, asp, true), 
+            Tools.qualifyPath(file.library, file.name, member, undefined, true)
+          ].join(` `);
         } else {
-          return `/QSYS.LIB/${file.library}.LIB/${file.name}.FILE/${member}.MBR`;
+          return Tools.qualifyPath(file.library, file.name, member, undefined, true);
         }
       })
-      .map(file => Tools.escapePath(file))
       .join(` `)
-      .replace(/([$\\])/g,'\\$1')
       .toUpperCase();
 
     const command = `for f in ${pathList}; do if [ -f $f ]; then echo $f; break; fi; done`;

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -678,7 +678,14 @@ export default class IBMiContent {
   async memberResolve(member: string, files: QsysPath[]): Promise<IBMiMember | undefined> {
     // Escape names for shell
     const pathList = files
-      .map(file => `/QSYS.LIB/${file.library}.LIB/${file.name}.FILE/${member}.MBR`)
+      .map(file => {
+        const asp = file.asp || this.config.sourceASP;
+        if (asp && asp.length > 0) {
+          return [`/${asp}/QSYS.LIB/${file.library}.LIB/${file.name}.FILE/${member}.MBR`, `/QSYS.LIB/${file.library}.LIB/${file.name}.FILE/${member}.MBR`].join(` `);
+        } else {
+          return `/QSYS.LIB/${file.library}.LIB/${file.name}.FILE/${member}.MBR`;
+        }
+      })
       .join(` `)
       .replace(/([$\\])/g,'\\$1')
       .toUpperCase();

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -686,6 +686,7 @@ export default class IBMiContent {
           return `/QSYS.LIB/${file.library}.LIB/${file.name}.FILE/${member}.MBR`;
         }
       })
+      .map(file => Tools.escapePath(file))
       .join(` `)
       .replace(/([$\\])/g,'\\$1')
       .toUpperCase();

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -136,10 +136,14 @@ export namespace Tools {
    * @param member
    * @param iasp Optional: an iASP name
    */
-  export function qualifyPath(library: string, object: string, member: string, iasp?: string) {
-    const path =
-      (iasp && iasp.length > 0 ? `/${iasp}` : ``) + `/QSYS.lib/${library}.lib/${object}.file/${member}.mbr`;
-    return path;
+  export function qualifyPath(library: string, object: string, member: string, iasp?: string, sanitise?: boolean) {
+    library = library.toUpperCase();
+    const libraryPath = library === `QSYS` ? `QSYS.LIB` : `QSYS.LIB/${Tools.sanitizeLibraryNames([library]).join(``)}.LIB`;
+    const memberPath = `${object.toUpperCase()}.FILE/${member.toUpperCase()}.MBR`
+    const memberSubpath = sanitise ? Tools.escapePath(memberPath) : memberPath;
+
+    const result = (iasp && iasp.length > 0 ? `/${iasp}` : ``) + `/${libraryPath}/${memberSubpath}`;
+    return result;
   }
 
   /**

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -28,6 +28,24 @@ export const ContentSuite: TestSuite = {
       });
     }},
 
+    {name: `Test memberResolve (with invalid ASP)`, test: async () => {
+      const content = instance.getContent();
+  
+      const member = await content?.memberResolve(`MATH`, [
+        {library: `QSYSINC`, name: `MIH`}, // Doesn't exist here
+        {library: `QSYSINC`, name: `H`, asp: `myasp`} // Does exist, but not in the ASP
+      ]);
+  
+      assert.deepStrictEqual(member, {
+        asp: undefined,
+        library: `QSYSINC`,
+        file: `H`,
+        name: `MATH`,
+        extension: `MBR`,
+        basename: `MATH.MBR`
+      });
+    }},
+
     {name: `Test memberResolve with bad name`, test: async () => {
       const content = instance.getContent();
   

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -89,6 +89,7 @@ export interface Profile {
 }
 
 export interface QsysPath {
+  asp?: string,
   library: string,
   name: string,
 }


### PR DESCRIPTION
### Changes

Similar to opening files, `memberResolve` will now look in the user defined ASP to find a member. Additionally, the API can accept an ASP and will use that instead.

Also solves a bug with the `qualifyPath` which wasn't handling `QSYS` correctly.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
