### PR TITLE
Fix error opening a specific member reference in Go To File

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -433,6 +433,14 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 }
                 selection = `${lib}/${file}/${fullMember}`;
               };
+              if (selection.startsWith(`/`)) {
+                const streamFile = await content!.streamfileResolve([selection.substring(1)], [`/`]);
+                if (!streamFile) {
+                  vscode.window.showWarningMessage(`${selection} does not exist or is not a file.`);
+                  return;
+                }
+                selection = selection.toUpperCase() === quickPick.value.toUpperCase() ? quickPick.value : selection;
+              }
               vscode.commands.executeCommand(`code-for-ibmi.openEditable`, selection, 0, { readonly });
               quickPick.hide()
             } else {

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -249,7 +249,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
         if (config && config.enableSQL && (!quickPick.value.startsWith(`/`)) && quickPick.value.endsWith(`*`)) {
           const selectionSplit = quickPick.value.toUpperCase().split('/');
           const lastPart = selectionSplit[selectionSplit.length - 1];
-          const filterText = lastPart.substring(0, lastPart.indexOf(`*`));
+          let filterText = lastPart.substring(0, lastPart.indexOf(`*`));
 
           let resultSet: Tools.DB2Row[] = [];
 
@@ -328,6 +328,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                   description: 'Searching members..',
                 },
               ]
+
+              filterText = filterText.endsWith(`.`) ? filterText.substring(0, filterText.length - 1) : filterText;
 
               resultSet = await content!.runSQL(`
                   SELECT cast(TABLE_PARTITION as char(10) for bit data) TABLE_PARTITION, 

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -401,8 +401,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
         if (selection && selection !== LOADING_LABEL) {
           if (selection === clearList) {
             storage!.setSourceList({});
+            quickPick.items = clearListArray;
             vscode.window.showInformationMessage(`Cleared list.`);
-            quickPick.hide()
           } else {
             const selectionSplit = selection.split('/')
             if (selectionSplit.length === 3 || selection.startsWith(`/`)) {

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -240,6 +240,10 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
             ...clearListArray
           ];
           filteredItems = [];
+        } else {
+          if (!starRemoved && !list.includes(quickPick.value.toUpperCase())) {
+            quickPick.items = [quickPick.value.toUpperCase(), ...list].map(label => ({ label }));
+          }
         }
 
         // autosuggest
@@ -386,8 +390,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
               ...clearListArray
             ]
           }
-          starRemoved = false;
         }
+        starRemoved = false;
       })
 
       quickPick.onDidAccept(() => {

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -334,7 +334,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
               resultSet = await content!.runSQL(`
                   SELECT cast(TABLE_PARTITION as char(10) for bit data) TABLE_PARTITION, 
                     ifnull(PARTITION_TEXT, '') PARTITION_TEXT, 
-                    lower(ifnull(SOURCE_TYPE, '')) SOURCE_TYPE
+                    ifnull(SOURCE_TYPE, '') SOURCE_TYPE
                   FROM qsys2.SYSPARTITIONSTAT
                   WHERE TABLE_SCHEMA = '${connection!.sysNameInAmerican(selectionSplit[0])}'
                     AND table_name = '${connection!.sysNameInAmerican(selectionSplit[1])}'

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -404,7 +404,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
             quickPick.items = clearListArray;
             vscode.window.showInformationMessage(`Cleared list.`);
           } else {
-            const selectionSplit = selection.split('/')
+            const selectionSplit = selection.toUpperCase().split('/')
             if (selectionSplit.length === 3 || selection.startsWith(`/`)) {
               if (config && config.enableSQL && !selection.startsWith(`/`)) {
                 const lib = `${connection!.sysNameInAmerican(selectionSplit[0])}`;


### PR DESCRIPTION
### Changes

This PR will fix issue #1732 by (re)adding the entered value to the list, thus allowing it to be selected (accepted).
This was a regression from the new member search in function Go To file.

Additional fixes are included:
- Validation of entered member reference - previously the user could enter any extension for the member, and the member would still open. Now there is a warning if the member does not exist or the member type is wrong.
- Search now works even if member and dot has been specified when entering '*'.
- Member type is shown in uppercase like the other parts in a list item.
- SQL statements and use of metadata columns are now consistent.
- The Go To file dialog are kept open when the list is cleared.
- Validation of entered streamfile before open - keeping the list available in case of error.

### Checklist

* [x] have tested my change
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining