### PR TITLE
Delete password when private key is used

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,7 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
         }
 
         if (savePassword && connectionData.password) {
-          context.secrets.store(`${connectionData.name}_password`, `${connectionData.password}`);
+          await context.secrets.store(`${connectionData.name}_password`, `${connectionData.password}`);
         }
 
         return (await new IBMi().connect(connectionData, undefined, reloadSettings)).success;

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -614,8 +614,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
         return newValue;
       }
 
-      const value = context.secrets.get(connectionKey);
-      return value;
+      return await context.secrets.get(connectionKey);
     }),
 
     vscode.commands.registerCommand("code-for-ibmi.browse", (item: WithPath | MemberItem) => {

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -74,8 +74,7 @@ export async function registerUriHandler(context: ExtensionContext) {
                             password: undefined, // Removes the password from the object
                           });
 
-                          context.secrets.store(`${host}_password`, pass);
-
+                          await context.secrets.store(`${host}_password`, pass);
                           await GlobalConfiguration.set(`connections`, existingConnections);
                         }
                       }

--- a/src/views/ConnectionBrowser.ts
+++ b/src/views/ConnectionBrowser.ts
@@ -96,7 +96,7 @@ export class ObjectBrowserProvider {
               GlobalStorage.get().deleteServerSettingsCache(server.name);
 
               // Then remove the password
-              context.secrets.delete(`${server.name}_password`);
+              await context.secrets.delete(`${server.name}_password`);
 
               this.refresh();
             }

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -75,7 +75,7 @@ export class Login {
             });
 
             if (data.savePassword) {
-              context.secrets.store(`${data.name}_password`, `${data.password}`);
+              await context.secrets.store(`${data.name}_password`, `${data.password}`);
             }
 
             await GlobalConfiguration.set(`connections`, existingConnections);

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -152,7 +152,12 @@ export class Login {
     const existingConnections = GlobalConfiguration.get<ConnectionData[]>(`connections`) || [];
     let connectionConfig = existingConnections.find(item => item.name === name);
     if (connectionConfig) {
-      if (!connectionConfig.privateKeyPath) {
+      if (connectionConfig.privateKeyPath) {
+        // If connecting with a private key, remove the password
+        await context.secrets.delete(`${connectionConfig.name}_password`);
+
+      } else {
+        // Assume connection with a password, but prompt if we don't have one
         connectionConfig.password = await context.secrets.get(`${connectionConfig.name}_password`);
         if (!connectionConfig.password) {
           connectionConfig.password = await vscode.window.showInputBox({

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -303,6 +303,7 @@ export class SettingsUI {
               if (!data.privateKeyPath?.trim()) {
                 if (connection.privateKeyPath?.trim()) {
                   data.privateKeyPath = connection.privateKeyPath;
+                  context.secrets.delete(`${name}_password`);
                 }
                 else {
                   delete data.privateKeyPath;

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -303,7 +303,7 @@ export class SettingsUI {
               if (!data.privateKeyPath?.trim()) {
                 if (connection.privateKeyPath?.trim()) {
                   data.privateKeyPath = connection.privateKeyPath;
-                  context.secrets.delete(`${name}_password`);
+                  await context.secrets.delete(`${name}_password`);
                 }
                 else {
                   delete data.privateKeyPath;
@@ -311,8 +311,8 @@ export class SettingsUI {
               }
 
               if (data.password && !data.privateKeyPath) {
-                context.secrets.delete(`${name}_password`);
-                context.secrets.store(`${name}_password`, `${data.password}`);
+                await context.secrets.delete(`${name}_password`);
+                await context.secrets.store(`${name}_password`, `${data.password}`);
                 delete data.privateKeyPath;
               }
 


### PR DESCRIPTION
### Changes

There is a bug with starting the debugger if the user once used a password, but is now using a private key, as the user would never be prompted for the correct password when debugging.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
