### PR TITLE
Store that CL component was installed after installing

### DIFF
--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -97,6 +97,13 @@ export class GlobalStorage extends Storage {
     await this.set(SERVER_SETTINGS_CACHE_KEY(name), serverSettings);
   }
 
+  async setServerSettingsCacheSpecific(name: string, newSettings: Partial<CachedServerSettings>) {
+    await this.set(SERVER_SETTINGS_CACHE_KEY(name), {
+      ...this.getServerSettingsCache(name),
+      ...newSettings
+    });
+  }
+
   async deleteServerSettingsCache(name: string) {
     await this.set(SERVER_SETTINGS_CACHE_KEY(name), undefined);
   }

--- a/src/languages/clle/clApi.ts
+++ b/src/languages/clle/clApi.ts
@@ -2,6 +2,7 @@ import { window } from "vscode";
 import { instance } from "../../instantiate";
 
 import * as gencmdxml from "./gencmdxml";
+import { GlobalStorage } from "../../api/Storage";
 
 export async function init() {
   const clComponentsInstalled = checkRequirements();
@@ -46,7 +47,10 @@ async function install() {
     noLibList: true
   });
 
-  if (createResult.code !== 0) {
+  if (createResult.code === 0) {
+    connection.remoteFeatures[`GENCMDXML.PGM`] = `GENCMDXML`;
+    await GlobalStorage.get().setServerSettingsCacheSpecific(connection.currentConnectionName, { remoteFeatures: connection.remoteFeatures });
+  } else {
     throw new Error(`Failed to create GENCMDXML program.`);
   }
 }


### PR DESCRIPTION
### Changes

Solves a bug that was causing the CL installer message to always a appear after connecting for the first time, and choosing to ignore the installer.

Now, if you install on the second connect, you will no longer get the message.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
