### PR TITLE
Add new configuration option to control clearing of diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -407,6 +407,11 @@
 					],
 					"description": "Determine which view should be shown when running Actions"
 				},
+				"code-for-ibmi.clearAllErrorsAfterBuild": {
+					"type": "boolean",
+					"default": true,
+					"description": "When true, existing errors will be replaced with errors from the latest build. When false, errors will be appended to the existing list."
+				},
 				"code-for-ibmi.grepIgnoreDirs": {
 					"type": "array",
 					"items": {

--- a/package.json
+++ b/package.json
@@ -407,7 +407,7 @@
 					],
 					"description": "Determine which view should be shown when running Actions"
 				},
-				"code-for-ibmi.clearAllErrorsAfterBuild": {
+				"code-for-ibmi.clearErrorsBeforeBuild": {
 					"type": "boolean",
 					"default": true,
 					"description": "When true, existing errors will be replaced with errors from the latest build. When false, errors will be appended to the existing list."

--- a/src/api/errors/diagnostics.ts
+++ b/src/api/errors/diagnostics.ts
@@ -69,7 +69,10 @@ export async function refreshDiagnosticsFromServer(instance: Instance, evfeventI
     const tableData = await content.getTable(evfeventInfo.library, `EVFEVENT`, evfeventInfo.object);
     const lines = tableData.map(row => String(row.EVFEVENT));
 
-    clearDiagnostics();
+    if (GlobalConfiguration.get(`clearAllErrorsAfterBuild`)) {
+      // Clear all errors if the user has this setting enabled
+      clearDiagnostics();
+    }
 
     handleEvfeventLines(lines, instance, evfeventInfo);
   } else {
@@ -83,7 +86,10 @@ export async function refreshDiagnosticsFromLocal(instance: Instance, evfeventIn
     if (evfeventFiles) {
       const filesContent = await Promise.all(evfeventFiles.map(uri => vscode.workspace.fs.readFile(uri)));
 
-      clearDiagnostics();
+      if (GlobalConfiguration.get(`clearAllErrorsAfterBuild`)) {
+        // Clear all errors if the user has this setting enabled
+        clearDiagnostics();
+      }
 
       for (const contentBuffer of filesContent) {
         const content = contentBuffer.toString();

--- a/src/api/errors/diagnostics.ts
+++ b/src/api/errors/diagnostics.ts
@@ -69,7 +69,7 @@ export async function refreshDiagnosticsFromServer(instance: Instance, evfeventI
     const tableData = await content.getTable(evfeventInfo.library, `EVFEVENT`, evfeventInfo.object);
     const lines = tableData.map(row => String(row.EVFEVENT));
 
-    if (GlobalConfiguration.get(`clearAllErrorsAfterBuild`)) {
+    if (GlobalConfiguration.get(`clearErrorsBeforeBuild`)) {
       // Clear all errors if the user has this setting enabled
       clearDiagnostics();
     }
@@ -86,7 +86,7 @@ export async function refreshDiagnosticsFromLocal(instance: Instance, evfeventIn
     if (evfeventFiles) {
       const filesContent = await Promise.all(evfeventFiles.map(uri => vscode.workspace.fs.readFile(uri)));
 
-      if (GlobalConfiguration.get(`clearAllErrorsAfterBuild`)) {
+      if (GlobalConfiguration.get(`clearErrorsBeforeBuild`)) {
         // Clear all errors if the user has this setting enabled
         clearDiagnostics();
       }

--- a/src/api/errors/parser.ts
+++ b/src/api/errors/parser.ts
@@ -8,7 +8,7 @@ class EvfEventFileReader implements ISequentialFileReader {
   constructor(lines: string[]) {
     this.lines = lines;
   }
-
+f
   readNextLine(): string | undefined {
     const line = this.lines[this.index];
     if (line) {

--- a/src/api/errors/parser.ts
+++ b/src/api/errors/parser.ts
@@ -8,7 +8,7 @@ class EvfEventFileReader implements ISequentialFileReader {
   constructor(lines: string[]) {
     this.lines = lines;
   }
-f
+
   readNextLine(): string | undefined {
     const line = this.lines[this.index];
     if (line) {


### PR DESCRIPTION
### Changes

Adds the ability to keep diagnostics from other files around when running an Action.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
