### PR TITLE
Return exit code correctly from system command

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -660,7 +660,7 @@ export namespace CompileTools {
               command: [
                 ...options.noLibList? [] : buildLiblistCommands(connection, ileSetup),
                 ...commands.map(command =>
-                  `${`system ${GlobalConfiguration.get(`logCompileOutput`) ? `` : `-s`} "${command.replace(/[$]/g, `\\$&`)}"; if [[ $? -ne 0 ]]; then exit 1; fi`}`,
+                  `${`system ${GlobalConfiguration.get(`logCompileOutput`) ? `` : `-s`} "${command.replace(/[$]/g, `\\$&`)}"; exit $?`}`,
                 )
               ].join(` && `),
               directory: cwd,

--- a/src/testing/connection.ts
+++ b/src/testing/connection.ts
@@ -143,6 +143,32 @@ export const ConnectionSuite: TestSuite = {
       assert.strictEqual(result.stdout.includes(`Library List`), true);
     }},
 
+    {name: `Test runCommand (with error)`, test: async () => {
+      const connection = instance.getConnection();
+
+      // One day it'd be cool to test different locales/CCSIDs here
+      // const profileMatix = [{ccsid: 277, language: `DAN`, region: `DK`}];
+      // for (const setup of profileMatix) {
+        // const profileChange = await connection?.runCommand({
+        //   command: `CHGUSRPRF USRPRF(${connection.currentUser}) CCSID(${setup.ccsid}) LANGID(${setup.language}) CNTRYID(${setup.region})`,
+        //   noLibList: true
+        // });
+    
+        // console.log(profileChange);
+        // assert.strictEqual(profileChange?.code, 0);
+      // }
+
+      console.log((await connection?.runCommand({command: `DSPUSRPRF USRPRF(${connection.currentUser}) OUTPUT(*PRINT)`, noLibList: true}))?.stdout);
+
+      const result = await connection?.runCommand({
+        command: `CHKOBJ OBJ(QSYS/NOEXIST) OBJTYPE(*DTAARA)`,
+        noLibList: true
+      });
+  
+      assert.notStrictEqual(result?.code, 0);
+      assert.ok(result?.stderr);
+    }},
+
     {name: `Test runCommand (ILE, custom libl)`, test: async () => {
       const connection = instance.getConnection();
   


### PR DESCRIPTION
### Changes

Fixes a very weird bug that the core team have only been able to recreate on pub400:

```
qsh: 001-0019 Error found searching for command [[. No such path or directory.
```

This new test would fail without the one line change I made in `CompileTools#runCommand`.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
