### PR TITLE
Removed deprecated commands call and ignore library list

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -536,17 +536,14 @@ export namespace CompileTools {
     if (config && connection) {
       const cwd = options.cwd;
 
-      let ileSetup: ILELibrarySettings = {
+      const ileSetup: ILELibrarySettings = {
         currentLibrary: config.currentLibrary,
         libraryList: config.libraryList,
       };
 
       if (options.env) {
-        const libl: string | undefined = options.env[`&LIBL`];
-        const curlib: string | undefined = options.env[`&CURLIB`];
-
-        if (libl) ileSetup.libraryList = libl.split(` `);
-        if (curlib) ileSetup.currentLibrary = curlib;
+        ileSetup.libraryList = options.env[`&LIBL`]?.split(` `) || ileSetup.libraryList;
+        ileSetup.currentLibrary = options.env[`&CURLIB`] || ileSetup.currentLibrary;
       }
 
       // Remove any duplicates from the library list
@@ -576,7 +573,7 @@ export namespace CompileTools {
         const commands = commandString.split(`\n`).filter(command => command.trim().length > 0);
 
         if (writeEvent) {
-          if (options.environment === `ile`) {
+          if (options.environment === `ile` && !options.noLibList) {
             writeEvent.fire(`Current library: ` + ileSetup.currentLibrary + NEWLINE);
             writeEvent.fire(`Library list: ` + ileSetup.libraryList.join(` `) + NEWLINE);
           }
@@ -623,7 +620,7 @@ export namespace CompileTools {
           case `qsh`:
             commandResult = await connection.sendQsh({
               command: [
-                ...buildLiblistCommands(connection, ileSetup),
+                ...options.noLibList? [] : buildLiblistCommands(connection, ileSetup),
                 ...commands,
               ].join(` && `),
               directory: cwd,
@@ -636,7 +633,7 @@ export namespace CompileTools {
             // escape $ and # in commands
             commandResult = await connection.sendQsh({
               command: [
-                ...buildLiblistCommands(connection, ileSetup),
+                ...options.noLibList? [] : buildLiblistCommands(connection, ileSetup),
                 ...commands.map(command =>
                   `${`system ${GlobalConfiguration.get(`logCompileOutput`) ? `` : `-s`} "${command.replace(/[$]/g, `\\$&`)}"; if [[ $? -ne 0 ]]; then exit 1; fi`}`,
                 )

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -202,6 +202,10 @@ export default class IBMi {
         this.client.connection!.once(`end`, disconnected);
         this.client.connection!.once(`error`, disconnected);
 
+        if(!reconnecting){
+          instance.setConnection(this);
+        }
+
         progress.report({
           message: `Checking home directory.`
         });
@@ -794,8 +798,7 @@ export default class IBMi {
           }
         }
 
-        if (!reconnecting) {
-          instance.setConnection(this);
+        if (!reconnecting) {          
           vscode.workspace.getConfiguration().update(`workbench.editor.enablePreview`, false, true);
           await vscode.commands.executeCommand(`setContext`, `code-for-ibmi:connected`, true);
           instance.fire("connected");

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -122,9 +122,10 @@ export default class IBMiContent {
     const tempRmt = this.getTempRemote(path);
     while (true) {
       try {
-        await this.ibmi.remoteCommand(
-          `CPYTOSTMF FROMMBR('${path}') TOSTMF('${tempRmt}') STMFOPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`, `.`
-        );
+        await this.ibmi.runCommand({
+          command: `CPYTOSTMF FROMMBR('${path}') TOSTMF('${tempRmt}') STMFOPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
+          noLibList: true
+        });
 
         if (!localPath) {
           localPath = await tmpFile();
@@ -180,9 +181,10 @@ export default class IBMiContent {
 
       while (true) {
         try {
-          await this.ibmi.remoteCommand(
-            `QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${path}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
-          );
+          await this.ibmi.runCommand({
+            command: `QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${path}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
+            noLibList: true
+          });
           return true;
         }
         catch (e) {
@@ -286,25 +288,29 @@ export default class IBMiContent {
       const data = await this.runSQL(`SELECT * FROM ${library}.${file}`);
 
       if (deleteTable && this.config.autoClearTempData) {
-        this.ibmi.remoteCommand(`DLTOBJ OBJ(${library}/${file}) OBJTYPE(*FILE)`, `.`);
+        await this.ibmi.runCommand({
+          command: `DLTOBJ OBJ(${library}/${file}) OBJTYPE(*FILE)`,
+          noLibList: true
+        });
       }
 
       return data;
 
     } else {
       const tempRmt = this.getTempRemote(Tools.qualifyPath(library, file, member));
-      await this.ibmi.remoteCommand(
-        `QSYS/CPYTOIMPF FROMFILE(${library}/${file} ${member}) ` +
-        `TOSTMF('${tempRmt}') ` +
-        `MBROPT(*REPLACE) STMFCCSID(1208) RCDDLM(*CRLF) DTAFMT(*DLM) RMVBLANK(*TRAILING) ADDCOLNAM(*SQL) FLDDLM(',') DECPNT(*PERIOD)`
-      );
+      await this.ibmi.runCommand({
+        command: `QSYS/CPYTOIMPF FROMFILE(${library}/${file} ${member}) ` +
+          `TOSTMF('${tempRmt}') ` +
+          `MBROPT(*REPLACE) STMFCCSID(1208) RCDDLM(*CRLF) DTAFMT(*DLM) RMVBLANK(*TRAILING) ADDCOLNAM(*SQL) FLDDLM(',') DECPNT(*PERIOD)`,
+        noLibList: true
+      });
 
       let result = await this.downloadStreamfile(tempRmt);
 
       if (this.config.autoClearTempData) {
         await this.ibmi.sendCommand({ command: `rm -f ${tempRmt}`, directory: `.` });
         if (deleteTable) {
-          this.ibmi.remoteCommand(`DLTOBJ OBJ(${library}/${file}) OBJTYPE(*FILE)`, `.`);
+          await this.ibmi.runCommand({ command: `DLTOBJ OBJ(${library}/${file}) OBJTYPE(*FILE)`, noLibList: true });
         }
       }
 
@@ -344,7 +350,10 @@ export default class IBMiContent {
       `;
       results = await this.runSQL(statement);
     } else {
-      await this.ibmi.remoteCommand(`DSPOBJD OBJ(QSYS/*ALL) OBJTYPE(*LIB) DETAIL(*TEXTATR) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${TempName})`);
+      await this.ibmi.runCommand({
+        command: `DSPOBJD OBJ(QSYS/*ALL) OBJTYPE(*LIB) DETAIL(*TEXTATR) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${TempName})`,
+        noLibList: true
+      });
       results = await this.getTable(tempLib, TempName, TempName, true);
 
       if (results.length === 1 && !results[0].ODOBNM?.toString().trim()) {
@@ -431,7 +440,10 @@ export default class IBMiContent {
     const tempName = Tools.makeid();
 
     if (sourceFilesOnly) {
-      await this.ibmi.remoteCommand(`DSPFD FILE(${library}/${object}) TYPE(*ATR) FILEATR(*PF) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${tempName})`);
+      await this.ibmi.runCommand({
+        command: `DSPFD FILE(${library}/${object}) TYPE(*ATR) FILEATR(*PF) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${tempName})`,
+        noLibList: true
+      });
 
       const results = await this.getTable(tempLib, tempName, tempName, true);
       if (results.length === 1 && !results[0].PHFILE?.toString().trim()) {
@@ -451,7 +463,10 @@ export default class IBMiContent {
     } else {
       const objectTypes = (filters.types && filters.types.length ? filters.types.map(type => type.toUpperCase()).join(` `) : `*ALL`);
 
-      await this.ibmi.remoteCommand(`DSPOBJD OBJ(${library}/${object}) OBJTYPE(${objectTypes}) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${tempName})`);
+      await this.ibmi.runCommand({
+        command: `DSPOBJD OBJ(${library}/${object}) OBJTYPE(${objectTypes}) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${tempName})`,
+        noLibList: true
+      });
       const results = await this.getTable(tempLib, tempName, tempName, true);
 
       if (results.length === 1 && !results[0].ODOBNM?.toString().trim()) {
@@ -530,7 +545,10 @@ export default class IBMiContent {
       const tempLib = this.config.tempLibrary;
       const TempName = Tools.makeid();
 
-      await this.ibmi.remoteCommand(`DSPFD FILE(${library}/${sourceFile}) TYPE(*MBR) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${TempName})`);
+      await this.ibmi.runCommand({
+        command: `DSPFD FILE(${library}/${sourceFile}) TYPE(*MBR) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${TempName})`,
+        noLibList: true
+      });
       results = await this.getTable(tempLib, TempName, TempName, true);
       if (results.length === 1 && String(results[0].MBNAME).trim() === ``) {
         return [];
@@ -807,7 +825,8 @@ export default class IBMiContent {
 
   async checkObject(object: { library: string, name: string, type: string }, ...authorities: Authority[]) {
     return (await this.ibmi.runCommand({
-      command: `CHKOBJ OBJ(${object.library.toLocaleUpperCase()}/${object.name.toLocaleUpperCase()}) OBJTYPE(${object.type.toLocaleUpperCase()}) AUT(${authorities.join(" ")})`
+      command: `CHKOBJ OBJ(${object.library.toLocaleUpperCase()}/${object.name.toLocaleUpperCase()}) OBJTYPE(${object.type.toLocaleUpperCase()}) AUT(${authorities.join(" ")})`,
+      noLibList: true
     }))?.code === 0;
   }
 }

--- a/src/languages/clle/clApi.ts
+++ b/src/languages/clle/clApi.ts
@@ -11,14 +11,14 @@ export async function init() {
     window.showInformationMessage(`Would you like to install the CL prompting tools onto your system?`, `Yes`, `No`)
       .then(async result => {
         switch (result) {
-        case `Yes`:
-          try {
-            await install();
-            window.showInformationMessage(`CL components installed.`);
-          } catch (e) {
-            window.showInformationMessage(`Failed to install CL components.`);
-          }
-          break;
+          case `Yes`:
+            try {
+              await install();
+              window.showInformationMessage(`CL components installed.`);
+            } catch (e) {
+              window.showInformationMessage(`Failed to install CL components.`);
+            }
+            break;
         }
       });
   }
@@ -38,13 +38,14 @@ async function install() {
   const tempLib = config.tempLibrary;
 
   try {
-    await connection.remoteCommand(`CRTSRCPF ${tempLib}/QTOOLS`, undefined)
+    await connection.runCommand({ command: `CRTSRCPF ${tempLib}/QTOOLS`, noLibList: true })
   } catch (e) {
     //It may exist already so we just ignore the error
   }
 
   await content.uploadMemberContent(undefined, tempLib, `QTOOLS`, `GENCMDXML`, gencmdxml.content.join(`\n`));
-  await connection.remoteCommand(
-    `CRTBNDCL PGM(${tempLib}/GENCMDXML) SRCFILE(${tempLib}/QTOOLS) DBGVIEW(*SOURCE) TEXT('vscode-ibmi xml generator for commands')`
-  );
+  await connection.runCommand({
+    command: `CRTBNDCL PGM(${tempLib}/GENCMDXML) SRCFILE(${tempLib}/QTOOLS) DBGVIEW(*SOURCE) TEXT('vscode-ibmi xml generator for commands')`,
+    noLibList: true
+  });
 }

--- a/src/languages/clle/getnewlibl.ts
+++ b/src/languages/clle/getnewlibl.ts
@@ -14,7 +14,11 @@ export async function initGetNewLibl(instance: Instance) {
     const tempSourcePath = connection.getTempRemote(`getnewlibl.sql`) || `/tmp/getnewlibl.sql`;
 
     content!.writeStreamfile(tempSourcePath, getSource(config.tempLibrary)).then(() => {
-      connection.remoteCommand(`RUNSQLSTM SRCSTMF('${tempSourcePath}') COMMIT(*NONE) NAMING(*SQL)`, `/`)
+      connection.runCommand({
+        command: `RUNSQLSTM SRCSTMF('${tempSourcePath}') COMMIT(*NONE) NAMING(*SQL)`,
+        cwd: `/`,
+        noLibList: true
+      })
       .then(() => {
         connection.remoteFeatures[`GETNEWLIBL.PGM`] = `${config.tempLibrary}.GETNEWLIBL`;
       })

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -1,197 +1,225 @@
 import assert from "assert";
-import { Uri, commands, workspace } from "vscode";
-import { TestSuite } from ".";
-import { instance } from "../instantiate";
-import util from 'util';
 import tmp from 'tmp';
-import { CommandResult } from "../typings";
+import util from 'util';
+import { Uri, workspace } from "vscode";
+import { TestSuite } from ".";
 import { Tools } from "../api/Tools";
+import { instance } from "../instantiate";
+import { CommandResult } from "../typings";
 
 export const ContentSuite: TestSuite = {
   name: `Content API tests`,
   tests: [
-    {name: `Test memberResolve`, test: async () => {
-      const content = instance.getContent();
-  
-      const member = await content?.memberResolve(`MATH`, [
-        {library: `QSYSINC`, name: `MIH`}, // Doesn't exist here
-        {library: `QSYSINC`, name: `H`} // Does exist
-      ]);
-  
-      assert.deepStrictEqual(member, {
-        asp: undefined,
-        library: `QSYSINC`,
-        file: `H`,
-        name: `MATH`,
-        extension: `MBR`,
-        basename: `MATH.MBR`
-      });
-    }},
+    {
+      name: `Test memberResolve`, test: async () => {
+        const content = instance.getContent();
 
-    {name: `Test memberResolve with bad name`, test: async () => {
-      const content = instance.getContent();
-  
-      const member = await content?.memberResolve(`BOOOP`, [
-        {library: `QSYSINC`, name: `MIH`}, // Doesn't exist here
-        {library: `NOEXIST`, name: `SUP`}, // Doesn't exist here
-        {library: `QSYSINC`, name: `H`} // Doesn't exist here
-      ]);
-  
-      assert.deepStrictEqual(member, undefined);
-    }},
+        const member = await content?.memberResolve(`MATH`, [
+          { library: `QSYSINC`, name: `MIH` }, // Doesn't exist here
+          { library: `QSYSINC`, name: `H` } // Does exist
+        ]);
 
-    {name: `Test objectResolve .FILE`, test: async () => {
-      const content = instance.getContent();
-  
-      const lib = await content?.objectResolve(`MIH`, [
-        "QSYS2", // Doesn't exist here
-        "QSYSINC" // Does exist
-      ]);
-  
-      assert.strictEqual(lib, "QSYSINC");
-    }},
+        assert.deepStrictEqual(member, {
+          asp: undefined,
+          library: `QSYSINC`,
+          file: `H`,
+          name: `MATH`,
+          extension: `MBR`,
+          basename: `MATH.MBR`
+        });
+      }
+    },
 
-    {name: `Test objectResolve .PGM`, test: async () => {
-      const content = instance.getContent();
-  
-      const lib = await content?.objectResolve(`CMRCV`, [
-        "QSYSINC", // Doesn't exist here
-        "QSYS2" // Does exist 
-      ]);
-  
-      assert.strictEqual(lib, "QSYS2");
-    }},
+    {
+      name: `Test memberResolve with bad name`, test: async () => {
+        const content = instance.getContent();
 
-    {name: `Test objectResolve with bad name`, test: async () => {
-      const content = instance.getContent();
+        const member = await content?.memberResolve(`BOOOP`, [
+          { library: `QSYSINC`, name: `MIH` }, // Doesn't exist here
+          { library: `NOEXIST`, name: `SUP` }, // Doesn't exist here
+          { library: `QSYSINC`, name: `H` } // Doesn't exist here
+        ]);
 
-      const lib = await content?.objectResolve(`BOOOP`, [
-        "BADLIB", // Doesn't exist here
-        "QSYS2", // Doesn't exist here
-        "QSYSINC", // Doesn't exist here
-      ]);
-  
-      assert.strictEqual(lib, undefined);
-  
-    }},
-  
-    {name: `Test streamfileResolve`, test: async () => {
-      const content = instance.getContent();
-  
-      const streamfilePath = await content?.streamfileResolve([`git`], [`/QOpenSys/pkgs/sbin`, `/QOpenSys/pkgs/bin`])
-  
-      assert.strictEqual(streamfilePath, `/QOpenSys/pkgs/bin/git`);
-    }},
+        assert.deepStrictEqual(member, undefined);
+      }
+    },
 
-    {name: `Test streamfileResolve with bad name`, test: async () => {
-      const content = instance.getContent();
-  
-      const streamfilePath = await content?.streamfileResolve([`sup`], [`/QOpenSys/pkgs/sbin`, `/QOpenSys/pkgs/bin`])
-  
-      assert.strictEqual(streamfilePath, undefined);
-    }},
+    {
+      name: `Test objectResolve .FILE`, test: async () => {
+        const content = instance.getContent();
 
-    {name: `Test streamfileResolve with multiple names`, test: async () => {
-      const content = instance.getContent();
-  
-      const streamfilePath = await content?.streamfileResolve([`sup`, `sup2`, `git`], [`/QOpenSys/pkgs/sbin`, `/QOpenSys/pkgs/bin`])
-  
-      assert.strictEqual(streamfilePath, `/QOpenSys/pkgs/bin/git`);
-    }},
+        const lib = await content?.objectResolve(`MIH`, [
+          "QSYS2", // Doesn't exist here
+          "QSYSINC" // Does exist
+        ]);
+
+        assert.strictEqual(lib, "QSYSINC");
+      }
+    },
+
+    {
+      name: `Test objectResolve .PGM`, test: async () => {
+        const content = instance.getContent();
+
+        const lib = await content?.objectResolve(`CMRCV`, [
+          "QSYSINC", // Doesn't exist here
+          "QSYS2" // Does exist 
+        ]);
+
+        assert.strictEqual(lib, "QSYS2");
+      }
+    },
+
+    {
+      name: `Test objectResolve with bad name`, test: async () => {
+        const content = instance.getContent();
+
+        const lib = await content?.objectResolve(`BOOOP`, [
+          "BADLIB", // Doesn't exist here
+          "QSYS2", // Doesn't exist here
+          "QSYSINC", // Doesn't exist here
+        ]);
+
+        assert.strictEqual(lib, undefined);
+
+      }
+    },
+
+    {
+      name: `Test streamfileResolve`, test: async () => {
+        const content = instance.getContent();
+
+        const streamfilePath = await content?.streamfileResolve([`git`], [`/QOpenSys/pkgs/sbin`, `/QOpenSys/pkgs/bin`])
+
+        assert.strictEqual(streamfilePath, `/QOpenSys/pkgs/bin/git`);
+      }
+    },
+
+    {
+      name: `Test streamfileResolve with bad name`, test: async () => {
+        const content = instance.getContent();
+
+        const streamfilePath = await content?.streamfileResolve([`sup`], [`/QOpenSys/pkgs/sbin`, `/QOpenSys/pkgs/bin`])
+
+        assert.strictEqual(streamfilePath, undefined);
+      }
+    },
+
+    {
+      name: `Test streamfileResolve with multiple names`, test: async () => {
+        const content = instance.getContent();
+
+        const streamfilePath = await content?.streamfileResolve([`sup`, `sup2`, `git`], [`/QOpenSys/pkgs/sbin`, `/QOpenSys/pkgs/bin`])
+
+        assert.strictEqual(streamfilePath, `/QOpenSys/pkgs/bin/git`);
+      }
+    },
 
 
 
-    {name: `Test streamfileResolve with blanks in names`, test: async () => {
-      const connection = instance.getConnection();
-      const content = instance.getContent();
-      const files = [`normalname`, `name with blank`, `name_with_quote'`, `name_with_dollar$`];
-      const dir = `/tmp/${Date.now()}`;
-      const dirWithSubdir = `${dir}/${files[0]}`;
+    {
+      name: `Test streamfileResolve with blanks in names`, test: async () => {
+        const connection = instance.getConnection();
+        const content = instance.getContent();
+        const files = [`normalname`, `name with blank`, `name_with_quote'`, `name_with_dollar$`];
+        const dir = `/tmp/${Date.now()}`;
+        const dirWithSubdir = `${dir}/${files[0]}`;
 
-      let result: CommandResult | undefined;
+        let result: CommandResult | undefined;
 
-      result = await connection?.sendCommand({command: `mkdir -p "${dir}"`});
-      assert.strictEqual(result?.code, 0);
-      try{
-        for (const file of files) {
-          result = await connection?.sendCommand({command: `touch "${dir}/${file}"`});
+        result = await connection?.sendCommand({ command: `mkdir -p "${dir}"` });
+        assert.strictEqual(result?.code, 0);
+        try {
+          for (const file of files) {
+            result = await connection?.sendCommand({ command: `touch "${dir}/${file}"` });
+            assert.strictEqual(result?.code, 0);
+          };
+
+          for (const file of files) {
+            let result = await content?.streamfileResolve([`${Date.now()}`, file], [`${Date.now()}`, dir]);
+            assert.strictEqual(result, `${dir}/${file}`, `Resolving file "${dir}/${file}" failed`);
+          }
+        }
+        finally {
+          result = await connection?.sendCommand({ command: `rm -r "${dir}"` });
           assert.strictEqual(result?.code, 0);
-        };
-
-        for (const file of files) {
-          let result = await content?.streamfileResolve([`${Date.now()}`, file], [`${Date.now()}`, dir]);
-          assert.strictEqual(result, `${dir}/${file}`, `Resolving file "${dir}/${file}" failed`);
         }
       }
-      finally{
-        result = await connection?.sendCommand({command: `rm -r "${dir}"`});
-        assert.strictEqual(result?.code, 0);
+    },
+
+    {
+      name: `Test downloadMemberContent`, test: async () => {
+        const content = instance.getContent();
+
+        const tmpFile = await util.promisify(tmp.file)();
+        const memberContent = await content?.downloadMemberContent(undefined, 'QSYSINC', 'H', 'MATH', tmpFile);
+        const tmpFileContent = (await workspace.fs.readFile(Uri.file(tmpFile))).toString();
+
+        assert.strictEqual(tmpFileContent, memberContent);
       }
-    }},
+    },
 
-    {name: `Test downloadMemberContent`, test: async () => {
-      const content = instance.getContent();
+    {
+      name: `Test runSQL (basic select)`, test: async () => {
+        const content = instance.getContent();
 
-      const tmpFile = await util.promisify(tmp.file)();
-      const memberContent = await content?.downloadMemberContent(undefined, 'QSYSINC', 'H', 'MATH', tmpFile);
-      const tmpFileContent = (await workspace.fs.readFile(Uri.file(tmpFile))).toString();
-  
-      assert.strictEqual(tmpFileContent, memberContent);
-    }},
-    
-    {name: `Test runSQL (basic select)`, test: async () => {
-      const content = instance.getContent();
-  
-      const rows = await content?.runSQL(`select * from qiws.qcustcdt`);
-      assert.notStrictEqual(rows?.length, 0);
+        const rows = await content?.runSQL(`select * from qiws.qcustcdt`);
+        assert.notStrictEqual(rows?.length, 0);
 
-      const firstRow = rows![0];
-      assert.strictEqual(typeof firstRow[`BALDUE`], `number`);
-      assert.strictEqual(typeof firstRow[`CITY`], `string`);
-    }},
-
-    {name: `Test runSQL (bad basic select)`, test: async () => {
-      const content = instance.getContent();
-  
-      try {
-        await content?.runSQL(`select from qiws.qcustcdt`);
-      } catch (e: any) {
-        assert.strictEqual(e.message, `Token . was not valid. Valid tokens: , FROM INTO. (42601)`);
-        assert.strictEqual(e.sqlstate, `42601`);
+        const firstRow = rows![0];
+        assert.strictEqual(typeof firstRow[`BALDUE`], `number`);
+        assert.strictEqual(typeof firstRow[`CITY`], `string`);
       }
-    }},
+    },
 
-    {name: `Test runSQL (with comments)`, test: async () => {
-      const content = instance.getContent();
-  
-      const rows = await content?.runSQL([
-        `-- myselect`,
-        `select *`,
-        `from qiws.qcustcdt --my table`,
-        `limit 1`,
-      ].join(`\n`));
+    {
+      name: `Test runSQL (bad basic select)`, test: async () => {
+        const content = instance.getContent();
 
-      assert.strictEqual(rows?.length, 1);
-    }},
+        try {
+          await content?.runSQL(`select from qiws.qcustcdt`);
+        } catch (e: any) {
+          assert.strictEqual(e.message, `Token . was not valid. Valid tokens: , FROM INTO. (42601)`);
+          assert.strictEqual(e.sqlstate, `42601`);
+        }
+      }
+    },
 
-    {name: `Test getTable (SQL disabled)`, test: async () => {
-      const config = instance.getConfig();
-      const content = instance.getContent();
-  
-      const resetValue = config!.enableSQL;
+    {
+      name: `Test runSQL (with comments)`, test: async () => {
+        const content = instance.getContent();
 
-      // SQL needs to be disabled for this test.
-      config!.enableSQL = false;
-      const rows = await content?.getTable(`qiws`, `qcustcdt`, `*all`);
+        const rows = await content?.runSQL([
+          `-- myselect`,
+          `select *`,
+          `from qiws.qcustcdt --my table`,
+          `limit 1`,
+        ].join(`\n`));
 
-      config!.enableSQL = resetValue;
+        assert.strictEqual(rows?.length, 1);
+      }
+    },
 
-      assert.notStrictEqual(rows?.length, 0);
-      const firstRow = rows![0];
+    {
+      name: `Test getTable (SQL disabled)`, test: async () => {
+        const config = instance.getConfig();
+        const content = instance.getContent();
 
-      assert.strictEqual(typeof firstRow[`BALDUE`], `number`);
-      assert.strictEqual(typeof firstRow[`CITY`], `string`);
-    }},
+        const resetValue = config!.enableSQL;
+
+        // SQL needs to be disabled for this test.
+        config!.enableSQL = false;
+        const rows = await content?.getTable(`qiws`, `qcustcdt`, `*all`);
+
+        config!.enableSQL = resetValue;
+
+        assert.notStrictEqual(rows?.length, 0);
+        const firstRow = rows![0];
+
+        assert.strictEqual(typeof firstRow[`BALDUE`], `number`);
+        assert.strictEqual(typeof firstRow[`CITY`], `string`);
+      }
+    },
 
     {
       name: `Test getTable (SQL compared to nosql)`, test: async () => {
@@ -204,7 +232,10 @@ export const ContentSuite: TestSuite = {
         // First we fetch the table in SQL mode
         const tempLib = config!.tempLibrary;
         const TempName = Tools.makeid();
-        await connection?.remoteCommand(`DSPOBJD OBJ(QSYS/QSYSINC) OBJTYPE(*LIB) DETAIL(*TEXTATR) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${TempName})`);
+        await connection?.runCommand({
+          command: `DSPOBJD OBJ(QSYS/QSYSINC) OBJTYPE(*LIB) DETAIL(*TEXTATR) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${TempName})`,
+          noLibList: true
+        });
         const tableA = await content?.getTable(tempLib, TempName, TempName, true);
 
         config!.enableSQL = false;
@@ -219,183 +250,197 @@ export const ContentSuite: TestSuite = {
       }
     },
 
-    {name: `Test getTable (SQL enabled)`, test: async () => {
-      const config = instance.getConfig();
-      const content = instance.getContent();
-  
-      assert.strictEqual(config!.enableSQL, true, `SQL must be enabled for this test`);
+    {
+      name: `Test getTable (SQL enabled)`, test: async () => {
+        const config = instance.getConfig();
+        const content = instance.getContent();
 
-      const rows = await content?.getTable(`qiws`, `qcustcdt`, `qcustcdt`);
+        assert.strictEqual(config!.enableSQL, true, `SQL must be enabled for this test`);
 
-      assert.notStrictEqual(rows?.length, 0);
-    }},
+        const rows = await content?.getTable(`qiws`, `qcustcdt`, `qcustcdt`);
 
-    {name: `Test validateLibraryList`, test: async () => {
-      const content = instance.getContent();
-  
-      const badLibs = await content?.validateLibraryList([`QSYSINC`, `BEEPBOOP`]);
-
-      assert.strictEqual(badLibs?.includes(`BEEPBOOP`), true);
-      assert.strictEqual(badLibs?.includes(`QSYSINC`), false);
-    }},
-
-    {name: `Test validateLibraryList (sanitized)`, test: async () => {
-      const content = instance.getContent();
-  
-      const badLibs = await content?.validateLibraryList([`##BEEPBOOP`,`$BEEP$BOOP`,`QSYSINC`]);
-
-      assert.strictEqual(badLibs?.includes(`##BEEPBOOP`), true);
-      assert.strictEqual(badLibs?.includes(`$BEEP$BOOP`), true);
-      assert.strictEqual(badLibs?.includes(`QSYSINC`), false);
-    }},
-
-    {name: `Test getFileList`, test: async () => {
-      const content = instance.getContent();
-  
-      const objects = await content?.getFileList(`/`);
-
-      const qsysLib = objects?.find(obj => obj.name === `QSYS.LIB`);
-
-      assert.strictEqual(qsysLib?.name, `QSYS.LIB`);
-      assert.strictEqual(qsysLib?.path, `/QSYS.LIB`);
-      assert.strictEqual(qsysLib?.type, `directory`);
-      assert.strictEqual(qsysLib?.owner, `qsys`);
-    }},
-
-    {name: `Test getFileList (non-existing file)`, test: async () => {
-      const content = instance.getContent();
-
-      const objects = await content?.getFileList(`/tmp/${Date.now()}`);
-
-      assert.strictEqual(objects?.length, 0);
-    }},
-
-    {name: `Test getFileList (special chars)`, test: async () => {
-      const connection = instance.getConnection();
-      const content = instance.getContent();
-      const files = [`name with blank`, `name_with_quote'`, `name_with_dollar$`];
-      const dir = `/tmp/${Date.now()}`;
-      const dirWithSubdir = `${dir}/${files[0]}`;
-
-      let result: CommandResult | undefined;
-
-      result = await connection?.sendCommand({command: `mkdir -p "${dirWithSubdir}"`});
-      assert.strictEqual(result?.code, 0);
-      try{
-        for (const file of files) {
-          result = await connection?.sendCommand({command: `touch "${dirWithSubdir}/${file}"`});
-          assert.strictEqual(result?.code, 0);
-        };
-
-        const objects = await content?.getFileList(`${dirWithSubdir}`);
-        assert.strictEqual(objects?.length, files.length);
-        assert.deepStrictEqual(objects?.map(a => a.name).sort(), files.sort());
+        assert.notStrictEqual(rows?.length, 0);
       }
-      finally{
-        result = await connection?.sendCommand({command: `rm -r "${dir}"`});
+    },
+
+    {
+      name: `Test validateLibraryList`, test: async () => {
+        const content = instance.getContent();
+
+        const badLibs = await content?.validateLibraryList([`QSYSINC`, `BEEPBOOP`]);
+
+        assert.strictEqual(badLibs?.includes(`BEEPBOOP`), true);
+        assert.strictEqual(badLibs?.includes(`QSYSINC`), false);
+      }
+    },
+
+    {
+      name: `Test getFileList`, test: async () => {
+        const content = instance.getContent();
+
+        const objects = await content?.getFileList(`/`);
+
+        const qsysLib = objects?.find(obj => obj.name === `QSYS.LIB`);
+
+        assert.strictEqual(qsysLib?.name, `QSYS.LIB`);
+        assert.strictEqual(qsysLib?.path, `/QSYS.LIB`);
+        assert.strictEqual(qsysLib?.type, `directory`);
+        assert.strictEqual(qsysLib?.owner, `qsys`);
+      }
+    },
+
+    {
+      name: `Test getFileList (non-existing file)`, test: async () => {
+        const content = instance.getContent();
+
+        const objects = await content?.getFileList(`/tmp/${Date.now()}`);
+
+        assert.strictEqual(objects?.length, 0);
+      }
+    },
+
+    {
+      name: `Test getFileList (special chars)`, test: async () => {
+        const connection = instance.getConnection();
+        const content = instance.getContent();
+        const files = [`name with blank`, `name_with_quote'`, `name_with_dollar$`];
+        const dir = `/tmp/${Date.now()}`;
+        const dirWithSubdir = `${dir}/${files[0]}`;
+
+        let result: CommandResult | undefined;
+
+        result = await connection?.sendCommand({ command: `mkdir -p "${dirWithSubdir}"` });
         assert.strictEqual(result?.code, 0);
+        try {
+          for (const file of files) {
+            result = await connection?.sendCommand({ command: `touch "${dirWithSubdir}/${file}"` });
+            assert.strictEqual(result?.code, 0);
+          };
+
+          const objects = await content?.getFileList(`${dirWithSubdir}`);
+          assert.strictEqual(objects?.length, files.length);
+          assert.deepStrictEqual(objects?.map(a => a.name).sort(), files.sort());
+        }
+        finally {
+          result = await connection?.sendCommand({ command: `rm -r "${dir}"` });
+          assert.strictEqual(result?.code, 0);
+        }
       }
-    }},
+    },
 
-    {name: `Test getObjectList (all objects)`, test: async () => {
-      const content = instance.getContent();
-  
-      const objects = await content?.getObjectList({library: `QSYSINC`});
+    {
+      name: `Test getObjectList (all objects)`, test: async () => {
+        const content = instance.getContent();
 
-      assert.notStrictEqual(objects?.length, 0);
-    }},
+        const objects = await content?.getObjectList({ library: `QSYSINC` });
 
-    {name: `Test getObjectList (pgm filter)`, test: async () => {
-      const content = instance.getContent();
-  
-      const objects = await content?.getObjectList({library: `QSYSINC`, types: [`*PGM`]});
+        assert.notStrictEqual(objects?.length, 0);
+      }
+    },
 
-      assert.notStrictEqual(objects?.length, 0);
+    {
+      name: `Test getObjectList (pgm filter)`, test: async () => {
+        const content = instance.getContent();
 
-      const containsNonPgms = objects?.some(obj => obj.type !== `*PGM`);
+        const objects = await content?.getObjectList({ library: `QSYSINC`, types: [`*PGM`] });
 
-      assert.strictEqual(containsNonPgms, false);
-    }},
+        assert.notStrictEqual(objects?.length, 0);
 
-    {name: `Test getObjectList (source files only)`, test: async () => {
-      const content = instance.getContent();
-  
-      const objects = await content?.getObjectList({library: `QSYSINC`, types: [`*SRCPF`]});
+        const containsNonPgms = objects?.some(obj => obj.type !== `*PGM`);
 
-      assert.notStrictEqual(objects?.length, 0);
+        assert.strictEqual(containsNonPgms, false);
+      }
+    },
 
-      const containsNonFiles = objects?.some(obj => obj.type !== `*FILE`);
+    {
+      name: `Test getObjectList (source files only)`, test: async () => {
+        const content = instance.getContent();
 
-      assert.strictEqual(containsNonFiles, false);
-    }},
+        const objects = await content?.getObjectList({ library: `QSYSINC`, types: [`*SRCPF`] });
 
-    {name: `Test getObjectList (source files only, named filter)`, test: async () => {
-      const content = instance.getContent();
-  
-      const objects = await content?.getObjectList({library: `QSYSINC`, types: [`*SRCPF`], object: `MIH`});
+        assert.notStrictEqual(objects?.length, 0);
 
-      assert.strictEqual(objects?.length, 1);
+        const containsNonFiles = objects?.some(obj => obj.type !== `*FILE`);
 
-      assert.strictEqual(objects[0].type, `*FILE`);
-      assert.strictEqual(objects[0].text, `DATA BASE FILE FOR C INCLUDES FOR MI`);
-    }},
+        assert.strictEqual(containsNonFiles, false);
+      }
+    },
 
-    {name: `getMemberList (SQL, no filter)`, test: async () => {
-      const content = instance.getContent();
+    {
+      name: `Test getObjectList (source files only, named filter)`, test: async () => {
+        const content = instance.getContent();
 
-      let members = await content?.getMemberList(`qsysinc`, `mih`, `*inxen`);
+        const objects = await content?.getObjectList({ library: `QSYSINC`, types: [`*SRCPF`], object: `MIH` });
 
-      assert.strictEqual(members?.length, 3);
+        assert.strictEqual(objects?.length, 1);
 
-      members = await content?.getMemberList(`qsysinc`, `mih`);
+        assert.strictEqual(objects[0].type, `*FILE`);
+        assert.strictEqual(objects[0].text, `DATA BASE FILE FOR C INCLUDES FOR MI`);
+      }
+    },
 
-      const actbpgm = members?.find(mbr => mbr.name === `ACTBPGM`);
+    {
+      name: `getMemberList (SQL, no filter)`, test: async () => {
+        const content = instance.getContent();
 
-      assert.strictEqual(actbpgm?.name, `ACTBPGM`);
-      assert.strictEqual(actbpgm?.extension, `C`);
-      assert.strictEqual(actbpgm?.text, `ACTIVATE BOUND PROGRAM`);
-      assert.strictEqual(actbpgm?.library, `QSYSINC`);
-      assert.strictEqual(actbpgm?.file, `MIH`);
-    }},
+        let members = await content?.getMemberList(`qsysinc`, `mih`, `*inxen`);
 
-    {name: `getMemberList (SQL compared to nosql)`, test: async () => {
-      const config = instance.getConfig();
-      const content = instance.getContent();
+        assert.strictEqual(members?.length, 3);
 
-      assert.strictEqual(config!.enableSQL, true, `SQL must be enabled for this test`);
-  
-      // First we fetch the members in SQL mode
-      const membersA = await content?.getMemberList(`qsysinc`, `mih`);
+        members = await content?.getMemberList(`qsysinc`, `mih`);
 
-      config!.enableSQL = false;
+        const actbpgm = members?.find(mbr => mbr.name === `ACTBPGM`);
 
-      // Then we fetch the members without SQL
-      const membersB = await content?.getMemberList(`qsysinc`, `mih`);
+        assert.strictEqual(actbpgm?.name, `ACTBPGM`);
+        assert.strictEqual(actbpgm?.extension, `C`);
+        assert.strictEqual(actbpgm?.text, `ACTIVATE BOUND PROGRAM`);
+        assert.strictEqual(actbpgm?.library, `QSYSINC`);
+        assert.strictEqual(actbpgm?.file, `MIH`);
+      }
+    },
 
-      // Reset the config
-      config!.enableSQL = true;
+    {
+      name: `getMemberList (SQL compared to nosql)`, test: async () => {
+        const config = instance.getConfig();
+        const content = instance.getContent();
 
-      assert.deepStrictEqual(membersA, membersB);
-    }},
+        assert.strictEqual(config!.enableSQL, true, `SQL must be enabled for this test`);
 
-    {name: `getMemberList (name filter, SQL compared to nosql)`, test: async () => {
-      const config = instance.getConfig();
-      const content = instance.getContent();
+        // First we fetch the members in SQL mode
+        const membersA = await content?.getMemberList(`qsysinc`, `mih`);
 
-      assert.strictEqual(config!.enableSQL, true, `SQL must be enabled for this test`);
-  
-      // First we fetch the members in SQL mode
-      const membersA = await content?.getMemberList(`qsysinc`, `mih`, `C*`);
+        config!.enableSQL = false;
 
-      config!.enableSQL = false;
+        // Then we fetch the members without SQL
+        const membersB = await content?.getMemberList(`qsysinc`, `mih`);
 
-      // Then we fetch the members without SQL
-      const membersB = await content?.getMemberList(`qsysinc`, `mih`, `C*`);
+        // Reset the config
+        config!.enableSQL = true;
 
-      // Reset the config
-      config!.enableSQL = true;
+        assert.deepStrictEqual(membersA, membersB);
+      }
+    },
 
-      assert.deepStrictEqual(membersA, membersB);
-    }},
+    {
+      name: `getMemberList (name filter, SQL compared to nosql)`, test: async () => {
+        const config = instance.getConfig();
+        const content = instance.getContent();
+
+        assert.strictEqual(config!.enableSQL, true, `SQL must be enabled for this test`);
+
+        // First we fetch the members in SQL mode
+        const membersA = await content?.getMemberList(`qsysinc`, `mih`, `C*`);
+
+        config!.enableSQL = false;
+
+        // Then we fetch the members without SQL
+        const membersB = await content?.getMemberList(`qsysinc`, `mih`, `C*`);
+
+        // Reset the config
+        config!.enableSQL = true;
+
+        assert.deepStrictEqual(membersA, membersB);
+      }
+    },
   ]
 };

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -32,12 +32,17 @@ export interface StandardIO {
 /**
  * External interface for extensions to call `code-for-ibmi.runCommand`
  */
+export type ActionType = "member" | "streamfile" | "object" | "file";
+export type ActionRefresh = "no" | "parent" | "filter" | "browser";
+export type ActionEnvironment = "ile" | "qsh" | "pase";
+
 export interface RemoteCommand {
   title?: string;
   command: string;
-  environment?: "ile" | "qsh" | "pase";
+  environment?: ActionEnvironment;
   cwd?: string;
   env?: Record<string, string>;
+  noLibList? : boolean
 }
 
 export interface CommandData extends StandardIO {
@@ -52,10 +57,6 @@ export interface CommandResult {
   stderr: string;
   command?: string;
 }
-
-export type ActionType = "member" | "streamfile" | "object" | "file";
-export type ActionRefresh = "no" | "parent" | "filter" | "browser";
-export type ActionEnvironment = "ile" | "qsh" | "pase";
 
 export interface Action {
   name: string;


### PR DESCRIPTION
### Changes
This PR includes the following changes:
- It removes the deprecated methods `remoteCommand` and `paseCommand` from `IBMi`.
- It replaces the calls to these two methods with `sendCommand` or `runCommand` depending on the context.
- It adds a `noLibList` option to `runCommand`. If it is set to `true`, `runCommand` will not build the library list before running the command. This will fix issues we had with people seeing their members as read-only because of a faulty library list. Other command calls that should ignore the library list have been updated as well.