### PR TITLE
`getTable` API: Make member optional

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -315,7 +315,7 @@ export default class IBMiContent {
    * @param member Will default to file provided
    * @param deleteTable Will delete the table after download
    */
-  async getTable(library: string, file: string, member: string, deleteTable?: boolean): Promise<Tools.DB2Row[]> {
+  async getTable(library: string, file: string, member?: string, deleteTable?: boolean): Promise<Tools.DB2Row[]> {
     if (!member) member = file; //Incase mbr is the same file
 
     if (file === member && this.config.enableSQL) {


### PR DESCRIPTION
### Changes

Makes the member parameter on the `getTable` API optional, and assumes it to be the same as the table if not provided.

It used to work like this before, so not sure when this change was made.