### PR TITLE
Show recently opened files :boom: 

### DIFF
--- a/package.json
+++ b/package.json
@@ -467,6 +467,23 @@
 					"default": false,
 					"description": "When lines with ILE diagnostics are edited, the diagnostic will be removed. Requires reload/restart if changed."
 				},
+        "code-for-ibmi.recentlyOpenedFilesLimit": {
+          "type": "integer",
+          "default": 10,
+          "description": "Number of files to keep in recently opened files list.",
+          "enum": [
+            0,
+            10,
+            20,
+            30
+          ],
+          "enumDescriptions": [
+            "Do not keep any recently opened files",
+            "Keep the 10 most recently opened files",
+            "Keep the 20 most recently opened files",
+            "Keep the 30 most recently opened files"
+          ]
+        },
 				"code-for-ibmi.safeDeleteMode": {
 					"type": "boolean",
 					"default": false,

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -7,6 +7,7 @@ const DEPLOYMENT_KEY = `deployment`;
 const DEBUG_KEY = `debug`;
 const SERVER_SETTINGS_CACHE_KEY = (name : string) => `serverSettingsCache_${name}`;
 const PREVIOUS_SEARCH_TERMS_KEY = `prevSearchTerms`;
+const PREVIOUSLY_OPENED_FILES_KEY = `prevOpenedFiles`;
 
 export type PathContent = Record<string, string[]>;
 export type DeploymentPath = Record<string, string>;
@@ -175,4 +176,11 @@ export class ConnectionStorage extends Storage {
     const deployDirs = this.get<DeploymentPath>(DEPLOYMENT_KEY) || {};
     return deployDirs[workspaceFolder.uri.fsPath].toLowerCase();
   }
-}
+
+  getPrevOpenedFiles() {
+    return this.get<string[]>(PREVIOUSLY_OPENED_FILES_KEY) || [];
+  }
+
+  async setPrevOpenedFiles(prevOpenedFiles: string[]) {
+    await this.set(PREVIOUSLY_OPENED_FILES_KEY, prevOpenedFiles);
+  }}

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -7,7 +7,7 @@ const DEPLOYMENT_KEY = `deployment`;
 const DEBUG_KEY = `debug`;
 const SERVER_SETTINGS_CACHE_KEY = (name : string) => `serverSettingsCache_${name}`;
 const PREVIOUS_SEARCH_TERMS_KEY = `prevSearchTerms`;
-const PREVIOUSLY_OPENED_FILES_KEY = `prevOpenedFiles`;
+const RECENTLY_OPENED_FILES_KEY = `recentlyOpenedFiles`;
 
 export type PathContent = Record<string, string[]>;
 export type DeploymentPath = Record<string, string>;
@@ -177,10 +177,10 @@ export class ConnectionStorage extends Storage {
     return deployDirs[workspaceFolder.uri.fsPath].toLowerCase();
   }
 
-  getPrevOpenedFiles() {
-    return this.get<string[]>(PREVIOUSLY_OPENED_FILES_KEY) || [];
+  getRecentlyOpenedFiles() {
+    return this.get<string[]>(RECENTLY_OPENED_FILES_KEY) || [];
   }
 
-  async setPrevOpenedFiles(prevOpenedFiles: string[]) {
-    await this.set(PREVIOUSLY_OPENED_FILES_KEY, prevOpenedFiles);
+  async setRecentlyOpenedFiles(recentlyOpenedFiles: string[]) {
+    await this.set(RECENTLY_OPENED_FILES_KEY, recentlyOpenedFiles);
   }}

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -183,4 +183,9 @@ export class ConnectionStorage extends Storage {
 
   async setRecentlyOpenedFiles(recentlyOpenedFiles: string[]) {
     await this.set(RECENTLY_OPENED_FILES_KEY, recentlyOpenedFiles);
-  }}
+  }
+
+  async clearRecentlyOpenedFiles() {
+    await this.set(RECENTLY_OPENED_FILES_KEY, undefined);
+  }
+}

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -129,6 +129,11 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
           await vscode.commands.executeCommand(`vscode.open`, uri);
         }
 
+        // Add file to front of previous files list.
+        const storage = instance.getStorage();
+        const prevOpened = storage!.getPrevOpenedFiles();
+        storage!.setPrevOpenedFiles([path, ...prevOpened.filter((file) => file !== path)]);
+
         return true;
       } catch (e) {
         console.log(e);
@@ -441,7 +446,6 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 selection = selection.toUpperCase() === quickPick.value.toUpperCase() ? quickPick.value : selection;
               }
               vscode.commands.executeCommand(`code-for-ibmi.openEditable`, selection, 0, { readonly });
-              storage!.setPrevOpenedFiles([selection].concat(prevOpened.filter((file) => file !== selection)));
               quickPick.hide()
             } else {
               quickPick.value = selection.toUpperCase() + '/'

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -183,6 +183,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       if (!storage && !content) return;
       let list: string[] = [];
 
+      const prevOpened = storage!.getPrevOpenedFiles();
       const sources = storage!.getSourceList();
       const dirs = Object.keys(sources);
 
@@ -194,10 +195,16 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
         });
       });
 
+      const prevItems: vscode.QuickPickItem[] = prevOpened.map(item => ({ label: item }));
       const listItems: vscode.QuickPickItem[] = list.map(item => ({ label: item }));
 
       const quickPick = vscode.window.createQuickPick();
       quickPick.items = [
+        {
+          label: 'Previous',
+          kind: vscode.QuickPickItemKind.Separator
+        },
+        ...prevItems,
         {
           label: 'Cached',
           kind: vscode.QuickPickItemKind.Separator
@@ -232,6 +239,11 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
         if (quickPick.value === ``) {
           quickPick.items = [
             {
+              label: 'Previous',
+              kind: vscode.QuickPickItemKind.Separator
+            },
+            ...prevItems,
+                {
               label: 'Cached',
               kind: vscode.QuickPickItemKind.Separator
             },
@@ -264,6 +276,11 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                   kind: vscode.QuickPickItemKind.Separator
                 },
                 ...filteredItems,
+                {
+                  label: 'Previous',
+                  kind: vscode.QuickPickItemKind.Separator
+                },
+                ...prevItems,
                 {
                   label: 'Cached',
                   kind: vscode.QuickPickItemKind.Separator
@@ -308,6 +325,11 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                   kind: vscode.QuickPickItemKind.Separator
                 },
                 ...filteredItems,
+                {
+                  label: 'Previous',
+                  kind: vscode.QuickPickItemKind.Separator
+                },
+                ...prevItems,
                 {
                   label: 'Cached',
                   kind: vscode.QuickPickItemKind.Separator
@@ -357,6 +379,11 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 },
                 ...filteredItems,
                 {
+                  label: 'Previous',
+                  kind: vscode.QuickPickItemKind.Separator
+                },
+                ...prevItems,
+                {
                   label: 'Cached',
                   kind: vscode.QuickPickItemKind.Separator
                 },
@@ -384,6 +411,11 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 kind: vscode.QuickPickItemKind.Separator
               },
               ...filteredItems,
+              {
+                label: 'Previous',
+                kind: vscode.QuickPickItemKind.Separator
+              },
+              ...prevItems,
               {
                 label: 'Cached',
                 kind: vscode.QuickPickItemKind.Separator
@@ -440,6 +472,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 selection = selection.toUpperCase() === quickPick.value.toUpperCase() ? quickPick.value : selection;
               }
               vscode.commands.executeCommand(`code-for-ibmi.openEditable`, selection, 0, { readonly });
+              storage!.setPrevOpenedFiles([selection].concat(prevOpened.filter((file) => file !== selection)));
               quickPick.hide()
             } else {
               quickPick.value = selection.toUpperCase() + '/'

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -172,8 +172,10 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(`code-for-ibmi.goToFileReadOnly`, async () => vscode.commands.executeCommand(`code-for-ibmi.goToFile`, true)),
     vscode.commands.registerCommand(`code-for-ibmi.goToFile`, async (readonly?: boolean) => {
       const LOADING_LABEL = `Please wait`;
-      const clearList = `$(trash) Clear list`;
-      const clearListArray = [{ label: ``, kind: vscode.QuickPickItemKind.Separator }, { label: clearList }];
+      const clearPrev = `$(trash) Clear previous`;
+      const clearPrevArray = [{ label: ``, kind: vscode.QuickPickItemKind.Separator }, { label: clearPrev }];
+      const clearCached = `$(trash) Clear cached`;
+      const clearCachedArray = [{ label: ``, kind: vscode.QuickPickItemKind.Separator }, { label: clearCached }];
       const storage = instance.getStorage();
       const content = instance.getContent();
       const config = instance.getConfig();
@@ -205,12 +207,13 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
           kind: vscode.QuickPickItemKind.Separator
         },
         ...prevItems,
+        ...(prevItems.length != 0 ? clearPrevArray : []),
         {
           label: 'Cached',
           kind: vscode.QuickPickItemKind.Separator
         },
         ...listItems,
-        ...clearListArray
+        ...(listItems.length != 0 ? clearCachedArray : [])
       ];
       quickPick.canSelectMany = false;
       (quickPick as any).sortByLabel = false; // https://github.com/microsoft/vscode/issues/73904#issuecomment-680298036
@@ -243,12 +246,13 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
               kind: vscode.QuickPickItemKind.Separator
             },
             ...prevItems,
-                {
+            ...(prevItems.length != 0 ? clearPrevArray : []),
+            {
               label: 'Cached',
               kind: vscode.QuickPickItemKind.Separator
             },
             ...listItems,
-            ...clearListArray
+            ...(listItems.length != 0 ? clearCachedArray : [])
           ];
           filteredItems = [];
         } else {
@@ -281,12 +285,13 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                   kind: vscode.QuickPickItemKind.Separator
                 },
                 ...prevItems,
+                ...(prevItems.length != 0 ? clearPrevArray : []),
                 {
                   label: 'Cached',
                   kind: vscode.QuickPickItemKind.Separator
                 },
                 ...listItems,
-                ...clearListArray
+                ...(listItems.length != 0 ? clearCachedArray : [])
               ]
 
               break;
@@ -330,12 +335,13 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                   kind: vscode.QuickPickItemKind.Separator
                 },
                 ...prevItems,
+                ...(prevItems.length != 0 ? clearPrevArray : []),
                 {
                   label: 'Cached',
                   kind: vscode.QuickPickItemKind.Separator
                 },
                 ...listItems,
-                ...clearListArray
+                ...(listItems.length != 0 ? clearCachedArray : [])
               ]
               quickPick.busy = false;
 
@@ -383,12 +389,13 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                   kind: vscode.QuickPickItemKind.Separator
                 },
                 ...prevItems,
+                ...(prevItems.length != 0 ? clearPrevArray : []),
                 {
                   label: 'Cached',
                   kind: vscode.QuickPickItemKind.Separator
                 },
                 ...listItems,
-                ...clearListArray
+                ...(listItems.length != 0 ? clearCachedArray : [])
               ]
               quickPick.busy = false;
 
@@ -416,12 +423,13 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 kind: vscode.QuickPickItemKind.Separator
               },
               ...prevItems,
+              ...(prevItems.length != 0 ? clearPrevArray : []),
               {
                 label: 'Cached',
                 kind: vscode.QuickPickItemKind.Separator
               },
               ...listItems,
-              ...clearListArray
+              ...(listItems.length != 0 ? clearCachedArray : [])
             ]
           }
         }
@@ -431,10 +439,40 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       quickPick.onDidAccept(async () => {
         let selection = quickPick.selectedItems[0].label;
         if (selection && selection !== LOADING_LABEL) {
-          if (selection === clearList) {
+          if (selection === clearPrev) {
+            prevItems.length = 0;
+            storage!.setPrevOpenedFiles([]);
+            quickPick.items = [
+              { 
+                label: 'Filter',
+                kind: vscode.QuickPickItemKind.Separator
+              },
+              ...filteredItems,
+              {
+                label: 'Cached',
+                kind: vscode.QuickPickItemKind.Separator
+              },
+              ...listItems,
+              ...(listItems.length != 0 ? clearCachedArray : [])
+            ];
+            vscode.window.showInformationMessage(`Cleared previously opened files.`);
+          } else if (selection === clearCached) {
+            listItems.length = 0;
             storage!.setSourceList({});
-            quickPick.items = clearListArray;
-            vscode.window.showInformationMessage(`Cleared list.`);
+            quickPick.items = [
+              { 
+                label: 'Filter',
+                kind: vscode.QuickPickItemKind.Separator
+              },
+              ...filteredItems,
+              {
+                label: 'Previous',
+                kind: vscode.QuickPickItemKind.Separator
+              },
+              ...prevItems,
+              ...(prevItems.length != 0 ? clearPrevArray : [])
+            ];
+            vscode.window.showInformationMessage(`Cleared cached files.`);
           } else {
             const selectionSplit = selection.toUpperCase().split('/')
             if (selectionSplit.length === 3 || selection.startsWith(`/`)) {


### PR DESCRIPTION
### Changes

This PR will show the recently opened files in the Go To file list, with the last opened file first in the list and a button to clear the list of recently opened files:

![image](https://github.com/codefori/vscode-ibmi/assets/13275072/a64469d6-791a-4e03-a51e-06ce9c2b051d)

This makes it very easy to reopen a previously edited/browsed file. :boom: 

A configuration setting has also been added to control the number of recently opened files in the list:

![image](https://github.com/codefori/vscode-ibmi/assets/13275072/dab39d01-4452-40e0-b778-30bd9e18558a)


### Checklist

* [x] have tested my change
* [x] eslint is not complaining
* [x] **for feature PRs**: PR only includes one feature enhancement.
