### PR TITLE
Correct all places where it was expected runCommand to crash

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -552,7 +552,7 @@ export namespace CompileTools {
   /**
    * Execute a command
    */
-  export async function runCommand(instance: Instance, options: RemoteCommand, writeEvent?: EventEmitter<string>): Promise<CommandResult | null> {
+  export async function runCommand(instance: Instance, options: RemoteCommand, writeEvent?: EventEmitter<string>): Promise<CommandResult> {
     const connection = instance.getConnection();
     const config = instance.getConfig();
     if (config && connection) {
@@ -677,7 +677,12 @@ export namespace CompileTools {
       throw new Error("Please connect to an IBM i");
     }
 
-    return null;
+    return {
+      code: 1,
+      command: options.command,
+      stdout: ``,
+      stderr: `Command execution failed. (Internal)`,
+    };
   }
 
   /**

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -121,21 +121,20 @@ export default class IBMiContent {
     let path = Tools.qualifyPath(library, sourceFile, member, asp);
     const tempRmt = this.getTempRemote(path);
     while (true) {
-      try {
-        await this.ibmi.runCommand({
-          command: `CPYTOSTMF FROMMBR('${path}') TOSTMF('${tempRmt}') STMFOPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
-          noLibList: true
-        });
+      const copyResult = await this.ibmi.runCommand({
+        command: `CPYTOSTMF FROMMBR('${path}') TOSTMF('${tempRmt}') STMFOPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
+        noLibList: true
+      });
 
+      if (copyResult.code === 0) {
         if (!localPath) {
           localPath = await tmpFile();
         }
         await this.ibmi.downloadFile(localPath, tempRmt);
         return await readFileAsync(localPath, `utf8`);
-      }
-      catch (e) {
+      } else {
         if (!retry) {
-          const messageID = String(e).substring(0, 7);
+          const messageID = String(copyResult.stdout).substring(0, 7);
           switch (messageID) {
             case "CPDA08A":
               //We need to try again after we delete the temp remote
@@ -156,7 +155,7 @@ export default class IBMiContent {
         }
 
         if (!retry) {
-          throw e
+          throw new Error(`Failed downloading member: ${copyResult.stderr}`);
         }
       }
     }
@@ -182,16 +181,16 @@ export default class IBMiContent {
       await client.putFile(tmpobj, tempRmt);
 
       while (true) {
-        try {
-          await this.ibmi.runCommand({
-            command: `QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${path}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
-            noLibList: true
-          });
+        const copyResult = await this.ibmi.runCommand({
+          command: `QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${path}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
+          noLibList: true
+        });
+
+        if (copyResult.code === 0) {
           return true;
-        }
-        catch (e) {
+        } else {
           if (!retry) {
-            const messageID = String(e).substring(0, 7);
+            const messageID = String(copyResult.stderr).substring(0, 7);
             switch (messageID) {
               case "CPFA0A9":
                 //The member may be located on SYSBAS
@@ -201,7 +200,7 @@ export default class IBMiContent {
                 }
                 break;
               default:
-                throw e;
+                throw new Error(`Failed uploading member: ${copyResult.stderr}`);
             }
           }
         }
@@ -300,33 +299,38 @@ export default class IBMiContent {
 
     } else {
       const tempRmt = this.getTempRemote(Tools.qualifyPath(library, file, member));
-      await this.ibmi.runCommand({
+      const copyResult = await this.ibmi.runCommand({
         command: `QSYS/CPYTOIMPF FROMFILE(${library}/${file} ${member}) ` +
           `TOSTMF('${tempRmt}') ` +
           `MBROPT(*REPLACE) STMFCCSID(1208) RCDDLM(*CRLF) DTAFMT(*DLM) RMVBLANK(*TRAILING) ADDCOLNAM(*SQL) FLDDLM(',') DECPNT(*PERIOD)`,
         noLibList: true
       });
 
-      let result = await this.downloadStreamfile(tempRmt);
+      if (copyResult.code === 0) {
+        let result = await this.downloadStreamfile(tempRmt);
 
-      if (this.config.autoClearTempData) {
-        await this.ibmi.sendCommand({ command: `rm -f ${tempRmt}`, directory: `.` });
-        if (deleteTable) {
-          await this.ibmi.runCommand({ command: `DLTOBJ OBJ(${library}/${file}) OBJTYPE(*FILE)`, noLibList: true });
+        if (this.config.autoClearTempData) {
+          Promise.allSettled([
+            this.ibmi.sendCommand({ command: `rm -f ${tempRmt}`, directory: `.` }),
+            deleteTable ? this.ibmi.runCommand({ command: `DLTOBJ OBJ(${library}/${file}) OBJTYPE(*FILE)`, noLibList: true }) : Promise.resolve()
+          ]);
         }
-      }
 
-      return parse(result, {
-        columns: true,
-        skip_empty_lines: true,
-        cast: true,
-        onRecord(record) {
-          for (const key of Object.keys(record)) {
-            record[key] = record[key] === ` ` ? `` : record[key];
+        return parse(result, {
+          columns: true,
+          skip_empty_lines: true,
+          cast: true,
+          onRecord(record) {
+            for (const key of Object.keys(record)) {
+              record[key] = record[key] === ` ` ? `` : record[key];
+            }
+            return record;
           }
-          return record;
-        }
-      });
+        });
+
+      } else {
+        throw new Error(`Failed fetching table: ${copyResult.stderr}`);
+      }
     }
 
   }

--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -187,10 +187,14 @@ export class ExtendedIBMiContent {
           await connection.sendCommand({ command: `${setccsid} 1208 ${tempRmt}` });
         }
 
-        await connection.runCommand({
+        const insertResult = await connection.runCommand({
           command: `QSYS/RUNSQLSTM SRCSTMF('${tempRmt}') COMMIT(*NONE) NAMING(*SQL)`,
           noLibList: true
         });
+
+        if (insertResult.code !== 0) {
+          throw new Error(`Failed to save member: ` + insertResult.stderr);
+        }
 
         if (this.sourceDateHandler.sourceDateMode === `diff`) {
           this.sourceDateHandler.baseSource.set(alias, body);

--- a/src/languages/clle/clApi.ts
+++ b/src/languages/clle/clApi.ts
@@ -37,15 +37,16 @@ async function install() {
 
   const tempLib = config.tempLibrary;
 
-  try {
-    await connection.runCommand({ command: `CRTSRCPF ${tempLib}/QTOOLS`, noLibList: true })
-  } catch (e) {
-    //It may exist already so we just ignore the error
-  }
+  //It may exist already so we just ignore the error
+  await connection.runCommand({ command: `CRTSRCPF ${tempLib}/QTOOLS`, noLibList: true })
 
   await content.uploadMemberContent(undefined, tempLib, `QTOOLS`, `GENCMDXML`, gencmdxml.content.join(`\n`));
-  await connection.runCommand({
+  const createResult = await connection.runCommand({
     command: `CRTBNDCL PGM(${tempLib}/GENCMDXML) SRCFILE(${tempLib}/QTOOLS) DBGVIEW(*SOURCE) TEXT('vscode-ibmi xml generator for commands')`,
     noLibList: true
   });
+
+  if (createResult.code !== 0) {
+    throw new Error(`Failed to create GENCMDXML program.`);
+  }
 }

--- a/src/languages/clle/getnewlibl.ts
+++ b/src/languages/clle/getnewlibl.ts
@@ -19,11 +19,12 @@ export async function initGetNewLibl(instance: Instance) {
         cwd: `/`,
         noLibList: true
       })
-      .then(() => {
-        connection.remoteFeatures[`GETNEWLIBL.PGM`] = `${config.tempLibrary}.GETNEWLIBL`;
-      })
-      .catch(() => {
-        window.showWarningMessage(`Unable to install GETNEWLIBL. See Code for IBM i output for details.`);
+      .then((result) => {
+        if (result.code === 0) {
+          connection.remoteFeatures[`GETNEWLIBL.PGM`] = `${config.tempLibrary}.GETNEWLIBL`;
+        } else {
+          window.showWarningMessage(`Unable to install GETNEWLIBL. See Code for IBM i output for details.`);
+        }
       })
     })
   }

--- a/src/testing/action.ts
+++ b/src/testing/action.ts
@@ -79,25 +79,23 @@ export const ActionSuite: TestSuite = {
         const connection = instance.getConnection();
         const tempLib = config!.tempLibrary;
 
-        try {
-          await connection!.runCommand({ command: `DLTOBJ OBJ(${tempLib}/QRPGLESRC) OBJTYPE(*FILE)` });
-        } finally {
-          await connection!.runCommand({ command: `CRTSRCPF FILE(${tempLib}/QRPGLESRC) RCDLEN(112)` });
-          await connection!.runCommand({ command: `ADDPFM FILE(${tempLib}/QRPGLESRC) MBR(HELLO) SRCTYPE(RPGLE)` });
-          await content!.uploadMemberContent(undefined, tempLib, 'QRPGLESRC', 'HELLO', helloWorldProject.files![0].content.join('\n'));
-          const action: Action = {
-            "name": "Create Bound RPG Program (CRTBNDRPG)",
-            "command": "CRTBNDRPG PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT)",
-            "type": "member",
-            "environment": "ile",
-            "extensions": [
-              "RPGLE",
-              "RPG"
-            ],
-          };
-          const uri = getMemberUri({ library: tempLib, file: 'QRPGLESRC', name: 'HELLO', extension: 'RPGLE' })
-          await testHelloWorldProgram(uri, action, tempLib);
-        }
+        await connection!.runCommand({ command: `DLTOBJ OBJ(${tempLib}/QRPGLESRC) OBJTYPE(*FILE)` });
+
+        await connection!.runCommand({ command: `CRTSRCPF FILE(${tempLib}/QRPGLESRC) RCDLEN(112)` });
+        await connection!.runCommand({ command: `ADDPFM FILE(${tempLib}/QRPGLESRC) MBR(HELLO) SRCTYPE(RPGLE)` });
+        await content!.uploadMemberContent(undefined, tempLib, 'QRPGLESRC', 'HELLO', helloWorldProject.files![0].content.join('\n'));
+        const action: Action = {
+          "name": "Create Bound RPG Program (CRTBNDRPG)",
+          "command": "CRTBNDRPG PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT)",
+          "type": "member",
+          "environment": "ile",
+          "extensions": [
+            "RPGLE",
+            "RPG"
+          ],
+        };
+        const uri = getMemberUri({ library: tempLib, file: 'QRPGLESRC', name: 'HELLO', extension: 'RPGLE' })
+        await testHelloWorldProgram(uri, action, tempLib);
       }
     }
   ]

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -493,16 +493,12 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         const memberPath = connection.parserMemberPath(fullPath);
         const error = await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: t(`objectBrowser.copyMember.progressTitle`, fullPath.toUpperCase()) }, async (progress) => {
           try {
-            let newMemberExists = true;
-
             const checkResult = await connection.runCommand({
               command: `CHKOBJ OBJ(${memberPath.library}/${memberPath.file}) OBJTYPE(*FILE) MBR(${memberPath.name})`,
               noLibList: true
             })
 
-            if (!checkResult.stdout.includes(`CPF9815`)) {
-              newMemberExists = false;
-            }
+            const newMemberExists = checkResult.code === 0;
 
             if (newMemberExists) {
               const result = await vscode.window.showInformationMessage(t(`objectBrowser.copyMember.overwrite`, memberPath.name), { modal: true }, t(`Yes`), t(`No`))

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -10,7 +10,7 @@ import { GlobalStorage } from '../api/Storage';
 import { getMemberUri } from "../filesystems/qsys/QSysFs";
 import { instance, setSearchResults } from "../instantiate";
 import { t } from "../locale";
-import { BrowserItem, BrowserItemParameters, FilteredItem, FocusOptions, IBMiFile, IBMiMember, IBMiObject, MemberItem, ObjectItem, SourcePhysicalFileItem } from "../typings";
+import { BrowserItem, BrowserItemParameters, CommandResult, FilteredItem, FocusOptions, IBMiFile, IBMiMember, IBMiObject, MemberItem, ObjectItem, SourcePhysicalFileItem } from "../typings";
 import { editFilter } from "../webviews/filters";
 
 const writeFileAsync = util.promisify(fs.writeFile);
@@ -446,20 +446,20 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         const fullPath = toPath(fullName);
         const member = connection.parserMemberPath(fullPath);
         const error = await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: t(`objectBrowser.createMember.progressTitle`, fullPath) }, async (progress) => {
-          try {
-            await connection.runCommand({
-              command: `ADDPFM FILE(${member.library}/${member.file}) MBR(${member.name}) SRCTYPE(${member.extension.length > 0 ? member.extension : `*NONE`})`,
-              noLibList: true
-            })
+          const addResult = await connection.runCommand({
+            command: `ADDPFM FILE(${member.library}/${member.file}) MBR(${member.name}) SRCTYPE(${member.extension.length > 0 ? member.extension : `*NONE`})`,
+            noLibList: true
+          })
 
+          if (addResult.code === 0) {
             if (GlobalConfiguration.get(`autoOpenFile`)) {
               vscode.commands.executeCommand(`vscode.open`, getMemberUri(member));
             }
 
             objectBrowser.refresh(node);
-          }
-          catch (e) {
-            return e;
+
+          } else {
+            return addResult.stderr
           }
         });
 
@@ -494,15 +494,14 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         const error = await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: t(`objectBrowser.copyMember.progressTitle`, fullPath.toUpperCase()) }, async (progress) => {
           try {
             let newMemberExists = true;
-            try {
-              await connection.runCommand({
-                command: `CHKOBJ OBJ(${memberPath.library}/${memberPath.file}) OBJTYPE(*FILE) MBR(${memberPath.name})`,
-                noLibList: true
-              })
-            } catch (e) {
-              if (String(e).includes(`CPF9815`)) {
-                newMemberExists = false;
-              }
+
+            const checkResult = await connection.runCommand({
+              command: `CHKOBJ OBJ(${memberPath.library}/${memberPath.file}) OBJTYPE(*FILE) MBR(${memberPath.name})`,
+              noLibList: true
+            })
+
+            if (!checkResult.stdout.includes(`CPF9815`)) {
+              newMemberExists = false;
             }
 
             if (newMemberExists) {
@@ -517,16 +516,13 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
               }
             }
 
-            try {
-              await connection.runCommand({
-                command: `CPYSRCF FROMFILE(${oldMember.library}/${oldMember.file}) TOFILE(${memberPath.library}/${memberPath.file}) FROMMBR(${oldMember.name}) TOMBR(${memberPath.name}) MBROPT(*REPLACE)`,
-                noLibList: true
-              })
-            } catch (e) {
-              // Ignore CPF2869 Empty member is not copied.
-              if (!String(e).includes(`CPF2869`)) {
-                throw (e)
-              }
+            const copyResult = await connection.runCommand({
+              command: `CPYSRCF FROMFILE(${oldMember.library}/${oldMember.file}) TOFILE(${memberPath.library}/${memberPath.file}) FROMMBR(${oldMember.name}) TOMBR(${memberPath.name}) MBROPT(*REPLACE)`,
+              noLibList: true
+            })
+
+            if (copyResult.stderr.includes(`CPF2869`)) {
+              throw (copyResult.stderr)
             }
 
             if (oldMember.extension !== memberPath.extension) {
@@ -570,17 +566,18 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         const connection = getConnection();
         const { library, file, name } = connection.parserMemberPath(node.path);
 
-        try {
-          await connection.runCommand({
-            command: `RMVM FILE(${library}/${file}) MBR(${name})`,
-            noLibList: true
-          });
+        const removeResult = await connection.runCommand({
+          command: `RMVM FILE(${library}/${file}) MBR(${name})`,
+          noLibList: true
+        });
 
+        if (removeResult.code === 0) {
           vscode.window.showInformationMessage(t(`objectBrowser.deleteMember.infoMessage`, node.path));
 
           objectBrowser.refresh(node.parent);
-        } catch (e) {
-          vscode.window.showErrorMessage(t(`objectBrowser.deleteMember.errorMessage`, e));
+
+        } else {
+          vscode.window.showErrorMessage(t(`objectBrowser.deleteMember.errorMessage`, removeResult.stderr));
         }
 
         //Not sure how to remove the item from the list. Must refresh - but that might be slow?
@@ -599,17 +596,18 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         const escapedText = newText.replace(/'/g, `''`);
         const connection = getConnection();
 
-        try {
-          await connection.runCommand({
-            command: `CHGPFM FILE(${library}/${file}) MBR(${name}) TEXT('${escapedText}')`,
-            noLibList: true
-          });
+        const changeResult = await connection.runCommand({
+          command: `CHGPFM FILE(${library}/${file}) MBR(${name}) TEXT('${escapedText}')`,
+          noLibList: true
+        });
 
+        if (changeResult.code === 0) {
           node.description = newText;
           objectBrowser.refresh(node);
-        } catch (e) {
-          vscode.window.showErrorMessage(t(`objectBrowser.updateMemberText.errorMessage`, e));
+        } else {
+          vscode.window.showErrorMessage(t(`objectBrowser.updateMemberText.errorMessage`, changeResult.stderr));
         }
+
       }
     }),
     vscode.commands.registerCommand(`code-for-ibmi.renameMember`, async (node: ObjectBrowserMemberItem) => {
@@ -638,25 +636,32 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
           }
 
           if (newMember) {
-            try {
-              if (oldMember.name !== newMember.name) {
-                await connection.runCommand({
-                  command: `RNMM FILE(${library}/${sourceFile}) MBR(${oldMember.name}) NEWMBR(${newMember.name})`,
-                  noLibList: true
-                });
-              }
-              if (oldMember.extension !== newMember.extension) {
-                await connection.runCommand({
-                  command: `CHGPFM FILE(${library}/${sourceFile}) MBR(${newMember.name}) SRCTYPE(${newMember.extension.length > 0 ? newMember.extension : `*NONE`})`,
-                  noLibList: true
-                });
-              }
+            let commandResult: CommandResult;
 
-              objectBrowser.refresh(node.parent);
-            } catch (e) {
-              newNameOK = false;
-              vscode.window.showErrorMessage(t(`objectBrowser.renameMember.errorMessage`, e));
+            if (oldMember.name !== newMember.name) {
+              commandResult = await connection.runCommand({
+                command: `RNMM FILE(${library}/${sourceFile}) MBR(${oldMember.name}) NEWMBR(${newMember.name})`,
+                noLibList: true
+              });
+              
+              if (commandResult.code !== 0) {
+                newNameOK = false;
+                vscode.window.showErrorMessage(t(`objectBrowser.renameMember.errorMessage`, commandResult.stderr));
+              }
             }
+            if (oldMember.extension !== newMember.extension) {
+              commandResult = await connection.runCommand({
+                command: `CHGPFM FILE(${library}/${sourceFile}) MBR(${newMember.name}) SRCTYPE(${newMember.extension.length > 0 ? newMember.extension : `*NONE`})`,
+                noLibList: true
+              });
+
+              if (commandResult.code !== 0) {
+                newNameOK = false;
+                vscode.window.showErrorMessage(t(`objectBrowser.renameMember.errorMessage`, commandResult.stderr));
+              }
+            }
+
+            objectBrowser.refresh(node.parent);
           }
         }
       } while (newBasename && !newNameOK)
@@ -824,14 +829,13 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
 
         const filters = config.objectFilters;
 
-        try {
-          await connection.runCommand({
-            command: `CRTLIB LIB(${newLibrary})`,
-            noLibList: true
-          });
-        } catch (e) {
-          vscode.window.showErrorMessage(t(`objectBrowser.createLibrary.errorMessage`, newLibrary, e));
-          return;
+        const createResult = await connection.runCommand({
+          command: `CRTLIB LIB(${newLibrary})`,
+          noLibList: true
+        });
+
+        if (createResult.code !== 0) {
+          vscode.window.showErrorMessage(t(`objectBrowser.createLibrary.errorMessage`, newLibrary, createResult.stderr));
         }
 
         filters.push({
@@ -872,20 +876,19 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
 
       if (fileName) {
         const connection = getConnection();
-        try {
-          const library = filter.library;
-          const uriPath = `${library}/${fileName.toUpperCase()}`
+        const library = filter.library;
+        const uriPath = `${library}/${fileName.toUpperCase()}`
 
-          vscode.window.showInformationMessage(t(`objectBrowser.createSourceFile.infoMessage`, uriPath));
+        vscode.window.showInformationMessage(t(`objectBrowser.createSourceFile.infoMessage`, uriPath));
+        const createResult = await connection.runCommand({
+          command: `CRTSRCPF FILE(${uriPath}) RCDLEN(112)`,
+          noLibList: true
+        });
 
-          await connection.runCommand({
-            command: `CRTSRCPF FILE(${uriPath}) RCDLEN(112)`,
-            noLibList: true
-          });
-
+        if (createResult.code === 0) {
           objectBrowser.refresh(node);
-        } catch (e) {
-          vscode.window.showErrorMessage(t(`objectBrowser.createSourceFile.errorMessage`, e));
+        } else {
+          vscode.window.showErrorMessage(t(`objectBrowser.createSourceFile.errorMessage`, createResult.stderr));
         }
       }
     }),
@@ -906,19 +909,19 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
           const escapedText = newText.replace(/'/g, `''`).replace(/`/g, `\\\``);
           const connection = getConnection();
 
-          try {
-            newTextOK = true;
-            await connection.runCommand({
-              command: `CHGOBJD OBJ(${node.path}) OBJTYPE(${node.object.type}) TEXT(${newText.toUpperCase() !== `*BLANK` ? `'${escapedText}'` : `*BLANK`})`,
-              noLibList: true
-            });
+          newTextOK = true;
+          const changeResult = await connection.runCommand({
+            command: `CHGOBJD OBJ(${node.path}) OBJTYPE(${node.object.type}) TEXT(${newText.toUpperCase() !== `*BLANK` ? `'${escapedText}'` : `*BLANK`})`,
+            noLibList: true
+          });
 
+          if (changeResult.code === 0) {
             node.object.text = newText;
             node.updateDescription();
             objectBrowser.refresh(node);
             vscode.window.showInformationMessage(t(`objectBrowser.changeObjectDesc.infoMessage`, node.path, node.object.type.toUpperCase()));
-          } catch (e) {
-            vscode.window.showErrorMessage(t(`objectBrowser.changeObjectDesc.errorMessage2`, node.path, e));
+          } else {
+            vscode.window.showErrorMessage(t(`objectBrowser.changeObjectDesc.errorMessage2`, node.path, changeResult.stderr));
             newTextOK = false;
           }
         }
@@ -946,14 +949,15 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
           const [newLibrary, newObject] = escapedPath.split(`/`);
           const connection = getConnection();
 
-          try {
-            newPathOK = true;
-            await connection.runCommand({
-              command: node.object.type.toLocaleLowerCase() === `*lib` ?
-                `CPYLIB FROMLIB(${oldObject}) TOLIB(${newObject})` :
-                `CRTDUPOBJ OBJ(${oldObject}) FROMLIB(${oldLibrary}) OBJTYPE(${node.object.type}) TOLIB(${newLibrary}) NEWOBJ(${newObject})`,
-              noLibList: true
-            });
+          newPathOK = true;
+          const commandRes = await connection.runCommand({
+            command: node.object.type.toLocaleLowerCase() === `*lib` ?
+              `CPYLIB FROMLIB(${oldObject}) TOLIB(${newObject})` :
+              `CRTDUPOBJ OBJ(${oldObject}) FROMLIB(${oldLibrary}) OBJTYPE(${node.object.type}) TOLIB(${newLibrary}) NEWOBJ(${newObject})`,
+            noLibList: true
+          });
+
+          if (commandRes.code === 0) {
 
             if (oldLibrary.toLocaleLowerCase() === newLibrary.toLocaleLowerCase()) {
               objectBrowser.refresh(node.parent);
@@ -961,8 +965,8 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
             else if (!objectBrowser.autoRefresh(t(`objectBrowser.copyObject.infoMessage`, node.path, node.object.type.toUpperCase(), escapedPath))) {
               vscode.window.showInformationMessage(t(`objectBrowser.copyObject.infoMessage2`, node.path, node.object.type.toUpperCase(), escapedPath));
             }
-          } catch (e) {
-            vscode.window.showErrorMessage(t(`objectBrowser.copyObject.errorMessage4`, node.path, e));
+          } else {
+            vscode.window.showErrorMessage(t(`objectBrowser.copyObject.errorMessage4`, node.path, commandRes.stderr));
             newPathOK = false;
           }
         }
@@ -976,17 +980,17 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         const connection = getConnection();
         await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: t("objectBrowser.deleteObject.progress", node.path, node.object.type.toUpperCase()) }
           , async (progress) => {
-            try {
-              // TODO: Progress message about deleting!
-              await connection.runCommand({
-                command: `DLTOBJ OBJ(${node.path}) OBJTYPE(${node.object.type})`,
-                noLibList: true
-              });
+            // TODO: Progress message about deleting!
+            const deleteResult = await connection.runCommand({
+              command: `DLTOBJ OBJ(${node.path}) OBJTYPE(${node.object.type})`,
+              noLibList: true
+            });
 
+            if (deleteResult.code === 0) {
               vscode.window.showInformationMessage(t(`objectBrowser.deleteObject.infoMessage`, node.path, node.object.type.toUpperCase()));
               objectBrowser.refresh(node.parent);
-            } catch (e) {
-              vscode.window.showErrorMessage(t(`objectBrowser.deleteObject.errorMessage`, e));
+            } else {
+              vscode.window.showErrorMessage(t(`objectBrowser.deleteObject.errorMessage`, deleteResult.stderr));
             }
           }
         );
@@ -1010,19 +1014,19 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
           const connection = getConnection();
           newObjectOK = await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: t("objectBrowser.renameObject.progress", node.path, node.object.type.toUpperCase(), escapedObject) }
             , async (progress) => {
-              try {
-                await connection.runCommand({
-                  command: `RNMOBJ OBJ(${node.path}) OBJTYPE(${node.object.type}) NEWOBJ(${escapedObject})`,
-                  noLibList: true
-                });
+              const renameResult = await connection.runCommand({
+                command: `RNMOBJ OBJ(${node.path}) OBJTYPE(${node.object.type}) NEWOBJ(${escapedObject})`,
+                noLibList: true
+              });
 
-                vscode.window.showInformationMessage(t(`objectBrowser.renameObject.infoMessage`, node.path, node.object.type.toUpperCase(), escapedObject));
-                objectBrowser.refresh(node.parent);
-                return true;
-              } catch (e) {
-                vscode.window.showErrorMessage(t(`objectBrowser.renameObject.errorMessage2`, node.path, e));
+              if (renameResult.code !== 0) {
+                vscode.window.showErrorMessage(t(`objectBrowser.renameObject.errorMessage2`, node.path, renameResult.stderr));
                 return false;
               }
+
+              vscode.window.showInformationMessage(t(`objectBrowser.renameObject.infoMessage`, node.path, node.object.type.toUpperCase(), escapedObject));
+              objectBrowser.refresh(node.parent);
+              return true;
             }
           );
         }
@@ -1048,20 +1052,20 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
 
           newLibraryOK = await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: t("objectBrowser.moveObject.progress", node.path, node.object.type.toUpperCase(), escapedLibrary) }
             , async (progress) => {
-              try {
-                await connection.runCommand({
-                  command: `MOVOBJ OBJ(${node.path}) OBJTYPE(${node.object.type}) TOLIB(${newLibrary})`,
-                  noLibList: true
-                });
-
-                if (!objectBrowser.autoRefresh(t(`objectBrowser.moveObject.infoMessage`, node.path, node.object.type.toUpperCase(), escapedLibrary))) {
-                  vscode.window.showInformationMessage(t(`objectBrowser.moveObject.infoMessage2`, node.path, node.object.type.toUpperCase(), escapedLibrary));
-                }
-                return true;
-              } catch (e) {
-                vscode.window.showErrorMessage(t(`objectBrowser.moveObject.errorMessage2`, node.path, e));
+              const moveResult = await connection.runCommand({
+                command: `MOVOBJ OBJ(${node.path}) OBJTYPE(${node.object.type}) TOLIB(${newLibrary})`,
+                noLibList: true
+              });
+              
+              if (moveResult.code !== 0) {
+                vscode.window.showErrorMessage(t(`objectBrowser.moveObject.errorMessage2`, node.path, moveResult.stderr));
                 return false;
               }
+
+              if (!objectBrowser.autoRefresh(t(`objectBrowser.moveObject.infoMessage`, node.path, node.object.type.toUpperCase(), escapedLibrary))) {
+                vscode.window.showInformationMessage(t(`objectBrowser.moveObject.infoMessage2`, node.path, node.object.type.toUpperCase(), escapedLibrary));
+              }
+              return true;
             });
         }
       } while (newLibrary && !newLibraryOK)


### PR DESCRIPTION
### Changes

Noticed when testing the new connection settings PR that when reloading or creating a new connection, I was always seeing this message about the old data area that we don't like, even though it didn't exist.

Previously, we relied on an API that was throwing an exception if the returned status code was not 0. We removed that API in place of an API that never crashes, but we didn't change the code around it. This is a pretty important fix and likely needs to be deployed ASAP.

Highest impact areas:

* Creating the connection
* Object Browser UI/UX

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
