### PR TITLE
Check if field exists when looking for settings field requiring a restart

### DIFF
--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -240,7 +240,7 @@ export class SettingsUI {
                 }
               }
 
-              if (restartFields.some(item => data[item] !== config[item])) {
+              if (restartFields.some(item => data[item] && data[item] !== config[item])) {
                 restart = true;
               }
 


### PR DESCRIPTION
### Changes
This fixes a small issue that would always show this dialog, even when the settings requiring a restart were not changed:
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/2a637e8d-cfa2-4015-9f83-2a434c0a9299)

This happens if the debug service is not available or if the debug certificate are not managed by Code for IBM i.
The condition that tests if a `restart field` has been changed doesn't take into account the fact that this field may not exist in the settings page.

For example, my settings used to have a `debugCertDirectory`, but now this field doesn't show anymore on the settings page and changing the settings for this connection always asks to reload VSCode.

### Checklist
* [x] have tested my change