### PR TITLE
Fix/evfevent_reader

### DIFF
--- a/schemas/actions.json
+++ b/schemas/actions.json
@@ -65,7 +65,7 @@
             "$id": "#/actions/items/anyOf/0/properties/postDownload",
             "type": "array",
             "title": "Post Download",
-            "description": "Remote files/folders to download when the Action is complete.",
+            "description": "Remote files/folders to download when the Action is complete. Using `.evfevent` in combination with a build tool will populate the Problems view.",
             "default": [""],
             "items": {
               "type": "string",

--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -335,7 +335,9 @@ export namespace CompileTools {
                         env: Object.fromEntries(variables),
                       }, writeEmitter);
 
-                      const useLocalEvfevent = fromWorkspace && chosenAction.postDownload && chosenAction.postDownload.includes(`.evfevent`);
+                      const useLocalEvfevent = 
+                        fromWorkspace && chosenAction.postDownload && 
+                        (chosenAction.postDownload.includes(`.evfevent`) || chosenAction.postDownload.includes(`.evfevent/`));
 
                       if (commandResult) {
                         hasRun = true;

--- a/src/api/local/actions.ts
+++ b/src/api/local/actions.ts
@@ -44,7 +44,7 @@ export async function getLocalActions(currentWorkspace: WorkspaceFolder) {
 export async function getEvfeventFiles(currentWorkspace: WorkspaceFolder) {
   if (currentWorkspace) {
     const relativeSearch = new RelativePattern(currentWorkspace, `**/.evfevent/*`);
-    const iprojectFiles = await workspace.findFiles(relativeSearch, null, 1);
+    const iprojectFiles = await workspace.findFiles(relativeSearch, null);
 
     return iprojectFiles;
   }


### PR DESCRIPTION
### Changes

* Solves a bug where `.evfevent/` was not supported but `.evfevent` was
* Removes the hard limit of reading only one `.evfevent` file at a time during a local action

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
