### PR TITLE
Fix #1172 - No warning of truncated lines when saving to source member 

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -189,9 +189,9 @@ export default class IBMiContent {
 
         if (copyResult.code === 0) {
           const messages = Tools.parseMessages(copyResult.stderr);
-            if (messages.findId("CPIA083")) {
-              window.showWarningMessage( `${library}/${sourceFile}(${member}) was saved with truncated records!`);
-            }
+          if (messages.findId("CPIA083")) {
+            window.showWarningMessage(`${library}/${sourceFile}(${member}) was saved with truncated records!`);
+          }
           return true;
         } else {
           if (!retry) {

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -8,6 +8,7 @@ import { CommandResult, IBMiError, IBMiFile, IBMiMember, IBMiObject, IFSFile, Qs
 import { ConnectionConfiguration } from './Configuration';
 import { default as IBMi } from './IBMi';
 import { Tools } from './Tools';
+import { window } from 'vscode';
 const tmpFile = util.promisify(tmp.file);
 const readFileAsync = util.promisify(fs.readFile);
 const writeFileAsync = util.promisify(fs.writeFile);
@@ -187,6 +188,10 @@ export default class IBMiContent {
         });
 
         if (copyResult.code === 0) {
+          const messages = Tools.parseMessages(copyResult.stderr);
+            if (messages.findId("CPIA083")) {
+              window.showWarningMessage( `${library}/${sourceFile}(${member}) was saved with truncated records!`);
+            }
           return true;
         } else {
           if (!retry) {


### PR DESCRIPTION
### Changes

Show a warning message when the uploadMemberContent function gets a CPIA083 to tell the user the member content was saved but there were truncated lines. 

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [x] **for feature PRs**: PR only includes one feature enhancement.
