### PR TITLE
Fix/no_member_validation

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -422,27 +422,13 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 const file = `${connection!.sysNameInAmerican(selectionSplit[1])}`;
                 const member = path.parse(`${connection!.sysNameInAmerican(selectionSplit[2])}`);
                 member.ext = member.ext.substring(1);
-                const fullMember = await content!.runSQL(`
-                  select rtrim( cast( SYSTEM_TABLE_MEMBER as char( 10 ) for bit data ) ) as MEMBER
-                       , rtrim( coalesce( SOURCE_TYPE, '' ) ) as TYPE
-                    from QSYS2.SYSPARTITIONSTAT
-                   where ( SYSTEM_TABLE_SCHEMA, SYSTEM_TABLE_NAME, SYSTEM_TABLE_MEMBER ) = ( '${lib}', '${file}', '${member.name}' )
-                   limit 1
-                `).then((resultSet) => {
-                  return resultSet.length !== 1 ? {} :
-                    {
-                      base: `${resultSet[0].MEMBER}.${resultSet[0].TYPE}`,
-                      name: `${resultSet[0].MEMBER}`,
-                      ext: `${resultSet[0].TYPE}`,
-                    }
-                });
-                if (!fullMember) {
-                  vscode.window.showWarningMessage(`Member ${lib}/${file}/${member.base} does not exist.`);
-                  return;
-                } else if (fullMember.name !== member.name || (member.ext && fullMember.ext !== member.ext)) {
-                  vscode.window.showWarningMessage(`Member ${lib}/${file}/${member.name} of type ${member.ext} does not exist.`);
-                  return;
+
+                const fullMember = {
+                  base: member.base,
+                  name: member.name,
+                  ext: member.ext
                 }
+
                 selection = `${lib}/${file}/${fullMember.base}`;
               };
               if (selection.startsWith(`/`)) {

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -423,6 +423,11 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                 const member = path.parse(`${connection!.sysNameInAmerican(selectionSplit[2])}`);
                 member.ext = member.ext.substring(1);
 
+                if (member.ext.trim() === ``) {
+                  vscode.window.showErrorMessage(`${selection} does not include a member extension.`);
+                  return;
+                }
+
                 const fullMember = {
                   base: member.base,
                   name: member.name,


### PR DESCRIPTION
### Changes

Removes additional check to find out if the chosen member exists. There are two reasons why I think this is allowed:

1. Because if the user enters a path manually, we can assume it does exist. Even if it doesn't exist, the tab will open with a valid error saying the member cannot be found. Fine by me.
2. If the user is using the ability to search with the asterisk filter, then we already know that the member exists.
3. Turns out, on systems with a huge member count this statement was taking a long time to run. That is a problem.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
