### PR TITLE
`checkObject` to support checking member

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -885,13 +885,13 @@ export default class IBMiContent {
    * @param parameters A key/value object of parameters
    * @returns Formatted CL string
    */
-  static toCl(command: string, parameters: {[parameter: string]: string|number|undefined}) {
+  static toCl(command: string, parameters: {[parameter: string]: string|number|undefined}) {    
     let cl = command;
 
     for (const [key, value] of Object.entries(parameters)) {
       let parmValue;
 
-      if (value) {
+      if (value !== undefined) {
         if (typeof value === 'string') {
           if (value === value.toLocaleUpperCase()) {
             parmValue = value;

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -550,7 +550,31 @@ export const ContentSuite: TestSuite = {
         assert.notStrictEqual(qrpglesrc, undefined);
         assert.strictEqual(qrpglesrc?.attribute === "PF", true);
         assert.strictEqual(qrpglesrc?.type === "*FILE", true);
+      },
+    },
+    {
+      name: `Check object (file)`, test: async () => {
+        const content = instance.getContent();
+
+        const exists = await content?.checkObject({ library: `QSYSINC`, name: `MIH`, type: `*FILE` });
+        assert.ok(exists);
       }
-    }
+    },
+    {
+      name: `Check object (no exist)`, test: async () => {
+        const content = instance.getContent();
+
+        const exists = await content?.checkObject({ library: `QSYSINC`, name: `BOOOP`, type: `*FILE` });
+        assert.strictEqual(exists, false);
+      }
+    },
+    {
+      name: `Check object (source member)`, test: async () => {
+        const content = instance.getContent();
+
+        const exists = await content?.checkObject({ library: `QSYSINC`, name: `H`, type: `*FILE`, member: `MATH` });
+        assert.ok(exists);
+      }
+    },
   ]
 };

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -3,13 +3,14 @@ import tmp from 'tmp';
 import util from 'util';
 import { Uri, workspace } from "vscode";
 import { TestSuite } from ".";
+import IBMiContent from "../api/IBMiContent";
 import { Tools } from "../api/Tools";
 import { instance } from "../instantiate";
 import { CommandResult } from "../typings";
 
 export const ContentSuite: TestSuite = {
   name: `Content API tests`,
-  tests: [
+  tests: [        
     {
       name: `Test memberResolve`, test: async () => {
         const content = instance.getContent();
@@ -551,6 +552,20 @@ export const ContentSuite: TestSuite = {
         assert.strictEqual(qrpglesrc?.attribute === "PF", true);
         assert.strictEqual(qrpglesrc?.type === "*FILE", true);
       },
+    },
+    {
+      name: `To CL`, test: async () => {
+        const command = IBMiContent.toCl("TEST", {
+          ZERO: 0,
+          NONE:'*NONE',
+          EMPTY: `''`,
+          OBJNAME: `OBJECT`,
+          OBJCHAR: `ObJect`,
+          IFSPATH: `/hello/world`
+        });
+
+        assert.strictEqual(command, "TEST ZERO(0) NONE(*NONE) EMPTY('') OBJNAME(OBJECT) OBJCHAR('ObJect') IFSPATH('/hello/world')");
+      }
     },
     {
       name: `Check object (file)`, test: async () => {


### PR DESCRIPTION
### Changes

* Adds `member` property to `checkObject` API, allowing us to check if members exist
* Created a new `toCl` static method to generate the formatted CL commands. I'd like to move towards using this instead of hardcoding CL strings everywhere.
* Tests for `checkObject` API uses

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
