### PR TITLE
Feature/pseudo source

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -115,10 +115,10 @@ export namespace CompileTools {
           };
         });
 
-        const pseudoExtensions = config.psuedoSourceExtensions.map(ext => ext.toUpperCase());
+        const pseudoExtensions = config.pseudoSourceExtensions.map(ext => ext.toUpperCase());
         allActions.push({
-          name: `⚒️ Run as psuedo source`,
-          type: `psuedo`,
+          name: `⚒️ Run as pseudo source`,
+          type: `pseudo`,
           command: '',
           environment: 'ile',
           extensions: pseudoExtensions,
@@ -126,7 +126,7 @@ export namespace CompileTools {
         })
 
         // Then we get all the available Actions for the current context
-        availableActions = allActions.filter(action => (action.type === uri.scheme || action.type === `psuedo`) && (!action.extensions || action.extensions.includes(extension) || action.extensions.includes(fragment) || action.extensions.includes(`GLOBAL`)) && (!isProtected || action.runOnProtected))
+        availableActions = allActions.filter(action => (action.type === uri.scheme || action.type === `pseudo`) && (!action.extensions || action.extensions.includes(extension) || action.extensions.includes(fragment) || action.extensions.includes(`GLOBAL`)) && (!isProtected || action.runOnProtected))
           .sort((a, b) => (actionUsed.get(b.name) || 0) - (actionUsed.get(a.name) || 0))
           .map(action => ({
             label: action.name,
@@ -172,8 +172,8 @@ export namespace CompileTools {
             fromWorkspace = vscode.workspace.workspaceFolders[workspaceId || 0];
           }
 
-          if (chosenAction.type === `psuedo`) {
-            const pseudoResult = await runAsPsuedoSource(instance, uri);
+          if (chosenAction.type === `pseudo`) {
+            const pseudoResult = await runAsPseudoSource(instance, uri);
             return pseudoResult || false;
           }
 
@@ -781,7 +781,7 @@ export namespace CompileTools {
     return command;
   }
 
-  export async function runAsPsuedoSource(instance: Instance, uri: vscode.Uri) {
+  export async function runAsPseudoSource(instance: Instance, uri: vscode.Uri) {
     const connection = instance.getConnection();
     const config = instance.getConfig();
     if (config && connection) {
@@ -794,12 +794,12 @@ export namespace CompileTools {
       const commands = getCommandStrings(document);
 
       const result = await vscode.window.withProgress({
-        title: `Executing psuedo source`, 
+        title: `Executing pseudo source`, 
         location: vscode.ProgressLocation.Notification,
         cancellable: true
       }, async (progress, token) => {
         token.onCancellationRequested(() => {
-          vscode.window.showInformationMessage(`Psuedo source execution cancelled.`);
+          vscode.window.showInformationMessage(`Pseudo source execution cancelled.`);
         });
 
         let overallSuccess = true;
@@ -821,7 +821,7 @@ export namespace CompileTools {
 
           progress.report({ message: commandString });
           const commandResult = await runCommand(instance, {
-            title: `Psuedo source`,
+            title: `Pseudo source`,
             environment: `ile`,
             command: commandString,
           });

--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -124,17 +124,19 @@ export namespace CompileTools {
           }));
       }
 
-      const pseudoExtensions = [`clle`, `dtaara`];
-      if (pseudoExtensions.includes(extension.toLowerCase())) {
-        availableActions.push({
-          label: `Run as psuedo source`,
-          action: {
-            name: `Run as psuedo source`,
-            type: `psuedo`,
-            command: '',
-            environment: 'ile'
-          }
-        })
+      if (!isProtected) {
+        const pseudoExtensions = [`clle`, `dtaara`];
+        if (pseudoExtensions.includes(extension.toLowerCase())) {
+          availableActions.push({
+            label: `Run as psuedo source`,
+            action: {
+              name: `Run as psuedo source`,
+              type: `psuedo`,
+              command: '',
+              environment: 'ile'
+            }
+          })
+        }
       }
 
       if (customAction || availableActions.length) {
@@ -822,7 +824,7 @@ export namespace CompileTools {
           const variables = getDefaultVariables(instance, ileSetup);
           const commandString = replaceValues(command.content, variables);
 
-          progress.report({ message: `Executing ${commandString}` });
+          progress.report({ message: commandString });
           const commandResult = await runCommand(instance, {
             title: `Psuedo source`,
             environment: `ile`,
@@ -836,7 +838,7 @@ export namespace CompileTools {
           if (command.range) {
             diags.push({
               success: commandResult.code === 0,
-              message: commandResult.stderr,
+              message: commandResult.stderr || `No output.`,
               range: new Range(command.range.start, 0, command.range.end, document.lineAt(command.range.end).range.end.character)
             })
           }

--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -115,28 +115,23 @@ export namespace CompileTools {
           };
         });
 
+        const pseudoExtensions = [`CLLE`, `DTAARA`];
+        allActions.push({
+          name: `⚒️ Run as psuedo source`,
+          type: `psuedo`,
+          command: '',
+          environment: 'ile',
+          extensions: pseudoExtensions,
+          runOnProtected: false
+        })
+
         // Then we get all the available Actions for the current context
-        availableActions = allActions.filter(action => action.type === uri.scheme && (!action.extensions || action.extensions.includes(extension) || action.extensions.includes(fragment) || action.extensions.includes(`GLOBAL`)) && (!isProtected || action.runOnProtected))
+        availableActions = allActions.filter(action => (action.type === uri.scheme || action.type === `psuedo`) && (!action.extensions || action.extensions.includes(extension) || action.extensions.includes(fragment) || action.extensions.includes(`GLOBAL`)) && (!isProtected || action.runOnProtected))
           .sort((a, b) => (actionUsed.get(b.name) || 0) - (actionUsed.get(a.name) || 0))
           .map(action => ({
             label: action.name,
             action
           }));
-      }
-
-      if (!isProtected) {
-        const pseudoExtensions = [`clle`, `dtaara`];
-        if (pseudoExtensions.includes(extension.toLowerCase())) {
-          availableActions.push({
-            label: `Run as psuedo source`,
-            action: {
-              name: `Run as psuedo source`,
-              type: `psuedo`,
-              command: '',
-              environment: 'ile'
-            }
-          })
-        }
       }
 
       if (customAction || availableActions.length) {

--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -115,7 +115,7 @@ export namespace CompileTools {
           };
         });
 
-        const pseudoExtensions = [`CLLE`, `DTAARA`];
+        const pseudoExtensions = config.psuedoSourceExtensions.map(ext => ext.toUpperCase());
         allActions.push({
           name: `⚒️ Run as psuedo source`,
           type: `psuedo`,

--- a/src/api/Configuration.ts
+++ b/src/api/Configuration.ts
@@ -60,7 +60,7 @@ export namespace ConnectionConfiguration {
     quickConnect: boolean;
     defaultDeploymentMethod: DeploymentMethod | '';
     protectedPaths: string[];
-    psuedoSourceExtensions: string[];
+    pseudoSourceExtensions: string[];
     [name: string]: any;
   }
 
@@ -140,7 +140,7 @@ export namespace ConnectionConfiguration {
       quickConnect: (parameters.quickConnect === true || parameters.quickConnect === undefined),
       defaultDeploymentMethod: parameters.defaultDeploymentMethod || ``,
       protectedPaths: (parameters.protectedPaths || []),
-      psuedoSourceExtensions: (parameters.psuedoSourceExtensions || [`DTAARA`, `MSGF`, `BNDDIR`]),
+      pseudoSourceExtensions: (parameters.pseudoSourceExtensions || [`DTAARA`, `MSGF`, `BNDDIR`]),
     }
   }
 

--- a/src/api/Configuration.ts
+++ b/src/api/Configuration.ts
@@ -60,6 +60,7 @@ export namespace ConnectionConfiguration {
     quickConnect: boolean;
     defaultDeploymentMethod: DeploymentMethod | '';
     protectedPaths: string[];
+    psuedoSourceExtensions: string[];
     [name: string]: any;
   }
 
@@ -138,7 +139,8 @@ export namespace ConnectionConfiguration {
       readOnlyMode: (parameters.readOnlyMode === true),
       quickConnect: (parameters.quickConnect === true || parameters.quickConnect === undefined),
       defaultDeploymentMethod: parameters.defaultDeploymentMethod || ``,
-      protectedPaths: (parameters.protectedPaths || [])
+      protectedPaths: (parameters.protectedPaths || []),
+      psuedoSourceExtensions: (parameters.psuedoSourceExtensions || [`DTAARA`, `MSGF`, `BNDDIR`]),
     }
   }
 

--- a/src/api/errors/diagnostics.ts
+++ b/src/api/errors/diagnostics.ts
@@ -61,6 +61,23 @@ export function clearDiagnostic(uri: vscode.Uri, changeRange: vscode.Range) {
   }
 }
 
+export interface PseudoDiagnostic {
+  success: boolean,
+  message: string,
+  range: vscode.Range
+}
+
+export async function setDiagnosticsFromPseudo(instance: Instance, uri: vscode.Uri, diags: PseudoDiagnostic[]) {
+  const diagnostics: vscode.Diagnostic[] = [];
+
+  for (const error of diags) {
+    const diagnostic = new vscode.Diagnostic(error.range, error.message, error.success ? vscode.DiagnosticSeverity.Information : vscode.DiagnosticSeverity.Error);
+    diagnostics.push(diagnostic);
+  }
+
+  ileDiagnostics.set(uri, diagnostics);
+}
+
 export async function refreshDiagnosticsFromServer(instance: Instance, evfeventInfo: EvfEventInfo) {
   const content = instance.getContent();
 

--- a/src/languages/clle/clRunner.ts
+++ b/src/languages/clle/clRunner.ts
@@ -98,7 +98,8 @@ function getCommandString(selection: Selection, document: TextDocument): Documen
 function removePlusJoins(lines: string[]) {
   for (let i = 0; i < lines.length; i++) {
     lines[i] = lines[i].trim();
-    if (lines[i].endsWith(`+`)) lines[i] = lines[i].substring(0, lines[i].length - 1);
+    if (lines[i].startsWith(`/*`)) lines[i] = ``;
+    else if (lines[i].endsWith(`+`)) lines[i] = lines[i].substring(0, lines[i].length - 1);
   }
 
   return lines;

--- a/src/languages/clle/clRunner.ts
+++ b/src/languages/clle/clRunner.ts
@@ -35,7 +35,35 @@ export function initialise(context: ExtensionContext) {
   )
 }
 
-function getCommandString(selection: Selection, document: TextDocument): {content: string, range?: {start: number, end: number}} {
+interface LineRange {
+  start: number;
+  end: number;
+}
+
+interface DocumentCommand {
+  content: string;
+  range?: LineRange;
+}
+
+export function getCommandStrings(document: TextDocument): DocumentCommand[] {
+  let list: DocumentCommand[] = [];
+
+  let nextLine = new Position(0, 0);
+
+  while (nextLine.line < document.lineCount) {
+    const currentCommand = getCommandString(new Selection(nextLine, nextLine), document);
+    if (currentCommand.content) list.push(currentCommand);
+    if (currentCommand.range) {
+      nextLine = new Position(currentCommand.range.end + 1, 0);
+    } else {
+      break;
+    }
+  }
+
+  return list;
+}
+
+function getCommandString(selection: Selection, document: TextDocument): DocumentCommand {
   if (selection.isEmpty) {
     let line = selection.start.line;
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -32,7 +32,7 @@ export interface StandardIO {
 /**
  * External interface for extensions to call `code-for-ibmi.runCommand`
  */
-export type ActionType = "member" | "streamfile" | "object" | "file" | "psuedo";
+export type ActionType = "member" | "streamfile" | "object" | "file" | "pseudo";
 export type ActionRefresh = "no" | "parent" | "filter" | "browser";
 export type ActionEnvironment = "ile" | "qsh" | "pase";
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -32,7 +32,7 @@ export interface StandardIO {
 /**
  * External interface for extensions to call `code-for-ibmi.runCommand`
  */
-export type ActionType = "member" | "streamfile" | "object" | "file";
+export type ActionType = "member" | "streamfile" | "object" | "file" | "psuedo";
 export type ActionRefresh = "no" | "parent" | "filter" | "browser";
 export type ActionEnvironment = "ile" | "qsh" | "pase";
 

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -60,7 +60,7 @@ export class SettingsUI {
           .addHorizontalRule()
           .addCheckbox(`autoSaveBeforeAction`, `Auto Save for Actions`, `When current editor has unsaved changes, automatically save it before running an action.`, config.autoSaveBeforeAction)
           .addInput(`hideCompileErrors`, `Errors to ignore`, `A comma delimited list of errors to be hidden from the result of an Action in the EVFEVENT file. Useful for codes like <code>RNF5409</code>.`, { default: config.hideCompileErrors.join(`, `) })
-          .addInput(`psuedoSourceExtensions`, `Psuedo source extensions`, `A comma delimited list of file extensions that should be treated as psuedo sources. A psuedo source is a file containing CL commands which are executed as part of the Action.`, { default: config.psuedoSourceExtensions.join(`, `) });
+          .addInput(`pseudoSourceExtensions`, `Pseudo source extensions`, `A comma delimited list of file extensions that should be treated as pseudo sources. A pseudo source is a file containing CL commands which are executed as part of the Action.`, { default: config.pseudoSourceExtensions.join(`, `) });
 
         const tempDataTab = new Section();
         tempDataTab
@@ -242,7 +242,7 @@ export class SettingsUI {
                       .filter(item => item !== ``)
                       .filter(Tools.distinct);
                     break;
-                  case `psuedoSourceExtensions`:
+                  case `pseudoSourceExtensions`:
                     data[key] = String(data[key]).split(`,`)
                       .map(item => item.toUpperCase().trim())
                       .filter(item => item !== ``)

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -60,6 +60,7 @@ export class SettingsUI {
           .addHorizontalRule()
           .addCheckbox(`autoSaveBeforeAction`, `Auto Save for Actions`, `When current editor has unsaved changes, automatically save it before running an action.`, config.autoSaveBeforeAction)
           .addInput(`hideCompileErrors`, `Errors to ignore`, `A comma delimited list of errors to be hidden from the result of an Action in the EVFEVENT file. Useful for codes like <code>RNF5409</code>.`, { default: config.hideCompileErrors.join(`, `) })
+          .addInput(`psuedoSourceExtensions`, `Psuedo source extensions`, `A comma delimited list of file extensions that should be treated as psuedo sources. A psuedo source is a file containing CL commands which are executed as part of the Action.`, { default: config.psuedoSourceExtensions.join(`, `) });
 
         const tempDataTab = new Section();
         tempDataTab
@@ -238,6 +239,12 @@ export class SettingsUI {
                     data[key] = String(data[key]).split(`,`)
                       .map(item => item.trim())
                       .map(item => item.startsWith('/') ? item : item.toUpperCase())
+                      .filter(item => item !== ``)
+                      .filter(Tools.distinct);
+                    break;
+                  case `psuedoSourceExtensions`:
+                    data[key] = String(data[key]).split(`,`)
+                      .map(item => item.toUpperCase().trim())
                       .filter(item => item !== ``)
                       .filter(Tools.distinct);
                     break;


### PR DESCRIPTION
### Changes

Adds a new default Action called 'Run as pseudo source', which runs the individual CL commands from the source code and prints info the existing diagnostic instance to show the results.

![image](https://github.com/codefori/vscode-ibmi/assets/3708366/e8b20368-42f9-4378-81b9-dd3536a80167)

Only applies to sources where the extension matches the list as defined in the new user settings.

![image](https://github.com/codefori/vscode-ibmi/assets/3708366/25acc36f-2bd7-4c9b-abeb-b5c128ac38f4)

* Closes #1785
* Closes #1387 as we now use [and need] the built in CL logic in the base extension.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
