### PR TITLE
Fix error when referencing undefined parameters variable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ If you want to help but you're unsure what to work on, here are two easy places 
 
 Thanks so much to everyone [who has contributed](https://github.com/codefori/vscode-ibmi/graphs/contributors).
 
+* [@krethan](https://github.com/krethan)
 * [@connorholyday](https://github.com/connorholyday)
 * [@worksofliam](https://github.com/worksofliam)
 * [@alanseiden](https://github.com/alanseiden)

--- a/src/api/Configuration.ts
+++ b/src/api/Configuration.ts
@@ -144,9 +144,12 @@ export namespace ConnectionConfiguration {
   }
 
   export async function update(parameters: Parameters) {
-    let connections = getConnectionSettings();
-    connections.filter(conn => conn.name === parameters.name).forEach(conn => Object.assign(conn, parameters));
-    await updateAll(connections);
+    let connections;
+    if(parameters?.name) {
+      connections = getConnectionSettings();
+      connections.filter(conn => conn.name === parameters.name).forEach(conn => Object.assign(conn, parameters));
+      await updateAll(connections);
+    }
   }
 
   /**

--- a/src/api/Configuration.ts
+++ b/src/api/Configuration.ts
@@ -144,9 +144,8 @@ export namespace ConnectionConfiguration {
   }
 
   export async function update(parameters: Parameters) {
-    let connections;
     if(parameters?.name) {
-      connections = getConnectionSettings();
+      const connections = getConnectionSettings();
       connections.filter(conn => conn.name === parameters.name).forEach(conn => Object.assign(conn, parameters));
       await updateAll(connections);
     }


### PR DESCRIPTION
When parameters variable is undefined it is generating an error when trying to reference parameters.name. Added check to ensure parameters.name is defined before updating the connection information. There is also no need to update the connection information if parameters.name is undefined.