### PR TITLE
Feature/edit vs browse

### DIFF
--- a/package.json
+++ b/package.json
@@ -427,6 +427,15 @@
 					"default": true,
 					"description": "If enabled, will clear the IBM i Output before an Action is run."
 				},
+				"code-for-ibmi.defaultOpenMode": {
+					"type": "string",
+					"default": "edit",
+					"enum": [
+						"browse",
+						"edit"						
+					],
+					"description": "The action to take when clicking on a source member or stream file to open it."
+				},
 				"code-for-ibmi.autoOpenFile": {
 					"type": "boolean",
 					"default": true,
@@ -1547,6 +1556,12 @@
 				"title": "Browse",
 				"enablement": "code-for-ibmi:connected",
 				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.edit",
+				"title": "Edit",
+				"enablement": "code-for-ibmi:connected",
+				"category": "IBM i"
 			}
 		],
 		"keybindings": [
@@ -1668,6 +1683,14 @@
 			{
 				"id": "code-for-ibmi.sortMembers",
 				"label": "Sort by"
+			},
+			{
+				"id": "code-for-ibmi.openIFSFile",
+				"label": "Open"
+			},
+			{
+				"id": "code-for-ibmi.openMember",
+				"label": "Open"
 			}
 		],
 		"menus": {
@@ -1685,6 +1708,23 @@
 				},
 				{
 					"command": "code-for-ibmi.sortMembersByDate"
+				}
+			],
+			"code-for-ibmi.openIFSFile": [
+				{
+					"command": "code-for-ibmi.browse"
+				},
+				{
+					"command": "code-for-ibmi.edit"
+				}
+			],
+			"code-for-ibmi.openMember": [
+				{
+					"command": "code-for-ibmi.browse"
+				},
+				{
+					"command": "code-for-ibmi.edit",
+					"when": "viewItem == member"
 				}
 			],
 			"commandPalette": [
@@ -1774,6 +1814,10 @@
 				},
 				{
 					"command": "code-for-ibmi.browse",
+					"when": "never"
+				},
+				{
+					"command": "code-for-ibmi.edit",
 					"when": "never"
 				},
 				{
@@ -2201,9 +2245,9 @@
 					"group": "5_sourceFileStuff@1"
 				},
 				{
-					"command": "code-for-ibmi.browse",
+					"submenu": "code-for-ibmi.openMember",
 					"when": "view == objectBrowser && viewItem =~ /^member.*$/",
-					"group": "0_browse@1"
+					"group": "0_open@1"
 				},
 				{
 					"command": "code-for-ibmi.runAction",
@@ -2261,9 +2305,9 @@
 					"group": "inline"
 				},
 				{
-					"command": "code-for-ibmi.browse",
+					"submenu": "code-for-ibmi.openIFSFile",
 					"when": "view == ifsBrowser && !listMultiSelection && viewItem == streamfile",
-					"group": "0_browse@1"
+					"group": "0_open@1"
 				},
 				{
 					"command": "code-for-ibmi.runAction",

--- a/src/api/Configuration.ts
+++ b/src/api/Configuration.ts
@@ -59,6 +59,7 @@ export namespace ConnectionConfiguration {
     readOnlyMode: boolean;
     quickConnect: boolean;
     defaultDeploymentMethod: DeploymentMethod | '';
+    protectedPaths: string[];
     [name: string]: any;
   }
 
@@ -136,7 +137,8 @@ export namespace ConnectionConfiguration {
       debugEnableDebugTracing: (parameters.debugEnableDebugTracing === true),
       readOnlyMode: (parameters.readOnlyMode === true),
       quickConnect: (parameters.quickConnect === true || parameters.quickConnect === undefined),
-      defaultDeploymentMethod: parameters.defaultDeploymentMethod || ``
+      defaultDeploymentMethod: parameters.defaultDeploymentMethod || ``,
+      protectedPaths: (parameters.protectedPaths || [])
     }
   }
 

--- a/src/api/Configuration.ts
+++ b/src/api/Configuration.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { DeploymentMethod } from '../typings';
 
 export type SourceDateMode = "edit" | "diff";
+export type DefaultOpenMode = "browse" | "edit";
 
 const getConfiguration = (): vscode.WorkspaceConfiguration => {
   return vscode.workspace.getConfiguration(`code-for-ibmi`);

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -858,7 +858,7 @@ export default class IBMiContent {
     }
     else { //QSYS path
       const [library] = path.split('/');
-      return this.config.protectedPaths.includes(library);
+      return this.config.protectedPaths.includes(library.toLocaleUpperCase());
     }
   }
 }

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -438,10 +438,10 @@ export default class IBMiContent {
    */
   async getObjectList(filters: { library: string; object?: string; types?: string[]; }, sortOrder?: SortOrder): Promise<IBMiFile[]> {
     const library = filters.library.toUpperCase();
-    if(!await this.checkObject({ library: "QSYS", name: library, type: "*LIB"})){
+    if (!await this.checkObject({ library: "QSYS", name: library, type: "*LIB" })) {
       throw new Error(`Library ${library} does not exist.`);
     }
-    
+
     const object = (filters.object && filters.object !== `*` ? filters.object.toUpperCase() : `*ALL`);
     const sourceFilesOnly = (filters.types && filters.types.includes(`*SRCPF`));
 
@@ -561,7 +561,7 @@ export default class IBMiContent {
       results = await this.getTable(tempLib, TempName, TempName, true);
       if (results.length === 1 && String(results[0].MBNAME).trim() === ``) {
         return [];
-    }
+      }
 
       if (member || memberExt) {
         let pattern: RegExp | undefined, patternExt: RegExp | undefined;
@@ -845,6 +845,20 @@ export default class IBMiContent {
     return (await this.ibmi.runCommand({
       command: `CHKOBJ OBJ(${object.library.toLocaleUpperCase()}/${object.name.toLocaleUpperCase()}) OBJTYPE(${object.type.toLocaleUpperCase()}) AUT(${authorities.join(" ")})`,
       noLibList: true
-    }))?.code === 0;
+    })).code === 0;
+  }
+
+  async testStreamFile(path: string, right: "r" | "w" | "x") {
+    return (await this.ibmi.sendCommand({ command: `test -${right} ${path}` })).code === 0;
+  }
+
+  isProtectedPath(path: string) {
+    if (path.startsWith('/')) { //IFS path
+      return this.config.protectedPaths.some(p => path.startsWith(p));
+    }
+    else { //QSYS path
+      const [library] = path.split('/');
+      return this.config.protectedPaths.includes(library);
+    }
   }
 }

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -8,7 +8,7 @@ import Instance from "./api/Instance";
 import { Search } from "./api/Search";
 import { Terminal } from './api/Terminal';
 import { refreshDiagnosticsFromServer } from './api/errors/diagnostics';
-import { QSysFS, getMemberUri, getUriFromPath } from "./filesystems/qsys/QSysFs";
+import { QSysFS, getUriFromPath } from "./filesystems/qsys/QSysFs";
 import { init as clApiInit } from "./languages/clle/clApi";
 import * as clRunner from "./languages/clle/clRunner";
 import { initGetNewLibl } from "./languages/clle/getnewlibl";
@@ -600,26 +600,16 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
     }),
 
     vscode.commands.registerCommand("code-for-ibmi.browse", (item: WithPath | MemberItem) => {
-      return vscode.commands.executeCommand("vscode.openWithDefaultMode", item, "browse" as DefaultOpenMode);
+      return vscode.commands.executeCommand("code-for-ibmi.openWithDefaultMode", item, "browse" as DefaultOpenMode);
     }),
 
     vscode.commands.registerCommand("code-for-ibmi.edit", (item: WithPath | MemberItem) => {
-      return vscode.commands.executeCommand("vscode.openWithDefaultMode", item, "edit" as DefaultOpenMode);
+      return vscode.commands.executeCommand("code-for-ibmi.openWithDefaultMode", item, "edit" as DefaultOpenMode);
     }),
 
-    vscode.commands.registerCommand("vscode.openWithDefaultMode", (item: WithPath | MemberItem, overrideMode?: DefaultOpenMode) => {
+    vscode.commands.registerCommand("code-for-ibmi.openWithDefaultMode", (item: WithPath, overrideMode?: DefaultOpenMode) => {
       const readonly = (overrideMode || GlobalConfiguration.get<DefaultOpenMode>("defaultOpenMode")) === "browse";
-      let uri;
-      if ("member" in item) {
-        uri = getMemberUri(item.member, { readonly });
-      }
-      else {
-        uri = getUriFromPath(item.path, { readonly });
-      }
-
-      if (uri) {
-        return vscode.commands.executeCommand(`vscode.open`, uri);
-      }
+      vscode.commands.executeCommand(`code-for-ibmi.openEditable`, item.path, { readonly });
     })
   );
 

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -13,7 +13,7 @@ import { init as clApiInit } from "./languages/clle/clApi";
 import * as clRunner from "./languages/clle/clRunner";
 import { initGetNewLibl } from "./languages/clle/getnewlibl";
 import { SEUColorProvider } from "./languages/general/SEUColorProvider";
-import { Action, BrowserItem, DeploymentMethod, MemberItem, QsysFsOptions, WithPath } from "./typings";
+import { Action, BrowserItem, DeploymentMethod, MemberItem, OpenEditableOptions, WithPath } from "./typings";
 import { SearchView } from "./views/searchView";
 import { ActionsUI } from './webviews/actions';
 import { VariablesUI } from "./webviews/variables";
@@ -98,7 +98,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       `searchView`,
       searchViewContext
     ),
-    vscode.commands.registerCommand(`code-for-ibmi.openEditable`, async (path: string, line?: number, options?: QsysFsOptions) => {
+    vscode.commands.registerCommand(`code-for-ibmi.openEditable`, async (path: string, options?: OpenEditableOptions) => {
       console.log(path);
       options = options || {};
       options.readonly = options.readonly || instance.getContent()?.isProtectedPath(path);
@@ -117,8 +117,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
 
       const uri = getUriFromPath(path, options);
       try {
-        const selection = line ? new vscode.Range(line, 0, line, 1000) : undefined;
-        await vscode.commands.executeCommand(`vscode.openWith`, uri, 'default', { selection } as vscode.TextDocumentShowOptions);
+        await vscode.commands.executeCommand(`vscode.openWith`, uri, 'default', { selection: options.position } as vscode.TextDocumentShowOptions);
         return true;
       } catch (e) {
         console.log(e);
@@ -434,8 +433,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 }
                 selection = selection.toUpperCase() === quickPick.value.toUpperCase() ? quickPick.value : selection;
               }
-              vscode.commands.executeCommand(`code-for-ibmi.openEditable`, selection, 0, { readonly });
-              quickPick.hide()
+              vscode.commands.executeCommand(`code-for-ibmi.openEditable`, selection, { readonly });
+              quickPick.hide();
             } else {
               quickPick.value = selection.toUpperCase() + '/'
             }

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -114,24 +114,11 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
           }
         }
       }
+
       const uri = getUriFromPath(path, options);
       try {
-        if (line) {
-          // If a line is provided, we have to do a specific open
-          let doc = await vscode.workspace.openTextDocument(uri); // calls back into the provider
-          const editor = await vscode.window.showTextDocument(doc, { preview: false });
-
-          if (editor) {
-            const selectedLine = editor.document.lineAt(line);
-            editor.selection = new vscode.Selection(line, selectedLine.firstNonWhitespaceCharacterIndex, line, 100);
-            editor.revealRange(selectedLine.range, vscode.TextEditorRevealType.InCenter);
-          }
-
-        } else {
-          // Otherwise, do a generic open
-          await vscode.commands.executeCommand(`vscode.open`, uri);
-        }
-
+        const selection = line ? new vscode.Range(line, 0, line, 1000) : undefined;
+        await vscode.commands.executeCommand(`vscode.openWith`, uri, 'default', { selection } as vscode.TextDocumentShowOptions);
         return true;
       } catch (e) {
         console.log(e);

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,5 +1,5 @@
 import { Ignore } from 'ignore';
-import { ProviderResult, ThemeIcon, TreeItem, TreeItemCollapsibleState, WorkspaceFolder } from "vscode";
+import { ProviderResult, Range, ThemeIcon, TreeItem, TreeItemCollapsibleState, WorkspaceFolder } from "vscode";
 import { ConnectionConfiguration } from './api/Configuration';
 import { CustomUI } from "./api/CustomUI";
 import Instance from "./api/Instance";
@@ -195,11 +195,13 @@ export interface MemberItem extends FilteredItem, WithPath {
 
 export type IBMiMessage = {
   id: string
-  text: string  
+  text: string
 }
 
 export type IBMiMessages = {
   messages: IBMiMessage[]
-  findId(id:string) : IBMiMessage | undefined
+  findId(id: string): IBMiMessage | undefined
 }
 export const IFS_BROWSER_MIMETYPE = "application/vnd.code.tree.ifsbrowser";
+
+export type OpenEditableOptions = QsysFsOptions & { position?: Range };

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -127,11 +127,10 @@ class IFSFileItem extends IFSItem {
     this.contextValue = "streamfile";
     this.iconPath = vscode.ThemeIcon.File;
 
-    this.resourceUri = vscode.Uri.parse(this.path).with({ scheme: `streamfile` });
-    this.command = {
-      command: `code-for-ibmi.openEditable`,
+    this.resourceUri = vscode.Uri.parse(this.path).with({ scheme: `streamfile` }); this.command = {
+      command: "vscode.openWithDefaultMode",
       title: `Open Streamfile`,
-      arguments: [this.path]
+      arguments: [this]
     };
   }
 

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -128,7 +128,7 @@ class IFSFileItem extends IFSItem {
     this.iconPath = vscode.ThemeIcon.File;
 
     this.resourceUri = vscode.Uri.parse(this.path).with({ scheme: `streamfile` }); this.command = {
-      command: "vscode.openWithDefaultMode",
+      command: "code-for-ibmi.openWithDefaultMode",
       title: `Open Streamfile`,
       arguments: [this]
     };

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -276,7 +276,7 @@ class ObjectBrowserMemberItem extends ObjectBrowserItem implements MemberItem {
     this.description = member.text;
 
     this.resourceUri = getMemberUri(member, { readonly });
-    this.path = this.resourceUri.path;
+    this.path = this.resourceUri.path.substring(1);
     this.tooltip = `${this.path}`
       .concat(`${member.text ? `\n${t("text")}:\t\t${member.text}` : ``}`)
       .concat(`${member.lines != undefined ? `\n${t("lines")}:\t${member.lines}` : ``}`)
@@ -286,7 +286,7 @@ class ObjectBrowserMemberItem extends ObjectBrowserItem implements MemberItem {
     this.sortBy = (sort: SortOptions) => parent.sortBy(sort);
 
     this.command = {
-      command: "vscode.openWithDefaultMode",
+      command: "code-for-ibmi.openWithDefaultMode",
       title: `Open Member`,
       arguments: [this, (readonly ? "browse" : undefined) as DefaultOpenMode]
     };
@@ -447,7 +447,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
 
           if (addResult.code === 0) {
             if (GlobalConfiguration.get(`autoOpenFile`)) {
-              vscode.commands.executeCommand(`vscode.open`, getMemberUri(member));
+              vscode.commands.executeCommand(`code-for-ibmi.openEditable`, fullPath);
             }
 
             objectBrowser.refresh(node);
@@ -524,7 +524,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
             }
 
             if (GlobalConfiguration.get(`autoOpenFile`)) {
-              vscode.commands.executeCommand(`vscode.open`, getMemberUri(memberPath));
+              vscode.commands.executeCommand(`code-for-ibmi.openEditable`, memberPath);
             }
 
             if (oldMember.library.toLocaleLowerCase() === memberPath.library.toLocaleLowerCase()) {

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -1,10 +1,11 @@
 import vscode from "vscode";
 import { ConnectionConfiguration, GlobalConfiguration } from "../../api/Configuration";
 import { ComplexTab, CustomUI, Section } from "../../api/CustomUI";
+import { Tools } from "../../api/Tools";
+import { isManaged } from "../../api/debug";
 import * as certificates from "../../api/debug/certificates";
 import { instance } from "../../instantiate";
 import { ConnectionData, Server } from '../../typings';
-import { isManaged } from "../../api/debug";
 
 const ENCODINGS = [`37`, `256`, `273`, `277`, `278`, `280`, `284`, `285`, `297`, `500`, `871`, `870`, `905`, `880`, `420`, `875`, `424`, `1026`, `290`, `win37`, `win256`, `win273`, `win277`, `win278`, `win280`, `win284`, `win285`, `win297`, `win500`, `win871`, `win870`, `win905`, `win880`, `win420`, `win875`, `win424`, `win1026`];
 
@@ -27,10 +28,7 @@ export class SettingsUI {
   static init(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
-      vscode.commands.registerCommand(`code-for-ibmi.showAdditionalSettings`, async (
-        /** @type {Server|undefined} */ server,
-        /** @type {string|undefined} */ tab,
-      ) => {
+      vscode.commands.registerCommand(`code-for-ibmi.showAdditionalSettings`, async (server?: Server, tab?: string) => {
         const connectionSettings = GlobalConfiguration.get<ConnectionConfiguration.Parameters[]>(`connectionSettings`);
         const connection = instance.getConnection();
 
@@ -128,7 +126,8 @@ export class SettingsUI {
             }
           ], `Set your Default Deployment Method`)
           .addCheckbox(`sourceDateGutter`, `Source Dates in Gutter`, `When enabled, source dates will be displayed in the gutter.`, config.sourceDateGutter)
-          .addCheckbox(`readOnlyMode`, `Read only mode`, `When enabled, saving will be disabled for source members and IFS files.`, config.readOnlyMode)
+          .addCheckbox(`readOnlyMode`, `Read only mode`, `When enabled, source members and IFS files will always be opened in read-only mode.`, config.readOnlyMode)
+          .addInput(`protectedPaths`, `Protected paths`, `A comma separated list of libraries and/or IFS directories whose members will always be opened in read-only mode. (Example: <code>QGPL, /home/QSECOFR, MYLIB, /QIBM</code>)`, { default: config.protectedPaths.join(`, `) });
 
         const terminalsTab = new Section();
         if (connection && connection.remoteFeatures.tn5250) {
@@ -230,7 +229,11 @@ export class SettingsUI {
                     if (data[key].trim() === ``) data[key] = null;
                     break;
                   case `hideCompileErrors`:
-                    data[key] = data[key].split(`,`).map((item: string) => item.trim().toUpperCase()).filter((item: string) => item !== ``);
+                  case `protectedPaths`:
+                    data[key] = data[key].split(`,`)
+                      .map((item: string) => item.trim().toUpperCase())
+                      .filter((item: string) => item !== ``)
+                      .filter(Tools.distinct);
                     break;
                 }
 

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -243,19 +243,26 @@ export class SettingsUI {
               }
 
               if (restartFields.some(item => data[item] !== config[item])) {
-                restart = true;
+                restart = false;
               }
+              const reloadBrowsers = config.protectedPaths.join(",") !== data.protectedPaths.join(",");
 
               Object.assign(config, data);
               await instance.setConfig(config);
 
-              if (connection && restart) {
-                vscode.window.showInformationMessage(`Some settings require a restart to take effect. Reload workspace now?`, `Reload`, `No`)
-                  .then(async (value) => {
-                    if (value === `Reload`) {
-                      await vscode.commands.executeCommand(`workbench.action.reloadWindow`);
-                    }
-                  });
+              if (connection) {
+                if (restart) {
+                  vscode.window.showInformationMessage(`Some settings require a restart to take effect. Reload workspace now?`, `Reload`, `No`)
+                    .then(async (value) => {
+                      if (value === `Reload`) {
+                        await vscode.commands.executeCommand(`workbench.action.reloadWindow`);
+                      }
+                    });
+                }
+                else if (reloadBrowsers){
+                  vscode.commands.executeCommand("code-for-ibmi.refreshIFSBrowser");
+                  vscode.commands.executeCommand("code-for-ibmi.refreshObjectBrowser");
+                }
               }
             }
           }

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -229,10 +229,17 @@ export class SettingsUI {
                     if (data[key].trim() === ``) data[key] = null;
                     break;
                   case `hideCompileErrors`:
-                    data[key] = split(data[key], true);
+                    data[key] = String(data[key]).split(`,`)
+                      .map(item => item.toUpperCase().trim())
+                      .filter(item => item !== ``)
+                      .filter(Tools.distinct);
                     break;
                   case `protectedPaths`:
-                    data[key] = split(data[key], false);
+                    data[key] = String(data[key]).split(`,`)
+                      .map(item => item.trim())
+                      .map(item => item.startsWith('/') ? item : item.toUpperCase())
+                      .filter(item => item !== ``)
+                      .filter(Tools.distinct);
                     break;
                 }
 
@@ -259,7 +266,7 @@ export class SettingsUI {
                       }
                     });
                 }
-                else if (reloadBrowsers){
+                else if (reloadBrowsers) {
                   vscode.commands.executeCommand("code-for-ibmi.refreshIFSBrowser");
                   vscode.commands.executeCommand("code-for-ibmi.refreshObjectBrowser");
                 }
@@ -320,12 +327,4 @@ export class SettingsUI {
       })
     )
   }
-}
-
-function split(value: string, uppercase: boolean) {
-  return value.split(`,`)
-    .map(item => item.trim())
-    .map(item => uppercase ? item.toUpperCase() : item)
-    .filter(item => item !== ``)
-    .filter(Tools.distinct);
 }

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -229,11 +229,10 @@ export class SettingsUI {
                     if (data[key].trim() === ``) data[key] = null;
                     break;
                   case `hideCompileErrors`:
+                    data[key] = split(data[key], true);
+                    break;
                   case `protectedPaths`:
-                    data[key] = data[key].split(`,`)
-                      .map((item: string) => item.trim().toUpperCase())
-                      .filter((item: string) => item !== ``)
-                      .filter(Tools.distinct);
+                    data[key] = split(data[key], false);
                     break;
                 }
 
@@ -313,8 +312,13 @@ export class SettingsUI {
         }
       })
     )
-
-
   }
+}
 
+function split(value: string, uppercase: boolean) {
+  return value.split(`,`)
+    .map(item => item.trim())
+    .map(item => uppercase ? item.toUpperCase() : item)
+    .filter(item => item !== ``)
+    .filter(Tools.distinct);
 }


### PR DESCRIPTION
### Changes
Resolves https://github.com/codefori/vscode-ibmi/issues/1752

As discussed in https://github.com/orgs/codefori/discussions/1331, browsing/editing support could use a little love. This PR brings some enhancement to address what was discussed:

- A new `Open` sub-menu replaces the single `Browse` action in stream files/member's right click menu. The sub-menu offers to explicitly open a streamfile/member read-only or for editing.
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/49b523b0-7a9e-4615-9211-eb02538c7832)
- A new global setting lets the user define what should be the open action by default when clicking on a streamfile/member to open it
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/6b94a93e-af63-4dd2-ac86-888a25c5a130)
- A new connection settings lets the user define `protected paths`: a comma-separated list of libraries and/or IFS paths that will always be opened read-only.
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/1bdec1e9-182d-4e0c-a46b-4d271f0b47d5)

Under the hood, all the actions that open a streamfile/member now end up using `code-for-ibmi.openEditable` that holds all the logic for checking if the target should be opened read-only or not. This command has also be enhanced to allow to open a resource and highlight a range in the opened document.


### Checklist
* [x] have tested my change