### PR TITLE
Trim whitespaces in object filter's library and object field

### DIFF
--- a/src/api/Filter.ts
+++ b/src/api/Filter.ts
@@ -19,7 +19,7 @@ export function parseFilter(filterString?: string, type?: FilterType): Filter {
         }
         break;
       default:
-        const filters = filterString.split(',');
+        const filters = filterString.split(',').map(f => f.trim());
         if (!filters.some(filter => /^\*(?:ALL)?$/.test(filter)) && (filters.length > 1 || filters[0].includes('*'))) { //*, *ALL or a single value with no '*' is not a filter
           predicates.push(...filters
             .map(filter => escapeStringRegexp(filter))

--- a/src/testing/filter.ts
+++ b/src/testing/filter.ts
@@ -40,6 +40,14 @@ export const FilterSuite: TestSuite = {
       }
     },
     {
+      name: `Multiple simples with whitespaces`, test: async () => {
+        const filter = parseFilter(" SQL*,*CMD  ,  *USR*  ", 'simple');
+        const filtered = QSYSINCS.filter(t => filter.test(t));
+        assert.strictEqual(filtered.length, 20);
+        assert.strictEqual(filtered.filter(t => t.startsWith("SQL") || t.endsWith("CMD") || t.includes("USR")).length, filtered.length);
+      }
+    },
+    {
       name: `RegExp`, test: async () => {
         const filter = parseFilter("^[^E].*CHG.*$", 'regex');
         const filtered = QSYSINCS.filter(t => filter.test(t));

--- a/src/webviews/filters/index.ts
+++ b/src/webviews/filters/index.ts
@@ -66,22 +66,21 @@ export async function editFilter(filter?: ConnectionConfiguration.ObjectFilters,
         //In case we need to play with the data
         switch (key) {
           case `name`:
-          case `filterType`:
-          case `library`:
+          case `filterType`:          
             data[key] = String(data[key]).trim();
             break;
           case `types`:
             data[key] = String(data[key]).split(`,`).map(item => item.trim().toUpperCase()).filter(item => item !== ``);
             break;
+          case `library`:
           case `object`:
             data[key] = (String(data[key].trim()) || `*`)
               .split(',')
-              .map(o => useRegexFilters ? o : o.toLocaleUpperCase())
+              .map(o => useRegexFilters ? o : o.toLocaleUpperCase().trim())
               .filter(Tools.distinct)
               .join(",");
             break;
-          case `member`:
-          case `member`:
+          case `member`:          
           case `memberType`:
             data[key] = String(data[key].trim()) || `*`;
             break;

--- a/src/webviews/filters/index.ts
+++ b/src/webviews/filters/index.ts
@@ -76,7 +76,7 @@ export async function editFilter(filter?: ConnectionConfiguration.ObjectFilters,
           case `object`:
             data[key] = (String(data[key].trim()) || `*`)
               .split(',')
-              .map(o => useRegexFilters ? o : o.toLocaleUpperCase().trim())
+              .map(o => useRegexFilters ? o : o.toLocaleUpperCase())
               .filter(Tools.distinct)
               .join(",");
             break;


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/1847

Whitespaces in object filter's `library` and `object` fields were not trimmed, resulting in the filtering not working correctly.

### Checklist
* [x] have tested my change