### PR TITLE
Escape path when testing streamfile for access rights

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -849,7 +849,7 @@ export default class IBMiContent {
   }
 
   async testStreamFile(path: string, right: "r" | "w" | "x") {
-    return (await this.ibmi.sendCommand({ command: `test -${right} ${path}` })).code === 0;
+    return (await this.ibmi.sendCommand({ command: `test -${right} ${Tools.escapePath(path)}` })).code === 0;
   }
 
   isProtectedPath(path: string) {


### PR DESCRIPTION
### Changes

This PR resolves issue #1762 by escaping the path before testing access rights for the streamfile.

### Checklist

* [x] have tested my change
