### PR TITLE
Fix CRTLIB error checking when connecting + other error checkings

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -660,7 +660,7 @@ export namespace CompileTools {
               command: [
                 ...options.noLibList? [] : buildLiblistCommands(connection, ileSetup),
                 ...commands.map(command =>
-                  `${`system ${GlobalConfiguration.get(`logCompileOutput`) ? `` : `-s`} "${command.replace(/[$]/g, `\\$&`)}"; if [[ $? -ne 0 ]]; then exit 1; fi`}`,
+                  `${`system ${GlobalConfiguration.get(`logCompileOutput`) ? `` : `-s`} "${command.replace(/[$]/g, `\\$&`)}"; exit $?`}`,
                 )
               ].join(` && `),
               directory: cwd,

--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -660,7 +660,7 @@ export namespace CompileTools {
               command: [
                 ...options.noLibList? [] : buildLiblistCommands(connection, ileSetup),
                 ...commands.map(command =>
-                  `${`system ${GlobalConfiguration.get(`logCompileOutput`) ? `` : `-s`} "${command.replace(/[$]/g, `\\$&`)}"; exit $?`}`,
+                  `${`system ${GlobalConfiguration.get(`logCompileOutput`) ? `` : `-s`} "${command.replace(/[$]/g, `\\$&`)}" && exit $?`}`,
                 )
               ].join(` && `),
               directory: cwd,

--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -660,7 +660,7 @@ export namespace CompileTools {
               command: [
                 ...options.noLibList? [] : buildLiblistCommands(connection, ileSetup),
                 ...commands.map(command =>
-                  `${`system ${GlobalConfiguration.get(`logCompileOutput`) ? `` : `-s`} "${command.replace(/[$]/g, `\\$&`)}" && exit $?`}`,
+                  `${`system ${GlobalConfiguration.get(`logCompileOutput`) ? `` : `-s`} "${command.replace(/[$]/g, `\\$&`)}"`}`,
                 )
               ].join(` && `),
               directory: cwd,

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -348,7 +348,6 @@ export default class IBMi {
           command: `CRTLIB LIB(${this.config.tempLibrary}) TEXT('Code for i temporary objects. May be cleared.')`,
           noLibList: true
         });
-        console.log(createdTempLib?.stderr);
 
         if (createdTempLib.code === 0) {
           tempLibrarySet = true;

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -345,7 +345,7 @@ export default class IBMi {
 
         //Next, we need to check the temp lib (where temp outfile data lives) exists
         const createdTempLib = await this.runCommand({
-          command: `CRTLIB LIB(` + this.config.tempLibrary + `) TEXT('Code for i temporary objects. May be cleared.')`,
+          command: `CRTLIB LIB(${this.config.tempLibrary}) TEXT('Code for i temporary objects. May be cleared.')`,
           noLibList: true
         });
         console.log(createdTempLib?.stderr);
@@ -1015,12 +1015,12 @@ export default class IBMi {
    */
   getTempRemote(key: string) {
     if (this.tempRemoteFiles[key] !== undefined) {
-      console.log(`Using existing temp: ` + this.tempRemoteFiles[key]);
+      console.log(`Using existing temp: ${this.tempRemoteFiles[key]}`);
       return this.tempRemoteFiles[key];
     } else
       if (this.config) {
         let value = path.posix.join(this.config.tempDir, `vscodetemp-${Tools.makeid()}`);
-        console.log(`Using new temp: ` + value);
+        console.log(`Using new temp: ${value}`);
         this.tempRemoteFiles[key] = value;
         return value;
       }

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -484,7 +484,7 @@ export default class IBMi {
             });
           }
 
-          const QCPFRMIMPF = await await this.runCommand({
+          const QCPFRMIMPF = await this.runCommand({
             command: `CHKOBJ OBJ(QSYS/QCPFRMIMPF) OBJTYPE(*DTAARA)`,
             noLibList: true
           });

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -416,7 +416,8 @@ export default class IBMi {
             .then(result => {
               // All good!
               if (result && result.stderr) {
-                if (!result.stderr.startsWith(`CPF2125`)) {
+                const messages = Tools.parseMessages(result.stderr);
+                if (!messages.findId(`CPF2125`)) {
                   // @ts-ignore We know the config exists.
                   vscode.window.showErrorMessage(`Temporary data not cleared from ${this.config.tempLibrary}.`, `View log`).then(async choice => {
                     if (choice === `View log`) {

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -190,17 +190,16 @@ export default class IBMiContent {
           return true;
         } else {
           if (!retry) {
-            const messageID = String(copyResult.stderr).substring(0, 7);
-            switch (messageID) {
-              case "CPFA0A9":
-                //The member may be located on SYSBAS
-                if (asp) {
-                  path = Tools.qualifyPath(library, sourceFile, member);
-                  retry = true;
-                }
-                break;
-              default:
-                throw new Error(`Failed uploading member: ${copyResult.stderr}`);
+            const messages = Tools.parseMessages(copyResult.stderr);
+            if (messages.findId("CPFA0A9")) {
+              //The member may be located on SYSBAS
+              if (asp) {
+                path = Tools.qualifyPath(library, sourceFile, member);
+                retry = true;
+              }
+            }
+            else {
+              throw new Error(`Failed uploading member: ${copyResult.stderr}`);
             }
           }
         }
@@ -706,7 +705,7 @@ export default class IBMiContent {
         const asp = file.asp || this.config.sourceASP;
         if (asp && asp.length > 0) {
           return [
-            Tools.qualifyPath(file.library, file.name, member, asp, true), 
+            Tools.qualifyPath(file.library, file.name, member, asp, true),
             Tools.qualifyPath(file.library, file.name, member, undefined, true)
           ].join(` `);
         } else {

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -2,6 +2,7 @@ import Crypto from 'crypto';
 import { readFileSync } from "fs";
 import path from "path";
 import vscode from "vscode";
+import { IBMiMessage, IBMiMessages } from '../typings';
 import { API, GitExtension } from "./import/git";
 
 export namespace Tools {
@@ -167,7 +168,7 @@ export namespace Tools {
         return part
       }
     })
-    .join(path.posix.sep);
+      .join(path.posix.sep);
 
     return path.posix.join(correctedDir, pathInfo.base);
   }
@@ -210,7 +211,7 @@ export namespace Tools {
       .toLowerCase();
   }
 
-  export function capitalize(text:string) {
+  export function capitalize(text: string) {
     return text.charAt(0).toUpperCase() + text.slice(1);
   }
 
@@ -222,5 +223,16 @@ export namespace Tools {
         // Quote libraries starting with #
         return library.startsWith(`#`) ? `"${library}"` : library;
       });
+  }
+
+  export function parseMessages(output: string): IBMiMessages {
+    const messages = output.split("\n").map(line => ({
+      id: line.substring(0, line.indexOf(':')).trim(),
+      text: line.substring(line.indexOf(':') + 1).trim()
+    }) as IBMiMessage);
+    return {
+      messages,
+      findId: id => messages.find(m => m.id === id)
+    }
   }
 }

--- a/src/testing/connection.ts
+++ b/src/testing/connection.ts
@@ -143,6 +143,32 @@ export const ConnectionSuite: TestSuite = {
       assert.strictEqual(result.stdout.includes(`Library List`), true);
     }},
 
+    {name: `Test runCommand (with error)`, test: async () => {
+      const connection = instance.getConnection();
+
+      // One day it'd be cool to test different locales/CCSIDs here
+      // const profileMatix = [{ccsid: 277, language: `DAN`, region: `DK`}];
+      // for (const setup of profileMatix) {
+        // const profileChange = await connection?.runCommand({
+        //   command: `CHGUSRPRF USRPRF(${connection.currentUser}) CCSID(${setup.ccsid}) LANGID(${setup.language}) CNTRYID(${setup.region})`,
+        //   noLibList: true
+        // });
+    
+        // console.log(profileChange);
+        // assert.strictEqual(profileChange?.code, 0);
+      // }
+
+      console.log((await connection?.runCommand({command: `DSPUSRPRF USRPRF(${connection.currentUser}) OUTPUT(*PRINT)`, noLibList: true}))?.stdout);
+
+      const result = await connection?.runCommand({
+        command: `CHKOBJ OBJ(QSYS/NOEXIST) OBJTYPE(*DTAARA)`,
+        noLibList: true
+      });
+  
+      assert.notStrictEqual(result?.code, 0);
+      assert.ok(result?.stderr);
+    }},
+
     {name: `Test runCommand (ILE, custom libl)`, test: async () => {
       const connection = instance.getConnection();
   

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -42,7 +42,7 @@ export interface RemoteCommand {
   environment?: ActionEnvironment;
   cwd?: string;
   env?: Record<string, string>;
-  noLibList? : boolean
+  noLibList?: boolean
 }
 
 export interface CommandData extends StandardIO {
@@ -67,7 +67,7 @@ export interface Action {
   deployFirst?: boolean;
   postDownload?: string[];
   refresh?: ActionRefresh;
-  runOnProtected?:boolean;  
+  runOnProtected?: boolean;
 }
 
 export interface ConnectionData {
@@ -191,4 +191,14 @@ export interface SourcePhysicalFileItem extends FilteredItem, WithPath {
 
 export interface MemberItem extends FilteredItem, WithPath {
   member: IBMiMember
+}
+
+export type IBMiMessage = {
+  id: string
+  text: string  
+}
+
+export type IBMiMessages = {
+  messages: IBMiMessage[]
+  findId(id:string) : IBMiMessage | undefined
 }

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -7,6 +7,7 @@ import { MemberParts } from "../api/IBMi";
 import { SortOptions, SortOrder } from "../api/IBMiContent";
 import { Search } from "../api/Search";
 import { GlobalStorage } from '../api/Storage';
+import { Tools } from "../api/Tools";
 import { getMemberUri } from "../filesystems/qsys/QSysFs";
 import { instance, setSearchResults } from "../instantiate";
 import { t } from "../locale";
@@ -517,7 +518,8 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
               noLibList: true
             })
 
-            if (copyResult.stderr.includes(`CPF2869`)) {
+            const messages = Tools.parseMessages(copyResult.stderr);
+            if (messages.findId(`CPF2869`)) {
               throw (copyResult.stderr)
             }
 


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/1739

This PR adds a method that will parse commands `stderr` into `IBMiMessages` to facilitate error analysis.
This helps checking what IBM i messages are returned after a command call and fixes some checking that only looked for the first returned message ID.

Also fixes a very weird bug that the core team have only been able to recreate on pub400:

```
qsh: 001-0019 Error found searching for command [[. No such path or directory.
```

This new test would fail without the one line change I made in CompileTools#runCommand.

### Checklist
* [x] have tested my change