### PR TITLE
Fix missing throw in downloadMemberContent

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -8,6 +8,7 @@ import { CommandResult, IBMiError, IBMiFile, IBMiMember, IBMiObject, IFSFile, Qs
 import { ConnectionConfiguration } from './Configuration';
 import { default as IBMi } from './IBMi';
 import { Tools } from './Tools';
+import { r } from 'tar';
 const tmpFile = util.promisify(tmp.file);
 const readFileAsync = util.promisify(fs.readFile);
 const writeFileAsync = util.promisify(fs.writeFile);
@@ -149,11 +150,13 @@ export default class IBMiContent {
               }
               break;
             default:
-              throw e;
+              retry = false;
+              break;
           }
         }
-        else {
-          throw e;
+
+        if (!retry) {
+          throw e
         }
       }
     }

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -8,7 +8,6 @@ import { CommandResult, IBMiError, IBMiFile, IBMiMember, IBMiObject, IFSFile, Qs
 import { ConnectionConfiguration } from './Configuration';
 import { default as IBMi } from './IBMi';
 import { Tools } from './Tools';
-import { r } from 'tar';
 const tmpFile = util.promisify(tmp.file);
 const readFileAsync = util.promisify(fs.readFile);
 const writeFileAsync = util.promisify(fs.writeFile);


### PR DESCRIPTION
### Changes

I noticed when vscode-rpgle tries to fetch rpglint.json from the QSYS file system, it was spamming if it was not found. This was due to some invalid retry logic where it would just get caught in a loop. This is also possibly related to the issue @pabloto found in #1704. You would see this, including for all missing includes, in the output log.

```
.: system "CPYTOSTMF FROMMBR('/QSYS.lib/LIAMA.lib/VSCODE.file/RPGLINT.mbr') TOSTMF('/tmp/vscodetemp-O_7cyB9KET') STMFOPT(*REPLACE) STMFCCSID(1208) DBFCCSID(*FILE)"
{
    "code": 255,
    "signal": null,
    "stdout": "",
    "stderr": "CPFA0A9: Object not found.  Object is /QSYS.lib/LIAMA.lib/VSCODE.file/RPGLINT.mbr.\nCPFA097: Object not copied.  Object is /QSYS.lib/LIAMA.lib/VSCODE.file/RPGLINT.mbr."
}
```

### To test:

#### Recreate

1. Check out to `master`
2. Have vscode-rpgle installed
3. Make sure the `VSCODE` source file exists, but make sure no `RPGLINT.JSON` member exists in it
4. Create a brand new SQL/RPGLE member in the same library: `source.rpgle`
5. See the spam (like above) in the output console

#### The fix

1. Checkout this PR and launch in debug
2. Have vscode-rpgle installed
3. Make sure the `VSCODE` source file exists, but make sure no `RPGLINT.JSON` member exists in it
4. Create a brand new SQL/RPGLE member in the same library: `source.rpgle`
5. See it (like above) written to the output log once and then stop.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
