### PR TITLE
Speed up library list loading when SQL is disabled

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -398,7 +398,7 @@ export default class IBMiContent {
       `;
       results = await this.runSQL(statement);
     } else {
-      results = await this.getQTempTable([`CALL QSYS2.QCMDEXC('DSPOBJD OBJ(QSYS/*ALL) OBJTYPE(*LIB) DETAIL(*TEXTATR) OUTPUT(*OUTFILE) OUTFILE(QTEMP/LIBLIST)')`], "LIBLIST");
+      results = await this.getQTempTable(libraries.map(library => `@DSPOBJD OBJ(QSYS/${library}) OBJTYPE(*LIB) DETAIL(*TEXTATR) OUTPUT(*OUTFILE) OUTFILE(QTEMP/LIBLIST) OUTMBR(*FIRST *ADD)`), "LIBLIST");
       if (results.length === 1 && !results[0].ODOBNM?.toString().trim()) {
         return [];
       }
@@ -506,7 +506,7 @@ export default class IBMiContent {
     let createOBJLIST;
     if (sourceFilesOnly) {
       //DSPFD only
-      createOBJLIST =`select PHFILE as NAME, ` +
+      createOBJLIST = `select PHFILE as NAME, ` +
         `'*FILE' as TYPE, ` +
         `PHFILA as ATTRIBUTE, ` +
         `PHTXT as TEXT, ` +


### PR DESCRIPTION
### Changes
When SQL is disabled, loading the library list items take a significant amount of time because it runs `DSPOBJD OBJ(QSYS/*ALL)` to load the librarys' description.
This PR makes it run one `DSPOBJD` for each library which speeds up the loading of the Library List view.

The other possible fix for this is to disregard `config.enableSQL` entirely and always use `OBJECT_STATISTICS`.

### Checklist
* [x] have tested my change