### PR TITLE
Check if a library exists before listing its content

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -438,6 +438,10 @@ export default class IBMiContent {
    */
   async getObjectList(filters: { library: string; object?: string; types?: string[]; }, sortOrder?: SortOrder): Promise<IBMiFile[]> {
     const library = filters.library.toUpperCase();
+    if(!await this.checkObject({ library: "QSYS", name: library, type: "*LIB"})){
+      throw new Error(`Library ${library} does not exist.`);
+    }
+    
     const object = (filters.object && filters.object !== `*` ? filters.object.toUpperCase() : `*ALL`);
     const sourceFilesOnly = (filters.types && filters.types.includes(`*SRCPF`));
 
@@ -557,7 +561,7 @@ export default class IBMiContent {
       results = await this.getTable(tempLib, TempName, TempName, true);
       if (results.length === 1 && String(results[0].MBNAME).trim() === ``) {
         return [];
-      }
+    }
 
       if (member || memberExt) {
         let pattern: RegExp | undefined, patternExt: RegExp | undefined;


### PR DESCRIPTION
### Changes
This PR fixes the `getObjectList` method that showed a confusing error when trying to list objects from a non existing library:
![fail1](https://github.com/codefori/vscode-ibmi/assets/11096890/b88d9f46-0090-4e90-93bf-08d52f227b41)

Now the method will first check if the library exist before carrying on and show a relevant error message if it doesn't:
![fail2](https://github.com/codefori/vscode-ibmi/assets/11096890/c6b976cf-3329-4c2d-bd4f-3b2b50c01e25)

### Testing
- Create filter for a library that doesn't exist
- Expand the filter
- Witness the error messages

### Checklist
* [x] have tested my change