### PR TITLE
Display more explicit error message when connection fails

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -874,7 +874,7 @@ export default class IBMi {
         };
       });
 
-    } catch (e) {
+    } catch (e: any) {
 
       if (this.client.isConnected()) {
         this.client.dispose();
@@ -887,9 +887,20 @@ export default class IBMi {
         return this.connect(connectionObject, true);
       }
 
+      let error = e;
+      if (e.code === "ENOTFOUND") {
+        error = `Host is unreachable. Check the connection's hostname/IP address.`;
+      }
+      else if (e.code === "ECONNREFUSED") {
+        error = `Port ${connectionObject.port} is unreachable. Check the connection's port number or run command STRTCPSVR SERVER(*SSHD) on the host.`
+      }
+      else if (e.level === "client-authentication") {
+        error = `Check your credentials${e.message ? ` (${e.message})` : ''}.`;
+      }
+
       return {
         success: false,
-        error: e
+        error
       };
     }
     finally {


### PR DESCRIPTION
### Changes
This PR makes the connection failure messages more explicit, depending on the error.

There are three error cases for which we provide an explicit message:
- Host is unreachable
- Port is unreachable
- Credentials are wrong

If the error case cannot be determined from the error returned by SSH, then the error is displayed as it used to be.

Example of the three possible messages:
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/877c5e92-012c-484e-8225-e8d03b254eef)


