### PR TITLE
Removes deploy option from object browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -2456,11 +2456,6 @@
 					"group": "3_ifsTransfer@3"
 				},
 				{
-					"command": "code-for-ibmi.setDeployLocation",
-					"when": "view == objectBrowser && viewItem == filter && workspaceFolderCount >= 1",
-					"group": "3_ifsTransfer@3"
-				},
-				{
 					"command": "code-for-ibmi.changeObjectDesc",
 					"when": "view == objectBrowser && viewItem =~ /^object/",
 					"group": "1_objActions@1"


### PR DESCRIPTION
### Changes

Fixes #1556. Years ago, we had the option to deploy from local to source members. We took that out years ago too, but this context option was left in.

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
