### PR TITLE
Fix path splitting when opening a member on an IASP

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -3,12 +3,12 @@ import fs from 'fs';
 import path from 'path';
 import tmp from 'tmp';
 import util from 'util';
+import { window } from 'vscode';
 import { ObjectTypes } from '../filesystems/qsys/Objects';
 import { CommandResult, IBMiError, IBMiFile, IBMiMember, IBMiObject, IFSFile, QsysPath } from '../typings';
 import { ConnectionConfiguration } from './Configuration';
 import { default as IBMi } from './IBMi';
 import { Tools } from './Tools';
-import { window } from 'vscode';
 const tmpFile = util.promisify(tmp.file);
 const readFileAsync = util.promisify(fs.readFile);
 const writeFileAsync = util.promisify(fs.writeFile);
@@ -861,9 +861,9 @@ export default class IBMiContent {
     if (path.startsWith('/')) { //IFS path
       return this.config.protectedPaths.some(p => path.startsWith(p));
     }
-    else { //QSYS path
-      const [library] = path.split('/');
-      return this.config.protectedPaths.includes(library.toLocaleUpperCase());
+    else { //QSYS path      
+      const qsysObject = Tools.parseQSysPath(path);
+      return this.config.protectedPaths.includes(qsysObject.library.toLocaleUpperCase());
     }
   }
 }

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -2,7 +2,7 @@ import Crypto from 'crypto';
 import { readFileSync } from "fs";
 import path from "path";
 import vscode from "vscode";
-import { IBMiMessage, IBMiMessages } from '../typings';
+import { IBMiMessage, IBMiMessages, QsysPath } from '../typings';
 import { API, GitExtension } from "./import/git";
 
 export namespace Tools {
@@ -233,6 +233,23 @@ export namespace Tools {
     return {
       messages,
       findId: id => messages.find(m => m.id === id)
+    }
+  }
+
+  export function parseQSysPath(path: string) : QsysPath{
+    const parts = path.split('/');
+    if(parts.length > 3){
+      return {
+        asp: parts[0],
+        library: parts[1],
+        name: parts[2]
+      }
+    }
+    else{
+      return {
+        library: parts[0],
+        name: parts[1]
+      }
     }
   }
 }

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -110,8 +110,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
           options.readonly = !await instance.getContent()?.testStreamFile(path, "w");
         }
         else {
-          const [library, name] = path.split('/');
-          const writable = await instance.getContent()?.checkObject({ library, name, type: '*FILE' }, "*UPD");
+          const qsysObject = Tools.parseQSysPath(path);
+          const writable = await instance.getContent()?.checkObject({ library: qsysObject.library, name: qsysObject.name, type: '*FILE' }, "*UPD");
           if (!writable) {
             options.readonly = true;
           }
@@ -707,19 +707,19 @@ async function createQuickPickItemsList(
   labelFiltered: string = ``, filtered: vscode.QuickPickItem[] = [],
   labelRecent: string = ``, recent: vscode.QuickPickItem[] = [],
   labelCached: string = ``, cached: vscode.QuickPickItem[] = [],
-  ) {
-    const clearRecentArray = [{ label: ``, kind: vscode.QuickPickItemKind.Separator }, { label: CLEAR_RECENT }];
-    const clearCachedArray = [{ label: ``, kind: vscode.QuickPickItemKind.Separator }, { label: CLEAR_CACHED }];
+) {
+  const clearRecentArray = [{ label: ``, kind: vscode.QuickPickItemKind.Separator }, { label: CLEAR_RECENT }];
+  const clearCachedArray = [{ label: ``, kind: vscode.QuickPickItemKind.Separator }, { label: CLEAR_CACHED }];
 
-    const returnedList: vscode.QuickPickItem[] = [
-      { label: labelFiltered, kind: vscode.QuickPickItemKind.Separator },
-      ...filtered,
-      { label: labelRecent, kind: vscode.QuickPickItemKind.Separator },
-      ...recent,
-      ...(recent.length != 0 ? clearRecentArray : []),
-      { label: labelCached, kind: vscode.QuickPickItemKind.Separator },
-      ...cached,
-      ...(cached.length != 0 ? clearCachedArray : [])
-    ];
-    return returnedList;
+  const returnedList: vscode.QuickPickItem[] = [
+    { label: labelFiltered, kind: vscode.QuickPickItemKind.Separator },
+    ...filtered,
+    { label: labelRecent, kind: vscode.QuickPickItemKind.Separator },
+    ...recent,
+    ...(recent.length != 0 ? clearRecentArray : []),
+    { label: labelCached, kind: vscode.QuickPickItemKind.Separator },
+    ...cached,
+    ...(cached.length != 0 ? clearCachedArray : [])
+  ];
+  return returnedList;
 }


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/1765

The path parsing was incorrect when opening a member located on an iASP. Since this kind of path begins with the iASP, it would return the iASP name as being the library.

This PR adds a method in `Tools` that will correctly parse the path in any case.

### Checklist
* [x] have tested my change