### PR TITLE
Add concurrency level to postDownloads

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -430,7 +430,7 @@ export namespace CompileTools {
                           const downloads = postDownloads.map(
                             async (postDownload) => {
                               if (postDownload.type === vscode.FileType.Directory) {
-                                return connection.downloadDirectory(postDownload.localPath, postDownload.remotePath, { recursive: true });
+                                return connection.downloadDirectory(postDownload.localPath, postDownload.remotePath, { recursive: true, concurrency: 5 });
                               } else {
                                 return connection.downloadFile(postDownload.localPath, postDownload.remotePath);
                               }


### PR DESCRIPTION
### Changes

In other places where we download directories, we have used a concurrency level of 5. I have also added that to post download of an Action.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
