### PR TITLE
Fix context menu items wording in IFS browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1463,7 +1463,7 @@
 			{
 				"command": "code-for-ibmi.refreshObjectBrowser",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Refresh Object Browser",
+				"title": "Refresh",
 				"category": "IBM i",
 				"icon": "$(refresh)"
 			},

--- a/package.json
+++ b/package.json
@@ -1244,20 +1244,20 @@
 			{
 				"command": "code-for-ibmi.refreshIFSBrowser",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Refresh IFS List",
+				"title": "Refresh",
 				"category": "IBM i",
 				"icon": "$(refresh)"
 			},
 			{
 				"command": "code-for-ibmi.refreshIFSBrowserItem",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Refresh IFS List item",
+				"title": "Refresh List item",
 				"category": "IBM i"
 			},
 			{
 				"command": "code-for-ibmi.revealInIFSBrowser",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Reveal IFS Browser Item",
+				"title": "Reveal Browser Item",
 				"category": "IBM i"
 			},
 			{
@@ -1270,7 +1270,7 @@
 			{
 				"command": "code-for-ibmi.deleteIFS",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Delete Object",
+				"title": "Delete",
 				"category": "IBM i"
 			},
 			{
@@ -1282,7 +1282,7 @@
 			{
 				"command": "code-for-ibmi.moveIFS",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Rename or Move Object",
+				"title": "Rename/Move",
 				"category": "IBM i",
 				"icon": "$(files)"
 			},
@@ -1296,21 +1296,21 @@
 			{
 				"command": "code-for-ibmi.searchIFS",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Search Directory",
+				"title": "Search",
 				"category": "IBM i",
 				"icon": "$(search)"
 			},
 			{
 				"command": "code-for-ibmi.createDirectory",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Create Directory",
+				"title": "New Directory",
 				"category": "IBM i",
 				"icon": "$(new-folder)"
 			},
 			{
 				"command": "code-for-ibmi.createStreamfile",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Create Streamfile",
+				"title": "New File",
 				"category": "IBM i",
 				"icon": "$(new-file)"
 			},
@@ -1344,49 +1344,49 @@
 			{
 				"command": "code-for-ibmi.addIFSShortcut",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Add IFS Shortcut",
+				"title": "Add Shortcut",
 				"category": "IBM i",
 				"icon": "$(add)"
 			},
 			{
 				"command": "code-for-ibmi.removeIFSShortcut",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Remove IFS Shortcut",
+				"title": "Remove Shortcut",
 				"category": "IBM i",
 				"icon": "$(remove)"
 			},
 			{
 				"command": "code-for-ibmi.sortIFSShortcuts",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Sort IFS Shortcuts",
+				"title": "Sort Shortcuts",
 				"category": "IBM i",
 				"icon": "$(list-ordered)"
 			},
 			{
 				"command": "code-for-ibmi.moveIFSShortcutDown",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Move IFS Shortcut Down",
+				"title": "Move Shortcut Down",
 				"category": "IBM i",
 				"icon": "$(arrow-down)"
 			},
 			{
 				"command": "code-for-ibmi.moveIFSShortcutUp",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Move IFS Shortcut Up",
+				"title": "Move Shortcut Up",
 				"category": "IBM i",
 				"icon": "$(arrow-up)"
 			},
 			{
 				"command": "code-for-ibmi.moveIFSShortcutToTop",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Move IFS Shortcut to Top",
+				"title": "Move Shortcut to Top",
 				"category": "IBM i",
 				"icon": "$(arrow-up)"
 			},
 			{
 				"command": "code-for-ibmi.moveIFSShortcutToBottom",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Move IFS Shortcut to Bottom",
+				"title": "Move Shortcut to Bottom",
 				"category": "IBM i",
 				"icon": "$(arrow-up)"
 			},
@@ -1569,7 +1569,7 @@
 			},
 			{
 				"command": "code-for-ibmi.openTerminalHere",
-				"title": "Open terminal here",
+				"title": "Open Terminal Here",
 				"category": "IBM i"
 			},
 			{
@@ -2340,35 +2340,35 @@
 					"when": "view == ifsBrowser && !listMultiSelection && viewItem == streamfile",
 					"group": "1_workspace@1"
 				},
+        {
+          "command": "code-for-ibmi.createStreamfile",
+          "when": "view == ifsBrowser && !listMultiSelection && viewItem =~ /^directory.*$/",
+          "group": "2_ifsStuff@1"
+        },
+        {
+          "command": "code-for-ibmi.createDirectory",
+          "when": "view == ifsBrowser && !listMultiSelection && viewItem =~ /^directory.*$/",
+          "group": "2_ifsStuff@2"
+        },
+        {
+          "command": "code-for-ibmi.copyIFS",
+          "when": "view == ifsBrowser && !listMultiSelection && !(viewItem =~ /^.*_protected$/)",
+          "group": "2_ifsStuff@3"
+        },
+        {
+          "command": "code-for-ibmi.moveIFS",
+          "when": "view == ifsBrowser && !listMultiSelection && !(viewItem =~ /^.*_protected$/)",
+          "group": "2_ifsStuff@4"
+        },
 				{
 					"command": "code-for-ibmi.deleteIFS",
 					"when": "view == ifsBrowser && !(viewItem =~ /^.*_protected$/)",
-					"group": "2_ifsStuff@4"
-				},
-				{
-					"command": "code-for-ibmi.moveIFS",
-					"when": "view == ifsBrowser && !listMultiSelection && !(viewItem =~ /^.*_protected$/)",
-					"group": "2_ifsStuff@2"
-				},
-				{
-					"command": "code-for-ibmi.copyIFS",
-					"when": "view == ifsBrowser && !listMultiSelection && !(viewItem =~ /^.*_protected$/)",
-					"group": "2_ifsStuff@2"
-				},
-				{
-					"command": "code-for-ibmi.createDirectory",
-					"when": "view == ifsBrowser && !listMultiSelection && viewItem =~ /^directory.*$/",
-					"group": "2_ifsStuff@2"
+					"group": "2_ifsStuff@5"
 				},
 				{
 					"submenu": "code-for-ibmi.sortIFSFiles",
 					"when": "view == ifsBrowser && !listMultiSelection",
 					"group": "5_ifsStuff@1"
-				},
-				{
-					"command": "code-for-ibmi.createStreamfile",
-					"when": "view == ifsBrowser && !listMultiSelection && viewItem =~ /^directory.*$/",
-					"group": "2_ifsStuff@1"
 				},
 				{
 					"command": "code-for-ibmi.searchIFS",
@@ -2385,15 +2385,15 @@
 					"when": "view == ifsBrowser && !listMultiSelection && viewItem =~ /^directory.*$/",
 					"group": "3_ifsStuff@3"
 				},
+        {
+          "command": "code-for-ibmi.createStreamfile",
+          "when": "view == ifsBrowser && !listMultiSelection && viewItem =~ /^shortcut.*$/",
+          "group": "2_ifsStuff@1"
+        },
 				{
 					"command": "code-for-ibmi.createDirectory",
 					"when": "view == ifsBrowser && !listMultiSelection && viewItem =~ /^shortcut.*$/",
 					"group": "2_ifsStuff@2"
-				},
-				{
-					"command": "code-for-ibmi.createStreamfile",
-					"when": "view == ifsBrowser && !listMultiSelection && viewItem =~ /^shortcut.*$/",
-					"group": "2_ifsStuff@1"
 				},
 				{
 					"command": "code-for-ibmi.searchIFS",


### PR DESCRIPTION
### Changes

This PR will make subtle changes to the wording of context menu items in the IFS browser, to be more compliant to the VS Code File Explorer and more concise.

IFS shortcut - before and after:
![image](https://github.com/codefori/vscode-ibmi/assets/13275072/1e00eaad-313d-4f31-910f-f48d65c47ebe) => ![image](https://github.com/codefori/vscode-ibmi/assets/13275072/dc120b2c-9431-4a3d-b06e-c3f146f8de89)


IFS directory - before and after:
![image](https://github.com/codefori/vscode-ibmi/assets/13275072/297263f3-51c8-4216-83e4-c51c596442eb) => ![image](https://github.com/codefori/vscode-ibmi/assets/13275072/e405f2b8-4418-4d85-adef-9ed3956b4819)

Also, in Object browser the refresh button text has been changed from "Refresh Objects Browser" to simply "Refresh".


### Checklist

* [x] have tested my change
