### PR TITLE
Allow dragging members to IFS directories

### DIFF
--- a/src/locale/ids/da.ts
+++ b/src/locale/ids/da.ts
@@ -116,6 +116,8 @@ export const da: Locale = {
   'ifsBrowser.doSearchInStreamfiles.progressMessage': `'{0}' i {1}.`,
   'ifsBrowser.doSearchInStreamfiles.noResults': `Ingen resultater blev fundet ved søgning efter '{0}' i {1}.`,
   'ifsBrowser.doSearchInStreamfiles.errorMessage': `Fejl ved søgning i filer.`,
+  'ifsBrowser.copyToStreamfile.infoMessage': `{0} member(s) kopieret til streamfile(s) i {1}.`,
+  'ifsBrowser.copyToStreamfile.failed': `Fejl ved kopiering af member(s) til {0}: {1}`,
   // LibraryListView:
   'LibraryListView.changeCurrentLibrary.currentlyActive': `Nuværende`,
   'LibraryListView.changeCurrentLibrary.recentlyUsed': `Tidligere`,

--- a/src/locale/ids/en.ts
+++ b/src/locale/ids/en.ts
@@ -116,6 +116,8 @@ export const en: Locale = {
   'ifsBrowser.doSearchInStreamfiles.progressMessage': `'{0}' in {1}.`,
   'ifsBrowser.doSearchInStreamfiles.noResults': `No results found searching for '{0}' in {1}.`,
   'ifsBrowser.doSearchInStreamfiles.errorMessage': `Error searching streamfiles.`,
+  'ifsBrowser.copyToStreamfile.infoMessage': `{0} member(s) copied to streamfile(s) in {1}.`,
+  'ifsBrowser.copyToStreamfile.failed': `Error copying member(s) to {0}: {1}`,
   // LibraryListView:
   'LibraryListView.changeCurrentLibrary.currentlyActive': `Currently active`,
   'LibraryListView.changeCurrentLibrary.recentlyUsed': `Recently used`,

--- a/src/locale/ids/fr.ts
+++ b/src/locale/ids/fr.ts
@@ -116,6 +116,8 @@ export const fr: Locale = {
   'ifsBrowser.doSearchInStreamfiles.progressMessage': `'{0}' dans {1}.`,
   'ifsBrowser.doSearchInStreamfiles.noResults': `Aucun résultat trouvé pour '{0}' dans {1}.`,
   'ifsBrowser.doSearchInStreamfiles.errorMessage': `Erreur lors de la recherche de fichiers.`,
+  'ifsBrowser.copyToStreamfile.infoMessage': `{0} member(s) copied to streamfile(s) in {1}.`,
+  'ifsBrowser.copyToStreamfile.failed': `Error copying member(s) to {0}: {1}`,
   // LibraryListView:
   'LibraryListView.changeCurrentLibrary.currentlyActive': `Active`,
   'LibraryListView.changeCurrentLibrary.recentlyUsed': `Utilisé récemment`,

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -200,6 +200,7 @@ export type IBMiMessages = {
   messages: IBMiMessage[]
   findId(id: string): IBMiMessage | undefined
 }
+export const OBJECT_BROWSER_MIMETYPE = "application/vnd.code.tree.objectbrowser";
 export const IFS_BROWSER_MIMETYPE = "application/vnd.code.tree.ifsbrowser";
 
 export type OpenEditableOptions = QsysFsOptions & { position?: Range };

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -9,7 +9,7 @@ import { GlobalStorage } from "../api/Storage";
 import { Tools } from "../api/Tools";
 import { instance, setSearchResults } from "../instantiate";
 import { t } from "../locale";
-import { BrowserItem, BrowserItemParameters, FocusOptions, IFSFile, IFS_BROWSER_MIMETYPE, WithPath } from "../typings";
+import { BrowserItem, BrowserItemParameters, CommandResult, FocusOptions, IFSFile, IFS_BROWSER_MIMETYPE, OBJECT_BROWSER_MIMETYPE, WithPath } from "../typings";
 
 const URI_LIST_MIMETYPE = "text/uri-list";
 const URI_LIST_SEPARATOR = "\r\n";
@@ -196,7 +196,7 @@ class ErrorItem extends BrowserItem {
 
 class IFSBrowserDragAndDrop implements vscode.TreeDragAndDropController<IFSItem> {
   readonly dragMimeTypes = [URI_LIST_MIMETYPE, IFS_BROWSER_MIMETYPE];
-  readonly dropMimeTypes = [URI_LIST_MIMETYPE, IFS_BROWSER_MIMETYPE];
+  readonly dropMimeTypes = [URI_LIST_MIMETYPE, IFS_BROWSER_MIMETYPE, OBJECT_BROWSER_MIMETYPE];
 
   handleDrag(source: readonly IFSItem[], dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken) {
     dataTransfer.set(IFS_BROWSER_MIMETYPE, new vscode.DataTransferItem(source));
@@ -209,8 +209,12 @@ class IFSBrowserDragAndDrop implements vscode.TreeDragAndDropController<IFSItem>
     if (target) {
       const toDirectory = (target.file.type === "streamfile" ? target.parent : target) as IFSDirectoryItem;
       const ifsBrowserItems = dataTransfer.get(IFS_BROWSER_MIMETYPE);
+      const objectBrowserItems = dataTransfer.get(OBJECT_BROWSER_MIMETYPE);
       if (ifsBrowserItems) {
         this.moveOrCopyItems(ifsBrowserItems.value as IFSItem[], toDirectory)
+      } else if (objectBrowserItems) {
+          const memberUris = (await objectBrowserItems.asString()).split(URI_LIST_SEPARATOR).map(uri => vscode.Uri.parse(uri));
+          this.CopyMembers(memberUris, toDirectory)
       }
       else {
         const explorerItems = dataTransfer.get(URI_LIST_MIMETYPE);
@@ -262,6 +266,31 @@ class IFSBrowserDragAndDrop implements vscode.TreeDragAndDropController<IFSItem>
         } else {
           vscode.window.showErrorMessage(t(`ifsBrowser.uploadStreamfile.${action}.failed`, toDirectory.path, result.stderr));
         }
+      }
+    }
+  }
+
+  private async CopyMembers(memberUris: vscode.Uri[], toDirectory: IFSDirectoryItem) {
+    const connection = instance.getConnection();
+    if (connection && memberUris && memberUris.length) {
+      try {
+        for (let uri of memberUris) {
+          let result;
+          const member = connection.parserMemberPath(uri.path);
+          const command: string = `CPYTOSTMF FROMMBR('${Tools.qualifyPath(member.library, member.file, member.name, member.asp)}') TOSTMF('${toDirectory.path}/${member.basename.toLocaleLowerCase()}') STMFCCSID(1208) ENDLINFMT(*LF)`;
+          result = await connection.runCommand({
+            command: command,
+            noLibList: true
+          });
+          if (result.code !== 0) {
+            throw(t(`ifsBrowser.copyToStreamfile.failed`, toDirectory.path, result!.stderr));
+          }
+        };
+
+        vscode.window.showInformationMessage(t(`ifsBrowser.copyToStreamfile.infoMessage`, memberUris.length, toDirectory.path));
+        toDirectory.refresh();
+      } catch (e: any) {
+        vscode.window.showErrorMessage(e || e.text);
       }
     }
   }

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -214,7 +214,7 @@ class IFSBrowserDragAndDrop implements vscode.TreeDragAndDropController<IFSItem>
         this.moveOrCopyItems(ifsBrowserItems.value as IFSItem[], toDirectory)
       } else if (objectBrowserItems) {
           const memberUris = (await objectBrowserItems.asString()).split(URI_LIST_SEPARATOR).map(uri => vscode.Uri.parse(uri));
-          this.CopyMembers(memberUris, toDirectory)
+          this.copyMembers(memberUris, toDirectory)
       }
       else {
         const explorerItems = dataTransfer.get(URI_LIST_MIMETYPE);
@@ -270,7 +270,7 @@ class IFSBrowserDragAndDrop implements vscode.TreeDragAndDropController<IFSItem>
     }
   }
 
-  private async CopyMembers(memberUris: vscode.Uri[], toDirectory: IFSDirectoryItem) {
+  private async copyMembers(memberUris: vscode.Uri[], toDirectory: IFSDirectoryItem) {
     const connection = instance.getConnection();
     if (connection && memberUris && memberUris.length) {
       try {

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -12,8 +12,10 @@ import { Tools } from "../api/Tools";
 import { getMemberUri } from "../filesystems/qsys/QSysFs";
 import { instance, setSearchResults } from "../instantiate";
 import { t } from "../locale";
-import { BrowserItem, BrowserItemParameters, CommandResult, FilteredItem, FocusOptions, IBMiMember, IBMiObject, MemberItem, ObjectItem, SourcePhysicalFileItem } from "../typings";
+import { BrowserItem, BrowserItemParameters, CommandResult, FilteredItem, FocusOptions, IBMiMember, IBMiObject, MemberItem, OBJECT_BROWSER_MIMETYPE, ObjectItem, SourcePhysicalFileItem } from "../typings";
 import { editFilter } from "../webviews/filters";
+
+const URI_LIST_SEPARATOR = "\r\n";
 
 const writeFileAsync = util.promisify(fs.writeFile);
 const objectNamesLower = () => GlobalConfiguration.get<boolean>(`ObjectBrowser.showNamesInLowercase`);
@@ -320,12 +322,25 @@ class ObjectBrowserMemberItem extends ObjectBrowserItem implements MemberItem {
   }
 }
 
+class ObjectBrowserMemberItemDragAndDrop implements vscode.TreeDragAndDropController<ObjectBrowserMemberItem> {
+  readonly dragMimeTypes = [OBJECT_BROWSER_MIMETYPE];
+  readonly dropMimeTypes = [];
+
+  handleDrag(source: readonly ObjectBrowserMemberItem[], dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken) {
+    dataTransfer.set(OBJECT_BROWSER_MIMETYPE, new vscode.DataTransferItem(source.filter(item => item.resourceUri?.scheme === `member`)
+    .map(item => item.resourceUri)
+    .join(URI_LIST_SEPARATOR)));
+  }
+}
+
 export function initializeObjectBrowser(context: vscode.ExtensionContext) {
   const objectBrowser = new ObjectBrowser();
   const objectTreeViewer = vscode.window.createTreeView(
     `objectBrowser`, {
     treeDataProvider: objectBrowser,
-    showCollapseAll: true
+    showCollapseAll: true,
+    canSelectMany: true,
+    dragAndDropController: new ObjectBrowserMemberItemDragAndDrop()
   });
 
   instance.onEvent(`connected`, () => objectBrowser.refresh());


### PR DESCRIPTION
### Changes

This PR will allow dragging members from the Object browser into IFS directories in the IFS browser, to allow easy conversion of source members to streamfiles.

When the member is dropped into the directory, it will be copied using the CPYTOSTMF command. The streamfile will be named the member including extension in lowercase, and it will be UTF-8 encoded.

### Checklist

* [x] have tested my change
* [x] **for feature PRs**: PR only includes one feature enhancement.
