### PR TITLE
Fix removing (temp) IFS directories

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -429,7 +429,7 @@ export default class IBMi {
             })
 
           this.sendCommand({
-            command: `rm -f ${path.posix.join(this.config.tempDir, `vscodetemp*`)}`
+            command: `rm -rf ${path.posix.join(this.config.tempDir, `vscodetemp*`)}`
           })
             .then(result => {
               // All good!

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -169,7 +169,7 @@ export default class IBMiContent {
           switch (messageID) {
             case "CPDA08A":
               //We need to try again after we delete the temp remote
-              const result = await this.ibmi.sendCommand({ command: `rm -f ${tempRmt}`, directory: `.` });
+              const result = await this.ibmi.sendCommand({ command: `rm -rf ${tempRmt}`, directory: `.` });
               retry = !result.code || result.code === 0;
               break;
             case "CPFA0A9":
@@ -344,7 +344,7 @@ export default class IBMiContent {
 
         if (this.config.autoClearTempData) {
           Promise.allSettled([
-            this.ibmi.sendCommand({ command: `rm -f ${tempRmt}`, directory: `.` }),
+            this.ibmi.sendCommand({ command: `rm -rf ${tempRmt}`, directory: `.` }),
             deleteTable ? this.ibmi.runCommand({ command: `DLTOBJ OBJ(${library}/${file}) OBJTYPE(*FILE)`, noLibList: true }) : Promise.resolve()
           ]);
         }

--- a/src/api/local/deployment.ts
+++ b/src/api/local/deployment.ts
@@ -198,7 +198,7 @@ export namespace Deployment {
   export async function deleteFiles(parameters: DeploymentParameters, toDelete: string[]) {
     if (toDelete.length) {
       Deployment.deploymentLog.appendLine(`\nDeleted:\n\t${toDelete.join('\n\t')}\n`);
-      await Deployment.getConnection().sendCommand({ directory: parameters.remotePath, command: `rm -f ${toDelete.join(' ')}` });
+      await Deployment.getConnection().sendCommand({ directory: parameters.remotePath, command: `rm -rf ${toDelete.join(' ')}` });
     }
   }
 


### PR DESCRIPTION
### Changes

When removing temp directories in IFS, the `rm` would fail because it won't delete directories without the `-r` flag (recursive):

![image](https://github.com/codefori/vscode-ibmi/assets/13275072/bb461e2e-9653-472f-a00d-12895d05e77c)

The `-r` flag has been added to the `rm` commands.

### Checklist

* [x] have tested my change
