### PR TITLE
Correctly read files from the IFS

### DIFF
--- a/src/filesystems/ifsFs.ts
+++ b/src/filesystems/ifsFs.ts
@@ -13,8 +13,8 @@ export class IFSFS implements vscode.FileSystemProvider {
   async readFile(uri: vscode.Uri, retrying?: boolean): Promise<Uint8Array> {
     const contentApi = instance.getContent();
     if (contentApi) {
-      const fileContent = await contentApi.downloadStreamfile(uri.path);
-      return new Uint8Array(Buffer.from(fileContent, `utf8`));
+      const fileContent = await contentApi.downloadStreamfileRaw(uri.path);
+      return fileContent;
     }
     else {
       if (retrying) {
@@ -40,7 +40,7 @@ export class IFSFS implements vscode.FileSystemProvider {
   async writeFile(uri: vscode.Uri, content: Uint8Array, options: { readonly create: boolean; readonly overwrite: boolean; }) {
     const contentApi = instance.getContent();
     if (contentApi) {
-      contentApi.writeStreamfile(uri.path, content);
+      contentApi.writeStreamfileRaw(uri.path, content);
     }
     else {
       throw new Error("Not connected to IBM i");


### PR DESCRIPTION
### Changes

I noticed our IFS filesystem wasn't forcing everything as UTF8, which meant we couldn't open up non UTF8 files like PDFs, images, and spreadsheets that reside in the IFS. 

I have added created new raw APIs that we should use instead, and made the previous download/write APIs call the raw API and convert to UTF8 to keep the previous functionality.

Test cases are continuing to pass.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
