### PR TITLE
Add tooltip for objects in object browser

### DIFF
--- a/src/locale/ids/da.ts
+++ b/src/locale/ids/da.ts
@@ -30,6 +30,9 @@ export const da: Locale = {
   'size': 'Størrelse',
   'modified': 'Ændret',
   'owner': 'Ejer',
+  'type': 'Type',
+  'attribute': 'Attribut',
+  'created_by': 'Oprettet af',
   // Sandbox:
   'sandbox.input.user.title': `Bruger for server`,
   'sandbox.input.user.prompt': `Indtast brugernavn for {0}`,

--- a/src/locale/ids/en.ts
+++ b/src/locale/ids/en.ts
@@ -30,6 +30,9 @@ export const en: Locale = {
   'size': 'Size',
   'modified': 'Modified',
   'owner': 'Owner',
+  'type': 'Type',
+  'attribute': 'Attribute',
+  'created_by': 'Created by',
   // Sandbox:
   'sandbox.input.user.title': `User for server`,
   'sandbox.input.user.prompt': `Enter username for {0}`,

--- a/src/locale/ids/fr.ts
+++ b/src/locale/ids/fr.ts
@@ -31,8 +31,8 @@ export const fr: Locale = {
   'modified': 'Modifié',
   'owner': 'Propriétaire',
   'type': 'Type',
-  'attribute': 'Attribute',
-  'created_by': 'Created by',
+  'attribute': 'Attribut',
+  'created_by': 'Créé par',
   // Sandbox:
   'sandbox.input.user.title': `Nom d'utilisateur`,
   'sandbox.input.user.prompt': `Entrez le nom d'utilisateur pour {0}`,

--- a/src/locale/ids/fr.ts
+++ b/src/locale/ids/fr.ts
@@ -30,6 +30,9 @@ export const fr: Locale = {
   'size': 'Taille',
   'modified': 'Modifié',
   'owner': 'Propriétaire',
+  'type': 'Type',
+  'attribute': 'Attribute',
+  'created_by': 'Created by',
   // Sandbox:
   'sandbox.input.user.title': `Nom d'utilisateur`,
   'sandbox.input.user.prompt': `Entrez le nom d'utilisateur pour {0}`,

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -103,6 +103,11 @@ export interface IBMiObject extends QsysPath {
   memberCount?: number
   sourceLength?: number
   CCSID?: number
+  size?: number
+  created?: Date
+  changed?: Date
+  created_by?: string
+  owner?: string
 }
 
 export interface IBMiMember {

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -288,7 +288,17 @@ class ObjectBrowserObjectItem extends ObjectBrowserItem implements ObjectItem {
     this.updateDescription();
 
     this.contextValue = `object.${type.toLowerCase()}${object.attribute ? `.${object.attribute}` : ``}${isProtected(this.filter) ? `_readonly` : ``}`;
-    this.tooltip = new vscode.MarkdownString(``);
+    this.tooltip = new vscode.MarkdownString(Tools.generateTooltipHtmlTable(this.path, {
+      type: object.type,
+      attribute: object.attribute,
+      text: object.text,
+      size: object.size,
+      created: object.created?.toISOString().slice(0, 19).replace(`T`, ` `),
+      changed: object.changed?.toISOString().slice(0, 19).replace(`T`, ` `),
+      created_by: object.created_by,
+      owner: object.owner,
+    }));
+    this.tooltip.supportHtml = true;
 
     this.resourceUri = vscode.Uri.from({
       scheme: `object`,


### PR DESCRIPTION
### Changes

This PR is a continuation of the tooltips changes - it adds a tooltip to objects in the object browser, when the object is not a source file:

![image](https://github.com/codefori/vscode-ibmi/assets/13275072/15967d3e-43d2-44c3-bb09-1789c8245527)

### Checklist

* [x] have tested my change
