### PR TITLE
Stop letting the same document be opened twice

### DIFF
--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -277,7 +277,6 @@ export namespace Tools {
   function uriStringWithoutFragment(uri: vscode.Uri) {
     // To lowercase because the URI path is case-insensitive
     const baseUri = uri.scheme + `:` + uri.path;
-    const isCaseSensitive = (uri.scheme === `streamfile` && uri.path.startsWith(`/QOpenSys/`));
     const isCaseSensitive = (uri.scheme === `streamfile` && /^\/QOpenSys\//i.test(uri.path));
   }
 

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -266,8 +266,8 @@ export namespace Tools {
    * Without this, it's possible for the same document to be opened twice simply due to the readonly flag.
    */
   export function findExistingDocumentUri(uri: vscode.Uri) {
-    const bathUriString = uriStringWithoutFragment(uri);
-    const possibleDoc = vscode.workspace.textDocuments.find(document => uriStringWithoutFragment(document.uri) === bathUriString);
+    const baseUriString = uriStringWithoutFragment(uri);
+    const possibleDoc = vscode.workspace.textDocuments.find(document => uriStringWithoutFragment(document.uri) === baseUriString);
     if (possibleDoc) {
       return possibleDoc.uri;
     }

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -259,50 +259,51 @@ export namespace Tools {
       }
     }
   }
-}
 
-/**
- * We do this to find previously opened files with the same path, but different case OR readonly flags.
- * Without this, it's possible for the same document to be opened twice simply due to the readonly flag.
- */
-export function findExistingDocumentUri(uri: vscode.Uri) {
-  const bathUriString = uriStringWithoutFragment(uri);
-  const possibleDoc = vscode.workspace.textDocuments.find(document => uriStringWithoutFragment(document.uri) === bathUriString);
-  if (possibleDoc) {
-    return possibleDoc.uri;
-  }
 
-  return uri;
-}
-
-/**
- * We convert member to lowercase as members are case insensitive.
- */
-function uriStringWithoutFragment(uri: vscode.Uri) {
-  // To lowercase because the URI path is case-insensitive
-  const baseUri = uri.scheme + `:` + uri.path;
-  const isCaseSensitive = (uri.scheme === `streamfile` && uri.path.startsWith(`/QOpenSys/`));
-  return (isCaseSensitive ? baseUri : baseUri.toLowerCase());
-}
-
-/**
- * Fixes an SQL statement to make it compatible with db2 CLI program QZDFMDB2.
- * - Changes `@clCommand` statements into Call `QSYS2.QCMDEX('clCommand')` procedure calls
- * - Makes sure each comment (`--`) starts on a new line
- * @param statement the statement to fix
- * @returns statement compatible with QZDFMDB2
- */
-export function fixSQL(statement: string) {
-  return statement.split("\n").map(line => {
-    if (line.startsWith('@')) {
-      //- Escape all '
-      //- Remove any trailing ;
-      //- Put the command in a Call QSYS2.QCMDEXC statement
-      line = `Call QSYS2.QCMDEXC('${line.substring(1, line.endsWith(";") ? line.length - 1 : undefined).replaceAll("'", "''")}');`;
+  /**
+   * We do this to find previously opened files with the same path, but different case OR readonly flags.
+   * Without this, it's possible for the same document to be opened twice simply due to the readonly flag.
+   */
+  export function findExistingDocumentUri(uri: vscode.Uri) {
+    const bathUriString = uriStringWithoutFragment(uri);
+    const possibleDoc = vscode.workspace.textDocuments.find(document => uriStringWithoutFragment(document.uri) === bathUriString);
+    if (possibleDoc) {
+      return possibleDoc.uri;
     }
 
-    //Make each comment start on a new line
-    return line.replaceAll("--", "\n--");
+    return uri;
   }
-  ).join("\n");
+
+  /**
+   * We convert member to lowercase as members are case insensitive.
+   */
+  function uriStringWithoutFragment(uri: vscode.Uri) {
+    // To lowercase because the URI path is case-insensitive
+    const baseUri = uri.scheme + `:` + uri.path;
+    const isCaseSensitive = (uri.scheme === `streamfile` && uri.path.startsWith(`/QOpenSys/`));
+    return (isCaseSensitive ? baseUri : baseUri.toLowerCase());
+  }
+
+  /**
+   * Fixes an SQL statement to make it compatible with db2 CLI program QZDFMDB2.
+   * - Changes `@clCommand` statements into Call `QSYS2.QCMDEX('clCommand')` procedure calls
+   * - Makes sure each comment (`--`) starts on a new line
+   * @param statement the statement to fix
+   * @returns statement compatible with QZDFMDB2
+   */
+  export function fixSQL(statement: string) {
+    return statement.split("\n").map(line => {
+      if (line.startsWith('@')) {
+        //- Escape all '
+        //- Remove any trailing ;
+        //- Put the command in a Call QSYS2.QCMDEXC statement
+        line = `Call QSYS2.QCMDEXC('${line.substring(1, line.endsWith(";") ? line.length - 1 : undefined).replaceAll("'", "''")}');`;
+      }
+
+      //Make each comment start on a new line
+      return line.replaceAll("--", "\n--");
+    }
+    ).join("\n");
+  }
 }

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -259,3 +259,22 @@ export namespace Tools {
     }
   }
 }
+
+/**
+ * We do this to find previously opened files with the same path, but different case OR readonly flags.
+ * Without this, it's possible for the same document to be opened twice simply due to the readonly flag.
+ */
+export function findExistingDocumentUri(uri: vscode.Uri) {
+  const bathUriString = uriStringWithoutFragment(uri).toLowerCase();
+  const possibleDoc = vscode.workspace.textDocuments.find(document => uriStringWithoutFragment(document.uri).toLowerCase() === bathUriString);
+  if (possibleDoc) {
+    return possibleDoc.uri;
+  }
+
+  return uri;
+}
+
+function uriStringWithoutFragment(uri: vscode.Uri) {
+  // To lowercase because the URI path is case-insensitive
+  return uri.scheme + `:` + uri.path;
+}

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -280,5 +280,6 @@ export function findExistingDocumentUri(uri: vscode.Uri) {
 function uriStringWithoutFragment(uri: vscode.Uri) {
   // To lowercase because the URI path is case-insensitive
   const baseUri = uri.scheme + `:` + uri.path;
-  return (uri.scheme === `member` ? baseUri.toLowerCase() : baseUri);
+  const isCaseSensitive = (uri.scheme === `streamfile` && uri.path.startsWith(`/QOpenSys/`));
+  return (isCaseSensitive ? baseUri : baseUri.toLowerCase());
 }

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -278,6 +278,7 @@ export namespace Tools {
     // To lowercase because the URI path is case-insensitive
     const baseUri = uri.scheme + `:` + uri.path;
     const isCaseSensitive = (uri.scheme === `streamfile` && /^\/QOpenSys\//i.test(uri.path));
+    return (isCaseSensitive ? baseUri : baseUri.toLowerCase());
   }
 
   /**

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -265,8 +265,8 @@ export namespace Tools {
  * Without this, it's possible for the same document to be opened twice simply due to the readonly flag.
  */
 export function findExistingDocumentUri(uri: vscode.Uri) {
-  const bathUriString = uriStringWithoutFragment(uri).toLowerCase();
-  const possibleDoc = vscode.workspace.textDocuments.find(document => uriStringWithoutFragment(document.uri).toLowerCase() === bathUriString);
+  const bathUriString = uriStringWithoutFragment(uri);
+  const possibleDoc = vscode.workspace.textDocuments.find(document => uriStringWithoutFragment(document.uri) === bathUriString);
   if (possibleDoc) {
     return possibleDoc.uri;
   }
@@ -274,7 +274,11 @@ export function findExistingDocumentUri(uri: vscode.Uri) {
   return uri;
 }
 
+/**
+ * We convert member to lowercase as members are case insensitive.
+ */
 function uriStringWithoutFragment(uri: vscode.Uri) {
   // To lowercase because the URI path is case-insensitive
-  return uri.scheme + `:` + uri.path;
+  const baseUri = uri.scheme + `:` + uri.path;
+  return (uri.scheme === `member` ? baseUri.toLowerCase() : baseUri);
 }

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -268,11 +268,7 @@ export namespace Tools {
   export function findExistingDocumentUri(uri: vscode.Uri) {
     const baseUriString = uriStringWithoutFragment(uri);
     const possibleDoc = vscode.workspace.textDocuments.find(document => uriStringWithoutFragment(document.uri) === baseUriString);
-    if (possibleDoc) {
-      return possibleDoc.uri;
-    }
-
-    return uri;
+    return possibleDoc?.uri || uri;
   }
 
   /**

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -282,7 +282,7 @@ export namespace Tools {
     // To lowercase because the URI path is case-insensitive
     const baseUri = uri.scheme + `:` + uri.path;
     const isCaseSensitive = (uri.scheme === `streamfile` && uri.path.startsWith(`/QOpenSys/`));
-    return (isCaseSensitive ? baseUri : baseUri.toLowerCase());
+    const isCaseSensitive = (uri.scheme === `streamfile` && /^\/QOpenSys\//i.test(uri.path));
   }
 
   /**

--- a/src/api/errors/diagnostics.ts
+++ b/src/api/errors/diagnostics.ts
@@ -5,6 +5,7 @@ import { parseErrors } from "./parser";
 import { FileError } from "../../typings";
 import { getEvfeventFiles } from "../local/actions";
 import { GlobalConfiguration } from "../Configuration";
+import { findExistingDocumentUri } from "../Tools";
 
 const ileDiagnostics = vscode.languages.createDiagnosticCollection(`ILE`);
 
@@ -168,9 +169,9 @@ export async function handleEvfeventLines(lines: string[], instance: Instance, e
         }
       } else {
         if (file.startsWith(`/`))
-          ileDiagnostics.set(vscode.Uri.from({ scheme: `streamfile`, path: file }), diagnostics);
+          ileDiagnostics.set(findExistingDocumentUri(vscode.Uri.from({ scheme: `streamfile`, path: file })), diagnostics);
         else {
-          const memberUri = vscode.Uri.from({ scheme: `member`, path: `/${asp}${file}${evfeventInfo.extension ? `.` + evfeventInfo.extension : ``}` });
+          const memberUri = findExistingDocumentUri(vscode.Uri.from({ scheme: `member`, path: `/${asp}${file}${evfeventInfo.extension ? `.` + evfeventInfo.extension : ``}` }));
           ileDiagnostics.set(memberUri, diagnostics);
         }
       }

--- a/src/api/errors/diagnostics.ts
+++ b/src/api/errors/diagnostics.ts
@@ -5,7 +5,7 @@ import { parseErrors } from "./parser";
 import { FileError } from "../../typings";
 import { getEvfeventFiles } from "../local/actions";
 import { GlobalConfiguration } from "../Configuration";
-import { findExistingDocumentUri } from "../Tools";
+import { Tools } from "../Tools";
 
 const ileDiagnostics = vscode.languages.createDiagnosticCollection(`ILE`);
 
@@ -169,9 +169,9 @@ export async function handleEvfeventLines(lines: string[], instance: Instance, e
         }
       } else {
         if (file.startsWith(`/`))
-          ileDiagnostics.set(findExistingDocumentUri(vscode.Uri.from({ scheme: `streamfile`, path: file })), diagnostics);
+          ileDiagnostics.set(Tools.findExistingDocumentUri(vscode.Uri.from({ scheme: `streamfile`, path: file })), diagnostics);
         else {
-          const memberUri = findExistingDocumentUri(vscode.Uri.from({ scheme: `member`, path: `/${asp}${file}${evfeventInfo.extension ? `.` + evfeventInfo.extension : ``}` }));
+          const memberUri = Tools.findExistingDocumentUri(vscode.Uri.from({ scheme: `member`, path: `/${asp}${file}${evfeventInfo.extension ? `.` + evfeventInfo.extension : ``}` }));
           ileDiagnostics.set(memberUri, diagnostics);
         }
       }

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -126,7 +126,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       if (existingUri) {
         const existingOptions = parseFSOptions(existingUri);
         if (existingOptions.readonly !== options.readonly) {
-          vscode.window.showWarningMessage(`The file is already open in another mode.`);
+          vscode.window.showWarningMessage(`The file is already opened in another mode.`);
           vscode.window.showTextDocument(existingUri);
           return false;
         }

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -1,4 +1,4 @@
-import { Tools, findExistingDocumentUri } from './api/Tools';
+import { Tools } from './api/Tools';
 
 import path, { dirname } from 'path';
 import * as vscode from "vscode";
@@ -121,7 +121,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
 
       const uri = getUriFromPath(path, options);
 
-      const existingUri = findExistingDocumentUri(uri);
+      const existingUri = Tools.findExistingDocumentUri(uri);
 
       if (existingUri) {
         const existingOptions = parseFSOptions(existingUri);

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -1,4 +1,4 @@
-import { Tools } from './api/Tools';
+import { Tools, findExistingDocumentUri } from './api/Tools';
 
 import path, { dirname } from 'path';
 import * as vscode from "vscode";
@@ -8,7 +8,7 @@ import Instance from "./api/Instance";
 import { Search } from "./api/Search";
 import { Terminal } from './api/Terminal';
 import { refreshDiagnosticsFromServer } from './api/errors/diagnostics';
-import { QSysFS, getUriFromPath } from "./filesystems/qsys/QSysFs";
+import { QSysFS, getUriFromPath, parseFSOptions } from "./filesystems/qsys/QSysFs";
 import { init as clApiInit } from "./languages/clle/clApi";
 import * as clRunner from "./languages/clle/clRunner";
 import { initGetNewLibl } from "./languages/clle/getnewlibl";
@@ -120,6 +120,18 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       }
 
       const uri = getUriFromPath(path, options);
+
+      const existingUri = findExistingDocumentUri(uri);
+
+      if (existingUri) {
+        const existingOptions = parseFSOptions(existingUri);
+        if (existingOptions.readonly !== options.readonly) {
+          vscode.window.showWarningMessage(`The file is already open in another mode.`);
+          vscode.window.showTextDocument(existingUri);
+          return false;
+        }
+      }
+
       try {
         await vscode.commands.executeCommand(`vscode.openWith`, uri, 'default', { selection: options.position } as vscode.TextDocumentShowOptions);
 


### PR DESCRIPTION
### Changes

* If you try and open a doucment, but already have it open in the oppisite edit mode, then you will get a warning and that open document will take focus.
* Clicking on an error should no longer open up a new document will try to use existing document URIs to inherit the readonly mode.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
