### PR TITLE
Fix error copying empty member

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -68,7 +68,7 @@ export default class IBMiContent {
   }
 
   /**
-   * 
+   *
    * @param remotePath Remote IFS path
    * @param localPath Local path to download file to
    */
@@ -103,7 +103,7 @@ export default class IBMiContent {
   }
 
   /**
-   * @param originalPath 
+   * @param originalPath
    * @param content Raw content
    * @param encoding Optional encoding to write.
    */
@@ -249,7 +249,7 @@ export default class IBMiContent {
    * Run SQL statements.
    * Each statement must be separated by a semi-colon and a new line (i.e. ;\n).
    * If a statement starts with @, it will be run as a CL command.
-   * 
+   *
    * @param statements
    * @returns a Result set
    */
@@ -259,7 +259,7 @@ export default class IBMiContent {
     if (QZDFMDB2) {
       if (this.chgJobCCSID === undefined) {
         this.chgJobCCSID = (this.ibmi.qccsid < 1 || this.ibmi.qccsid === 65535) && this.ibmi.defaultCCSID > 0 ? `@CHGJOB CCSID(${this.ibmi.defaultCCSID});\n` : '';
-      }      
+      }
 
       const output = await this.ibmi.sendCommand({
         command: `LC_ALL=EN_US.UTF-8 system "call QSYS/QZDFMDB2 PARM('-d' '-i' '-t')"`,
@@ -491,7 +491,7 @@ export default class IBMiContent {
     const type = filters.types && filters.types.length === 1 && filters.types[0] !== '*' ? filters.types[0] : '*ALL';
 
     const sourceFilesOnly = filters.types && filters.types.length === 1 && filters.types.includes(`*SRCPF`);
-    const withSourceFiles = ['*ALL', '*SRCPF'].includes(type);
+    const withSourceFiles = ['*ALL', '*SRCPF', '*FILE'].includes(type);
 
     const queries: string[] = [];
 
@@ -851,7 +851,7 @@ export default class IBMiContent {
   }
 
   /**
-   * 
+   *
    * @param command Optionally qualified CL command
    * @param parameters A key/value object of parameters
    * @returns Formatted CL string

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -580,7 +580,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
             })
 
             const copyMessages = Tools.parseMessages(copyResult.stderr);
-            if (copyMessages.messages.length && !copyMessages.findId(`CPF2869`)) {
+            if (copyResult.code !== 0 && copyMessages.messages.length && !(copyMessages.findId(`CPF2869`) && copyMessages.findId(`CPF2817`))) {
               throw (copyResult.stderr)
             }
 


### PR DESCRIPTION
### Changes

This PR will fix the change from PR #1851 - the test in the PR was not correct.
Now we check for return code first, and only if error code 1 and messages and not messages
`CPF2869 (Empty member &3 in file &1 in library &2 is not copied.)` and
`CPF2817 (Copy command ended because of error.)`
do we ignore the errors and accept the outcome.

### Checklist

* [x] have tested my change
