### PR TITLE
API change: use default CCSID to run SQL queries when needed

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -7,7 +7,6 @@ import path from 'path';
 import { instance } from "../instantiate";
 import { CommandData, CommandResult, ConnectionData, IBMiMember, RemoteCommand } from "../typings";
 import { CompileTools } from "./CompileTools";
-import IBMiContent from "./IBMiContent";
 import { CachedServerSettings, GlobalStorage } from './Storage';
 import { Tools } from './Tools';
 import * as configVars from './configVars';
@@ -15,8 +14,9 @@ import * as configVars from './configVars';
 export interface MemberParts extends IBMiMember {
   basename: string
 }
+const CCSID_SYSVAL = -2;
 
-let remoteApps = [ // All names MUST also be defined as key in 'remoteFeatures' below!!
+const remoteApps = [ // All names MUST also be defined as key in 'remoteFeatures' below!!
   {
     path: `/usr/bin/`,
     names: [`setccsid`, `iconv`, `attr`, `tar`, `ls`]
@@ -50,7 +50,8 @@ export default class IBMi {
   defaultUserLibraries: string[];
   outputChannel?: vscode.OutputChannel;
   aspInfo: { [id: number]: string };
-  qccsid: number | null;
+  qccsid: number;
+  defaultCCSID: number;
   remoteFeatures: { [name: string]: string | undefined };
   variantChars: { american: string, local: string };
   lastErrors: object[];
@@ -74,8 +75,8 @@ export default class IBMi {
      * the root of the IFS, thus why we store it.
      */
     this.aspInfo = {};
-
-    this.qccsid = null;
+    this.qccsid = CCSID_SYSVAL;
+    this.defaultCCSID = 0;
 
     this.remoteFeatures = {
       git: undefined,
@@ -560,8 +561,20 @@ export default class IBMi {
         }
 
         if (this.remoteFeatures[`QZDFMDB2.PGM`]) {
-          let statement;
-          let output;
+          //Temporary function to run SQL
+          const runSQL = async (statement: string) => {
+            const output = await this.sendCommand({
+              command: `LC_ALL=EN_US.UTF-8 system "call QSYS/QZDFMDB2 PARM('-d' '-i')"`,
+              stdin: statement
+            });
+
+            if (output.code === 0) {
+              return Tools.db2Parse(output.stdout);
+            }
+            else {
+              throw new Error(output.stdout);
+            }
+          };
 
           // Check for ASP information?
           if (quickConnect === true && cachedServerSettings?.aspInfo) {
@@ -574,7 +587,7 @@ export default class IBMi {
             //This is mostly a nice to have. We grab the ASP info so user's do
             //not have to provide the ASP in the settings.
             try {
-              const resultSet = await new IBMiContent(this).runSQL(`SELECT * FROM QSYS2.ASP_INFO`);
+              const resultSet = await runSQL(`SELECT * FROM QSYS2.ASP_INFO`);
               resultSet.forEach(row => {
                 if (row.DEVICE_DESCRIPTION_NAME && row.DEVICE_DESCRIPTION_NAME && row.DEVICE_DESCRIPTION_NAME !== `null`) {
                   this.aspInfo[Number(row.ASP_NUMBER)] = String(row.DEVICE_DESCRIPTION_NAME);
@@ -589,9 +602,10 @@ export default class IBMi {
           }
 
           // Fetch conversion values?
-          if (quickConnect === true && cachedServerSettings?.qccsid !== null && cachedServerSettings?.variantChars) {
+          if (quickConnect === true && cachedServerSettings?.qccsid !== null && cachedServerSettings?.variantChars && cachedServerSettings?.defaultCCSID) {
             this.qccsid = cachedServerSettings.qccsid;
             this.variantChars = cachedServerSettings.variantChars;
+            this.defaultCCSID = cachedServerSettings.defaultCCSID;
           } else {
             progress.report({
               message: `Fetching conversion values.`
@@ -599,34 +613,32 @@ export default class IBMi {
 
             // Next, we're going to see if we can get the CCSID from the user or the system.
             // Some things don't work without it!!!
-            try {
-              const CCSID_SYSVAL = -2;
-              statement = `select CHARACTER_CODE_SET_ID from table( QSYS2.QSYUSRINFO( USERNAME => upper('${this.currentUser}') ) )`;
-              output = await this.sendCommand({
-                command: `LC_ALL=EN_US.UTF-8 system "call QSYS/QZDFMDB2 PARM('-d' '-i')"`,
-                stdin: statement
-              });
+            try {              
+              const [userInfo] = await runSQL(`select CHARACTER_CODE_SET_ID from table( QSYS2.QSYUSRINFO( USERNAME => upper('${this.currentUser}') ) )`);
+              if (userInfo.CHARACTER_CODE_SET_ID !== `null` && typeof userInfo.CHARACTER_CODE_SET_ID === 'number') {
+                this.qccsid = userInfo.CHARACTER_CODE_SET_ID;
+              }
 
-              if (output.stdout) {
-                const [row] = Tools.db2Parse(output.stdout);
-                if (row && row.CHARACTER_CODE_SET_ID !== `null` && typeof row.CHARACTER_CODE_SET_ID === 'number') {
-                  this.qccsid = row.CHARACTER_CODE_SET_ID;
+              if (!this.qccsid || this.qccsid === CCSID_SYSVAL) {
+                const [systemCCSID] = await runSQL(`select SYSTEM_VALUE_NAME, CURRENT_NUMERIC_VALUE from QSYS2.SYSTEM_VALUE_INFO where SYSTEM_VALUE_NAME = 'QCCSID'`);
+                if (typeof systemCCSID.CURRENT_NUMERIC_VALUE === 'number') {
+                  this.qccsid = systemCCSID.CURRENT_NUMERIC_VALUE;
                 }
               }
 
-              if (this.qccsid === undefined || this.qccsid === CCSID_SYSVAL) {
-                statement = `select SYSTEM_VALUE_NAME, CURRENT_NUMERIC_VALUE from QSYS2.SYSTEM_VALUE_INFO where SYSTEM_VALUE_NAME = 'QCCSID'`;
-                output = await this.sendCommand({
-                  command: `LC_ALL=EN_US.UTF-8 system "call QSYS/QZDFMDB2 PARM('-d' '-i')"`,
-                  stdin: statement
-                });
+              try {
+                const [activeJob] = await runSQL(`Select DEFAULT_CCSID From Table(QSYS2.ACTIVE_JOB_INFO( JOB_NAME_FILTER => '*', DETAILED_INFO => 'ALL' ))`);
+                this.defaultCCSID = Number(activeJob.DEFAULT_CCSID);
+              }
+              catch (error) {
+                const [defaultCCSID] = (await this.runCommand({ command: "DSPJOB OPTION(*DFNA)" }))
+                  .stdout
+                  .split("\n")
+                  .filter(line => line.includes("DFTCCSID"));
 
-                if (output.stdout) {
-                  const rows = Tools.db2Parse(output.stdout);
-                  const ccsid = rows.find(row => row.SYSTEM_VALUE_NAME === `QCCSID`);
-                  if (ccsid && typeof ccsid.CURRENT_NUMERIC_VALUE === 'number') {
-                    this.qccsid = ccsid.CURRENT_NUMERIC_VALUE;
-                  }
+                const defaultCCSCID = Number(defaultCCSID.split("DFTCCSID").at(1)?.trim());
+                if (defaultCCSCID && !isNaN(defaultCCSCID)) {
+                  this.defaultCCSID = defaultCCSCID;
                 }
               }
 
@@ -639,24 +651,15 @@ export default class IBMi {
                 message: `Fetching local encoding values.`
               });
 
-              statement = `with VARIANTS ( HASH, AT, DOLLARSIGN ) as (`
+              const [variants] = await runSQL(`With VARIANTS ( HASH, AT, DOLLARSIGN ) as (`
                 + `  values ( cast( x'7B' as varchar(1) )`
                 + `         , cast( x'7C' as varchar(1) )`
                 + `         , cast( x'5B' as varchar(1) ) )`
                 + `)`
-                + `select HASH concat AT concat DOLLARSIGN as LOCAL`
-                + `  from VARIANTS; `;
-              output = await this.sendCommand({
-                command: `LC_ALL=EN_US.UTF-8 system "call QSYS/QZDFMDB2 PARM('-d' '-i')"`,
-                stdin: statement
-              });
-              if (output.stdout) {
-                const [row] = Tools.db2Parse(output.stdout);
-                if (row && row.LOCAL !== `null` && typeof row.LOCAL === 'string') {
-                  this.variantChars.local = row.LOCAL;
-                }
-              } else {
-                throw new Error(`There was an error running the SQL statement.`);
+                + `Select HASH concat AT concat DOLLARSIGN as LOCAL from VARIANTS`);
+
+              if (typeof variants.LOCAL === 'string' && variants.LOCAL !== `null`) {
+                this.variantChars.local = variants.LOCAL;
               }
             } catch (e) {
               // Oh well!
@@ -665,7 +668,6 @@ export default class IBMi {
           }
         } else {
           // Disable it if it's not found
-
           if (this.config.enableSQL) {
             progress.report({
               message: `SQL program not installed. Disabling SQL.`
@@ -866,7 +868,8 @@ export default class IBMi {
           },
           badDataAreasChecked: true,
           libraryListValidated: true,
-          pathChecked: true
+          pathChecked: true,
+          defaultCCSID: this.defaultCCSID
         });
 
         return {

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -676,6 +676,9 @@ export default class IBMi {
           }
         }
 
+        if((this.qccsid < 1 || this.qccsid === 65535)){
+          this.outputChannel?.appendLine(`\nUser CCSID is ${this.qccsid}; falling back to using default CCSID ${this.defaultCCSID}\n`);
+        }
 
         // give user option to set bash as default shell.
         if (this.remoteFeatures[`bash`]) {

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -589,7 +589,7 @@ export default class IBMiContent {
           rtrim(cast(a.system_table_name as char(10) for bit data)) AS SOURCE_FILE,
           rtrim(cast(b.system_table_member as char(10) for bit data)) as NAME,
           coalesce(rtrim(cast(b.source_type as varchar(10) for bit data)), '') as TYPE,
-          coalesce(rtrim(b.partition_text), '') as TEXT,
+          coalesce(rtrim(varchar(b.partition_text)), '') as TEXT,
           b.NUMBER_ROWS as LINES,
           extract(epoch from (b.CREATE_TIMESTAMP))*1000 as CREATED,
           extract(epoch from (b.LAST_SOURCE_UPDATE_TIMESTAMP))*1000 as CHANGED

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -45,6 +45,7 @@ export type CachedServerSettings = {
   badDataAreasChecked: boolean | null,
   libraryListValidated: boolean | null,
   pathChecked?: boolean
+  defaultCCSID: number | null;
 } | undefined;
 
 export class GlobalStorage extends Storage {

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -41,7 +41,7 @@ export namespace Tools {
         trimmed !== `?>`;
     });
 
-    if(!data[data.length-1]){
+    if (!data[data.length - 1]) {
       data.pop();
     }
 
@@ -243,20 +243,35 @@ export namespace Tools {
     }
   }
 
-  export function parseQSysPath(path: string) : QsysPath{
+  export function parseQSysPath(path: string): QsysPath {
     const parts = path.split('/');
-    if(parts.length > 3){
+    if (parts.length > 3) {
       return {
         asp: parts[0],
         library: parts[1],
         name: parts[2]
       }
     }
-    else{
+    else {
       return {
         library: parts[0],
         name: parts[1]
       }
     }
+  }
+
+  export function fixQZDFMDB2Statement(statement: string) {
+    return statement.split("\n").map(line => {
+      if (line.startsWith('@')) {
+        //- Escape all '
+        //- Remove any trailing ;
+        //- Put the command in a Call QSYS2.QCMDEXC statement
+        line = `Call QSYS2.QCMDEXC('${line.substring(1, line.endsWith(";") ? line.length - 1 : undefined).replaceAll("'", "''")}');`;
+      }
+
+      //Make each comment start on a new line
+      return line.replaceAll("--", "\n--");
+    }
+    ).join("\n");
   }
 }

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -37,6 +37,7 @@ export namespace Tools {
       const trimmed = line.trim();
       return trimmed !== `DB2>` &&
         !trimmed.startsWith(`DB20`) && // Notice messages
+        !/COMMAND .+ COMPLETED WITH EXIT STATUS \d+/.test(trimmed) && // @CL command execution output
         trimmed !== `?>`;
     });
 

--- a/src/testing/tools.ts
+++ b/src/testing/tools.ts
@@ -1,37 +1,53 @@
 import assert from "assert";
 import { TestSuite } from ".";
-import { instance } from "../instantiate";
 import { Tools } from "../api/Tools";
 
 export const ToolsSuite: TestSuite = {
   name: `Tools API tests`,
   tests: [
-    {name: `unqualifyPath (In a named library)`, test: async () => {
-      const qualifiedPath = `/QSYS.LIB/MYLIB.LIB/DEVSRC.FILE/THINGY.MBR`;
-      const simplePath = Tools.unqualifyPath(qualifiedPath);
-  
-      assert.strictEqual(simplePath, `/MYLIB/DEVSRC/THINGY.MBR`);
-    }},
+    {
+      name: `unqualifyPath (In a named library)`, test: async () => {
+        const qualifiedPath = `/QSYS.LIB/MYLIB.LIB/DEVSRC.FILE/THINGY.MBR`;
+        const simplePath = Tools.unqualifyPath(qualifiedPath);
 
-    {name: `unqualifyPath (In QSYS)`, test: async () => {
-      const qualifiedPath = `/QSYS.LIB/DEVSRC.FILE/THINGY.MBR`;
-      const simplePath = Tools.unqualifyPath(qualifiedPath);
-  
-      assert.strictEqual(simplePath, `/QSYS/DEVSRC/THINGY.MBR`);
-    }},
+        assert.strictEqual(simplePath, `/MYLIB/DEVSRC/THINGY.MBR`);
+      }
+    },
 
-    {name: `unqualifyPath (In an ASP)`, test: async () => {
-      const qualifiedPath = `/myasp/QSYS.LIB/MYLIB.LIB/DEVSRC.FILE/THINGY.MBR`;
-      const simplePath = Tools.unqualifyPath(qualifiedPath);
-  
-      assert.strictEqual(simplePath, `/myasp/MYLIB/DEVSRC/THINGY.MBR`);
-    }},
+    {
+      name: `unqualifyPath (In QSYS)`, test: async () => {
+        const qualifiedPath = `/QSYS.LIB/DEVSRC.FILE/THINGY.MBR`;
+        const simplePath = Tools.unqualifyPath(qualifiedPath);
 
-    {name: `sanitizeLibraryNames ($ and #)`, test: async () => {
-      const rawLibraryNames = [`QTEMP`, `#LIBRARY`, `My$lib`, `qsysinc`];
-      const sanitizedLibraryNames = Tools.sanitizeLibraryNames(rawLibraryNames);
-  
-      assert.deepStrictEqual(sanitizedLibraryNames, [`QTEMP`, `"#LIBRARY"`, `My\\$lib`, `qsysinc`]);
-    }},
+        assert.strictEqual(simplePath, `/QSYS/DEVSRC/THINGY.MBR`);
+      }
+    },
+
+    {
+      name: `unqualifyPath (In an ASP)`, test: async () => {
+        const qualifiedPath = `/myasp/QSYS.LIB/MYLIB.LIB/DEVSRC.FILE/THINGY.MBR`;
+        const simplePath = Tools.unqualifyPath(qualifiedPath);
+
+        assert.strictEqual(simplePath, `/myasp/MYLIB/DEVSRC/THINGY.MBR`);
+      }
+    },
+
+    {
+      name: `sanitizeLibraryNames ($ and #)`, test: async () => {
+        const rawLibraryNames = [`QTEMP`, `#LIBRARY`, `My$lib`, `qsysinc`];
+        const sanitizedLibraryNames = Tools.sanitizeLibraryNames(rawLibraryNames);
+
+        assert.deepStrictEqual(sanitizedLibraryNames, [`QTEMP`, `"#LIBRARY"`, `My\\$lib`, `qsysinc`]);
+      },
+    },
+    {
+      name: `fixQZDFMDB2Statement`, test: async () => {
+        let statement = Tools.fixQZDFMDB2Statement('Select * From MYTABLE -- This is a comment')
+        assert.deepStrictEqual(statement, 'Select * From MYTABLE \n-- This is a comment');
+
+        statement = Tools.fixQZDFMDB2Statement("@COMMAND LIB(QTEMP/*ALL) TEXT('Hello!');\nSelect * From QTEMP.MYTABLE -- This is mytable");
+        assert.deepStrictEqual(statement, "Call QSYS2.QCMDEXC('COMMAND LIB(QTEMP/*ALL) TEXT(''Hello!'')');\nSelect * From QTEMP.MYTABLE \n-- This is mytable");
+      }
+    }
   ]
 };

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -152,6 +152,7 @@ async function getRemoteSection() {
           `|IBM i OS|${osVersion?.OS || '?'}|`,
           `|Tech Refresh|${osVersion?.TR || '?'}|`,
           `|CCSID|${connection.qccsid || '?'}|`,
+          `|Default CCSID|${connection.defaultCCSID || '?'}|`,
           `|SQL|${config.enableSQL ? 'Enabled' : 'Disabled'}`,
           `|Source dates|${config.enableSourceDates ? 'Enabled' : 'Disabled'}`,
           '',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "ES2021",
+		"target": "ES2022",
 		"outDir": "out",
 		"lib": [
-			"ES2021"
+			"ES2022"
 		],
 		"forceConsistentCasingInFileNames": true,
 		"allowJs": true,


### PR DESCRIPTION
### Changes
Running SQL queries in a job whose CCSID is 65535 is bad. This PR tries to avoid conversion errors by running a `CHGJOB CCSID(xx)` command before every SQL statement run through `QZDFMDB2`.

In above command, `xx` is the job's default CCSID which is retrieved at connection time (once then cached).

Noticeable changes:
- Default CCSID is retrieved using the `ACTIVE_JOB` SQL service. If it fails, we fall back to using `DSPJOB OPTION(*DFNA)` and parsing the output.
- the `runSQL` method has been simplified a bit. The logic to sanitize the statement about to be run has been put in a separate method in `Tools` and there is a unit test to check it.
- `QZDFMDB2` allows to run CL command simply by prefixing them with `@`. It's convenient but it turns out such statements are always run in a separate job. So the method that sanitizes `QZDFMDB2` statements will also rewrite every `@command` into `Call QSYS2.QCMDEXC('command')`.
- A varchar conversion has been added in the `getMemberList` function to avoid a 1200 -> 65535 conversion issue, apparently unavoidable even with `CHGJOB`. The member's TEXT field is using CCSID 1200.
- The Default CCSID has been added to the `Report Issue` template. It is also reported in the Code for i output if QCCSID is bad.
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/11039186-81a3-4da3-9c93-38c8bc9f6064)


### Checklist
* [x] have tested my change