### PR TITLE
Update SEU Colors Feature

### DIFF
--- a/src/languages/general/SEUColorProvider.ts
+++ b/src/languages/general/SEUColorProvider.ts
@@ -3,7 +3,6 @@ import vscode from 'vscode';
 import { SEUColors } from './SEUColors';
 
 const hidden = vscode.window.createTextEditorDecorationType({
-  //letterSpacing: `-1em`,
   opacity: `0`,
   rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
 });

--- a/src/languages/general/SEUColorProvider.ts
+++ b/src/languages/general/SEUColorProvider.ts
@@ -43,37 +43,72 @@ export namespace SEUColorProvider {
           colorDecorations[name] = [];
         });
 
-        // Find the lines and the bytes and all that...
-        for (let lineIndex = 0; lineIndex < document.lineCount; lineIndex++) {
-          const line = document.lineAt(lineIndex);
-
-          const lineBytes = Buffer.from(line.text);
-
-          SEUColors.forEach((name, definition) => {
-            const byteIndex = lineBytes.indexOf(definition.bytes);
-            if (byteIndex >= 0) {
-              colorDecorations[name].push({
-                range: new vscode.Range(lineIndex, byteIndex + definition.bytes.length - 1, lineIndex, line.text.length)
-              });
-
-              hiddenDecorations.push({
-                range: new vscode.Range(lineIndex, byteIndex, lineIndex, byteIndex + 1),
-                renderOptions: {
-                  after: {
-                    contentText: ``.padEnd(definition.bytes.length),
-                  }
-                }
-              });
+        // Helper function: record a segment of a member line that should be hidden
+        function addSegmentToHide(lineIndex:number, startIndex:number, endIndex:number) {
+          hiddenDecorations.push({
+            range: new vscode.Range(lineIndex, startIndex, lineIndex, endIndex),
+            renderOptions: {
+              after: {
+                contentText: ` `
+              },
             }
-          })
+          });
         }
 
-        // Then set the decorations
+        // Helper function: record a segment of a member line that should be colored
+        function addSegmentToColor(lineIndex:number, startIndex:number, endIndex:number, colorName:string) {
+          colorDecorations[colorName].push({
+            range: new vscode.Range(lineIndex, startIndex, lineIndex, endIndex)
+          });
+        }
+
+        // Iterate over each line of text in the document
+        for (let lineIndex = 0; lineIndex < document.lineCount; lineIndex++) {
+          const line = document.lineAt(lineIndex);
+          const lineBytes = Buffer.from(line.text);
+
+          // Character index and definition of the previously found color sequence
+          let prevColorSeqCharIndex = 0;
+          let prevColorSeqDef = null;
+
+          // Check the line byte-by-byte
+          for (let byteIndex = 0; byteIndex < lineBytes.byteLength; ++byteIndex) {
+            const nextByte = lineBytes[byteIndex];
+            // If the current byte is NOT 194 (0xC2), only check the current byte.
+            // Otherwise, check both the current byte and the following byte
+            let bytesToCheck = [nextByte];
+            if(nextByte === 194)
+              bytesToCheck.push(lineBytes[byteIndex+1]);
+            // Find the color sequence, if any, indicated by the checked byte(s)
+            const colorDef = SEUColors.getColorDef(Buffer.from(bytesToCheck));
+            if(colorDef) {
+              // VS Code ranges are based on characters rather than bytes, and one byte is not always 
+              // interpreted as one character. So, find the character-based index where the color
+              // sequence appears.
+              const charIndex = lineBytes.slice(0,byteIndex).toString().length;
+              const seqCharLength = Buffer.from(bytesToCheck).toString().length;
+              console.log(lineBytes.slice(0, byteIndex).toString().length - lineBytes.slice(0, byteIndex).length);
+
+              addSegmentToHide(lineIndex, charIndex, charIndex + seqCharLength);
+              // If a color sequence was found earlier in the line,
+              // mark this as the end of the line segment to be colored according to that seuqnece
+              if(prevColorSeqDef)
+                addSegmentToColor(lineIndex, prevColorSeqCharIndex, charIndex, prevColorSeqDef);
+              prevColorSeqCharIndex = charIndex + seqCharLength;
+              prevColorSeqDef = colorDef;
+            }
+          }
+          // For the last color sequence on the line, color all characters until the end of the line
+          if(prevColorSeqDef)
+            addSegmentToColor(lineIndex, prevColorSeqCharIndex, line.text.length, prevColorSeqDef);
+        }
+
+        // Finally, set the decorations
         SEUColors.forEach((name, definition) => {
           activeEditor.setDecorations(definition.decoration, colorDecorations[name]);
         });
-
         activeEditor.setDecorations(hidden, hiddenDecorations);
+        
       }
     }
   }

--- a/src/languages/general/SEUColorProvider.ts
+++ b/src/languages/general/SEUColorProvider.ts
@@ -47,19 +47,7 @@ export namespace SEUColorProvider {
         // Helper function: record a segment of a member line that should be hidden
         function addSegmentToHide(lineIndex:number, startIndex:number, endIndex:number) {
           hiddenDecorations.push({
-            range: new vscode.Range(lineIndex, startIndex, lineIndex, endIndex),
-            renderOptions: {
-              before: {
-                contentText: Buffer.from([156]).toString(),
-                width: `0`,
-                textDecoration: `; opacity: 0;`
-              },
-              after: {
-                contentText: Buffer.from([152]).toString(),
-                width: `0`,
-                textDecoration: `; opacity: 0;`
-              },
-            }
+            range: new vscode.Range(lineIndex, startIndex, lineIndex, endIndex)
           });
         }
 
@@ -77,14 +65,14 @@ export namespace SEUColorProvider {
 
           // Character index and definition of the previously found color sequence
           let prevColorSeqCharIndex = 0;
-          let prevColorSeqDef = null;
+          let prevColorSeqDefinition = undefined;
 
           // Check the line byte-by-byte
           for (let byteIndex = 0; byteIndex < lineBytes.byteLength; ++byteIndex) {
             const nextByte = lineBytes[byteIndex];
-            // If the current byte is NOT 194 (0xC2), only check the current byte.
-            // Otherwise, check both the current byte and the following byte
-            let bytesToCheck = [nextByte];
+            // If the next byte is NOT 194 (0xC2), only check that byte.
+            // Otherwise, check both the next byte and the following byte.
+            const bytesToCheck = [nextByte];
             if(nextByte === 194)
               bytesToCheck.push(lineBytes[byteIndex+1]);
             // Find the color sequence, if any, indicated by the checked byte(s)
@@ -99,15 +87,15 @@ export namespace SEUColorProvider {
               addSegmentToHide(lineIndex, charIndex, charIndex + seqCharLength);
               // If a color sequence was found earlier in the line,
               // mark this as the end of the line segment to be colored according to that seuqnece
-              if(prevColorSeqDef)
-                addSegmentToColor(lineIndex, prevColorSeqCharIndex, charIndex, prevColorSeqDef);
+              if(prevColorSeqDefinition)
+                addSegmentToColor(lineIndex, prevColorSeqCharIndex, charIndex, prevColorSeqDefinition);
               prevColorSeqCharIndex = charIndex + seqCharLength;
-              prevColorSeqDef = colorDef;
+              prevColorSeqDefinition = colorDef;
             }
           }
           // For the last color sequence on the line, color all characters until the end of the line
-          if(prevColorSeqDef)
-            addSegmentToColor(lineIndex, prevColorSeqCharIndex, line.text.length, prevColorSeqDef);
+          if(prevColorSeqDefinition)
+            addSegmentToColor(lineIndex, prevColorSeqCharIndex, line.text.length, prevColorSeqDefinition);
         }
 
         // Finally, set the decorations

--- a/src/languages/general/SEUColorProvider.ts
+++ b/src/languages/general/SEUColorProvider.ts
@@ -3,8 +3,9 @@ import vscode from 'vscode';
 import { SEUColors } from './SEUColors';
 
 const hidden = vscode.window.createTextEditorDecorationType({
-  letterSpacing: `-1em`,
+  //letterSpacing: `-1em`,
   opacity: `0`,
+  rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
 });
 
 export namespace SEUColorProvider {
@@ -48,8 +49,15 @@ export namespace SEUColorProvider {
           hiddenDecorations.push({
             range: new vscode.Range(lineIndex, startIndex, lineIndex, endIndex),
             renderOptions: {
+              before: {
+                contentText: Buffer.from([156]).toString(),
+                width: `0`,
+                textDecoration: `; opacity: 0;`
+              },
               after: {
-                contentText: ` `
+                contentText: Buffer.from([152]).toString(),
+                width: `0`,
+                textDecoration: `; opacity: 0;`
               },
             }
           });
@@ -87,7 +95,6 @@ export namespace SEUColorProvider {
               // sequence appears.
               const charIndex = lineBytes.slice(0,byteIndex).toString().length;
               const seqCharLength = Buffer.from(bytesToCheck).toString().length;
-              console.log(lineBytes.slice(0, byteIndex).toString().length - lineBytes.slice(0, byteIndex).length);
 
               addSegmentToHide(lineIndex, charIndex, charIndex + seqCharLength);
               // If a color sequence was found earlier in the line,

--- a/src/languages/general/SEUColors.ts
+++ b/src/languages/general/SEUColors.ts
@@ -216,6 +216,18 @@ export namespace SEUColors {
     }
   };
 
+  const colorMap = new Map();
+  Object.entries(ColorDefinitions).forEach(c => {
+    const colorName = c[0];
+    const colorCode = c[1].bytes.join(','); // convert to string for use as Map key
+    console.log(colorCode);
+    colorMap.set(colorCode, colorName);
+  });
+
+  export function getColorDef(bytesToCheck: Buffer) {
+    return colorMap.get(bytesToCheck.join(','));
+  }
+
   export function forEach(cb: (name: string, color: Color) => void) {
     Object.entries(ColorDefinitions).forEach(c => cb(c[0], c[1]));
   }

--- a/src/languages/general/SEUColors.ts
+++ b/src/languages/general/SEUColors.ts
@@ -219,13 +219,12 @@ export namespace SEUColors {
   const colorMap = new Map();
   Object.entries(ColorDefinitions).forEach(c => {
     const colorName = c[0];
-    const colorCode = c[1].bytes.join(','); // convert to string for use as Map key
-    console.log(colorCode);
+    const colorCode = c[1].bytes.toString(); // convert to string for use as Map key
     colorMap.set(colorCode, colorName);
   });
 
   export function getColorDef(bytesToCheck: Buffer) {
-    return colorMap.get(bytesToCheck.join(','));
+    return colorMap.get(bytesToCheck.toString());
   }
 
   export function forEach(cb: (name: string, color: Color) => void) {


### PR DESCRIPTION
### Changes

Update SEU Colors Feature
* Updated SEUColorProvider.ts to address issue with overlapping characters (#1490) (the code now calculates ranges based on character count rather than byte count)
* Updated the SEUColorProvider.ts code that looks for color code sequences in the source member to use a Map-based function rather than individually check against every possible color code for each byte (also updated SEUColors.ts to provide the aforementioned function)
* When a color code is found, the styling now only applies until another color code is found (or until the line ends)

* Added a function to SEUColors.ts that uses a Map to check whether a given byte sequence matches any of the color sequences
* When reading bytes from a source member, SEUColorProvider.ts now uses the aforementioned Map-based function on each byte rather than individually checking it against every possible color sequence, to save time

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)