### PR TITLE
Change secrets API

### DIFF
--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -198,7 +198,7 @@ export class ConnectionStorage extends Storage {
     await this.set(RECENTLY_OPENED_FILES_KEY, undefined);
   }
 
-  async authorizeExtension(extension: string) {
+  async addAuthorizedExtension(extension: string) {
     const extensions = this.get<string[]>(AUTHORISED_EXTENSIONS_KEY) || [];
     if (!extensions.includes(extension)) {
       extensions.push(extension);
@@ -206,12 +206,12 @@ export class ConnectionStorage extends Storage {
     }
   }
 
-  extensionIsAuthorised(extension: string) {
+  isExtensionAuthorised(extension: string) {
     const extensions = this.get<string[]>(AUTHORISED_EXTENSIONS_KEY) || [];
     return extensions.includes(extension);
   }
 
-  authorizedExtensions(): string[] {
+  getAuthorizedExtensions(): string[] {
     return this.get<string[]>(AUTHORISED_EXTENSIONS_KEY) || [];
   }
 

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -8,6 +8,7 @@ const DEBUG_KEY = `debug`;
 const SERVER_SETTINGS_CACHE_KEY = (name : string) => `serverSettingsCache_${name}`;
 const PREVIOUS_SEARCH_TERMS_KEY = `prevSearchTerms`;
 const RECENTLY_OPENED_FILES_KEY = `recentlyOpenedFiles`;
+const AUTHORISED_EXTENSIONS_KEY = `authorisedExtensions`
 
 export type PathContent = Record<string, string[]>;
 export type DeploymentPath = Record<string, string>;
@@ -195,5 +196,18 @@ export class ConnectionStorage extends Storage {
 
   async clearRecentlyOpenedFiles() {
     await this.set(RECENTLY_OPENED_FILES_KEY, undefined);
+  }
+
+  async authorizeExtension(extension: string) {
+    const extensions = this.get<string[]>(AUTHORISED_EXTENSIONS_KEY) || [];
+    if (!extensions.includes(extension)) {
+      extensions.push(extension);
+      await this.set(AUTHORISED_EXTENSIONS_KEY, extensions);
+    }
+  }
+
+  extensionIsAuthorized(extension: string) {
+    const extensions = this.get<string[]>(AUTHORISED_EXTENSIONS_KEY) || [];
+    return extensions.includes(extension);
   }
 }

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -211,7 +211,7 @@ export class ConnectionStorage extends Storage {
     return extensions.includes(extension);
   }
 
-  authorizedExtensions() {
+  authorizedExtensions(): string[] {
     return this.get<string[]>(AUTHORISED_EXTENSIONS_KEY) || [];
   }
 

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -205,9 +205,9 @@ export class ConnectionStorage extends Storage {
     await this.set(RECENTLY_OPENED_FILES_KEY, undefined);
   }
 
-  async addAuthorisedExtension(extension: vscode.Extension<any>) {
+  async grantExtensionAuthorisation(extension: vscode.Extension<any>) {
     const extensions = this.getAuthorisedExtensions();
-    if (!this.isExtensionAuthorised(extension)) {
+    if (!this.getExtensionAuthorisation(extension)) {
       extensions.push({
         id: extension.id,
         displayName: extension.packageJSON.displayName,
@@ -218,23 +218,23 @@ export class ConnectionStorage extends Storage {
     }
   }
 
-  isExtensionAuthorised(extension: vscode.Extension<any>) {
+  getExtensionAuthorisation(extension: vscode.Extension<any>) {
     const authorisedExtension = this.getAuthorisedExtensions().find(authorisedExtension => authorisedExtension.id === extension.id);
     if (authorisedExtension) {
       authorisedExtension.lastAccess = new Date().getTime();
     }
-    return authorisedExtension !== undefined;
+    return authorisedExtension;
   }
 
   getAuthorisedExtensions(): AuthorisedExtension[] {
     return this.get<AuthorisedExtension[]>(AUTHORISED_EXTENSIONS_KEY) || [];
   }
 
-  removeAllAuthorisedExtension() {
-    this.removeAuthorisedExtension(this.getAuthorisedExtensions());
+  revokeAllExtensionAuthorisations() {
+    this.revokeExtensionAuthorisation(...this.getAuthorisedExtensions());
   }
 
-  removeAuthorisedExtension(extensions: AuthorisedExtension[]) {
+  revokeExtensionAuthorisation(...extensions: AuthorisedExtension[]) {
     const newExtensions = this.getAuthorisedExtensions().filter(ext => !extensions.includes(ext));
     return this.set(AUTHORISED_EXTENSIONS_KEY, newExtensions);
   }

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -206,8 +206,18 @@ export class ConnectionStorage extends Storage {
     }
   }
 
-  extensionIsAuthorized(extension: string) {
+  extensionIsAuthorised(extension: string) {
     const extensions = this.get<string[]>(AUTHORISED_EXTENSIONS_KEY) || [];
     return extensions.includes(extension);
+  }
+
+  authorizedExtensions() {
+    return this.get<string[]>(AUTHORISED_EXTENSIONS_KEY) || [];
+  }
+
+  removeAuthorizedExtension(extensions: string[]) {
+    const authorizedExtensions = this.get<string[]>(AUTHORISED_EXTENSIONS_KEY) || [];
+    const newExtensions = authorizedExtensions.filter(ext => !extensions.includes(ext));
+    return this.set(AUTHORISED_EXTENSIONS_KEY, newExtensions);
   }
 }

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -642,7 +642,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
             const storedPassword = await context.secrets.get(connectionKey);
 
             if (storedPassword) {
-              let isAuthed = storage.isExtensionAuthorised(extensionId);
+              let isAuthed = storage.isExtensionAuthorised(extension);
 
               if (!isAuthed) {
                 const detail = `The ${displayName} extension is requesting access to your password for this connection. ${reason ? `\n\nReason: ${reason}` : `The extension did not provide a reason for password access.`}`;
@@ -669,7 +669,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
 
                   switch (result) {
                     case `Allow`:
-                      await storage.addAuthorizedExtension(extensionId);
+                      await storage.addAuthorisedExtension(extension);
                       isAuthed = true;
                       done = true;
                       break;

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -21,7 +21,7 @@ import { VariablesUI } from "./webviews/variables";
 
 export let instance: Instance;
 
-const passwordAttempts: {[extensionId: string]: number} = {}
+const passwordAttempts: { [extensionId: string]: number } = {}
 
 const CLEAR_RECENT = `$(trash) Clear recently opened`;
 const CLEAR_CACHED = `$(trash) Clear cached`;
@@ -627,26 +627,24 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
         const extension = vscode.extensions.getExtension(extensionId);
         const isValid = (extension && extension.isActive);
         if (isValid) {
-
           const connection = instance.getConnection();
-          if (connection) {
+          const storage = instance.getStorage();
+          if (connection && storage) {
+            const displayName = extension.packageJSON.displayName || extensionId;
 
             // Some logic to stop spam from extensions.
             passwordAttempts[extensionId] = passwordAttempts[extensionId] || 0;
             if (passwordAttempts[extensionId] > 1) {
-              throw new Error(`Password request denied.`);
+              throw new Error(`Password request denied for extension ${displayName}.`);
             }
 
             const connectionKey = `${instance.getConnection()!.currentConnectionName}_password`;
             const storedPassword = await context.secrets.get(connectionKey);
 
             if (storedPassword) {
-
-              const storage = instance.getStorage()!;
               let isAuthed = storage.isExtensionAuthorised(extensionId);
 
               if (!isAuthed) {
-                const displayName = extension.packageJSON.displayName || extensionId;
                 const detail = `The ${displayName} extension is requesting access to your password for this connection. ${reason ? `\n\nReason: ${reason}` : `The extension did not provide a reason for password access.`}`;
                 let done = false;
                 let modal = true;
@@ -659,13 +657,13 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                   } else {
                     options.push(`Deny`);
                   }
-                  
+
                   const result = await vscode.window.showWarningMessage(
-                    modal ? `Password Request` : detail, 
+                    modal ? `Password Request` : detail,
                     {
                       modal,
                       detail,
-                    }, 
+                    },
                     ...options
                   );
 

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -642,7 +642,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
             const storedPassword = await context.secrets.get(connectionKey);
 
             if (storedPassword) {
-              let isAuthed = storage.isExtensionAuthorised(extension);
+              let isAuthed = storage.getExtensionAuthorisation(extension) !== undefined;
 
               if (!isAuthed) {
                 const detail = `The ${displayName} extension is requesting access to your password for this connection. ${reason ? `\n\nReason: ${reason}` : `The extension did not provide a reason for password access.`}`;
@@ -669,7 +669,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
 
                   switch (result) {
                     case `Allow`:
-                      await storage.addAuthorisedExtension(extension);
+                      await storage.grantExtensionAuthorisation(extension);
                       isAuthed = true;
                       done = true;
                       break;

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -622,28 +622,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       }
     }),
 
-    vscode.commands.registerCommand(`code-for-ibmi.secret`, async (key: string, newValue: string) => {
-      if (key === `password`) {
-        // TODO: consider forwarding to the other command instead of throwing an error
-        throw new Error(`Cannot work with password through this API.`);
-      }
-
-      console.log(`code-for-ibmi.secret command is deprecated and will be removed.`)
-
-      const connectionKey = `${instance.getConnection()!.currentConnectionName}_${key}`;
-      if (newValue) {
-        await context.secrets.store(connectionKey, newValue);
-        return newValue;
-      }
-
-      return await context.secrets.get(connectionKey);
-    }),
-
-    // TODO: should this be a connection API instead in the IBMi class?
-    // Opinion: no because it has UI elements to it
     vscode.commands.registerCommand(`code-for-ibmi.getPassword`, async (extensionId: string, reason?: string) => {
       if (extensionId) {
-        // We need to do some verification to make sure the callerExtension is a real extension
         const extension = vscode.extensions.getExtension(extensionId);
         const isValid = (extension && extension.isActive);
         if (isValid) {

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -627,6 +627,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
         throw new Error(`Cannot work with password through this API.`);
       }
 
+      console.log(`code-for-ibmi.secret command is deprecated and will be removed.`)
+
       const connectionKey = `${instance.getConnection()!.currentConnectionName}_${key}`;
       if (newValue) {
         await context.secrets.store(connectionKey, newValue);
@@ -652,7 +654,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
             }
 
             const storage = instance.getStorage()!;
-            let isAuthed = storage.extensionIsAuthorized(extensionId);
+            let isAuthed = storage.extensionIsAuthorised(extensionId);
 
             if (!isAuthed) {
               const result = await vscode.window.showWarningMessage(`Password request`, {

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -7,6 +7,7 @@ import { ContentSuite } from "./content";
 import { DeployToolsSuite } from "./deployTools";
 import { FilterSuite } from "./filter";
 import { ILEErrorSuite } from "./ileErrors";
+import { StorageSuite } from "./storage";
 import { TestSuitesTreeProvider } from "./testCasesTree";
 import { ToolsSuite } from "./tools";
 
@@ -17,7 +18,8 @@ const suites: TestSuite[] = [
   DeployToolsSuite,
   ToolsSuite,
   ILEErrorSuite,
-  FilterSuite
+  FilterSuite,
+  StorageSuite
 ]
 
 export type TestSuite = {

--- a/src/testing/storage.ts
+++ b/src/testing/storage.ts
@@ -1,0 +1,42 @@
+import assert from "assert";
+import vscode from "vscode";
+import { TestSuite } from ".";
+import { instance } from "../instantiate";
+
+export const StorageSuite: TestSuite = {
+  name: `Extension storage tests`,
+  tests: [
+    {
+      name: "Authorized extensions", test: async () => {
+        const storage = instance.getStorage();
+        if(storage){ 
+          const extension = vscode.extensions.getExtension("halcyontechltd.code-for-ibmi")!;          
+          try{
+            let auth = storage.getExtensionAuthorisation(extension);
+            assert.strictEqual(undefined, auth, "Extension is already authorized");
+            storage.grantExtensionAuthorisation(extension);
+            
+            auth = storage.getExtensionAuthorisation(extension);
+            assert.ok(auth, "Authorisation not found");
+            assert.strictEqual(new Date(auth.since).toDateString(), new Date().toDateString(), "Access date must be today");
+
+            const lastAccess = auth.lastAccess;
+            await new Promise(r => setTimeout(r, 100)); //Wait a bit
+            auth = storage.getExtensionAuthorisation(extension);
+            assert.ok(auth, "Authorisation not found");
+            assert.notStrictEqual(lastAccess, auth.lastAccess, "Last access did not change")
+          }
+          finally{
+            const auth = storage.getExtensionAuthorisation(extension);
+            if(auth){
+              storage.revokeExtensionAuthorisation(auth);
+            }
+          }
+        }
+        else{
+          throw Error("Cannot run test: no storage")
+        }
+      }
+    }
+  ]
+}

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -238,7 +238,7 @@ export class SettingsUI {
                 break;
 
               case `clearAllowedExts`:
-                instance.getStorage()?.removeAllAuthorisedExtension();
+                instance.getStorage()?.revokeAllExtensionAuthorisations();
                 break;
 
               default:

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -211,7 +211,7 @@ export class SettingsUI {
 
           passwordAuthTab
             .addParagraph(`The following extensions are authorized to use the password for this connection.`)
-            .addParagraph(`<ul>✅ <code>${passwordAuthorisedExtensions.map(ext => `<li>${ext}</li>`).join(``)}</code></ul>`)
+            .addParagraph(`<ul>${passwordAuthorisedExtensions.map(ext => `<li>✅ <code>${ext}</code></li>`).join(``)}</ul>`)
             .addButtons({ id: `clearAllowedExts`, label: `Clear list` })
 
           tabs.push({ label: `Extension Auth`, fields: passwordAuthTab.fields });

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -32,7 +32,7 @@ export class SettingsUI {
       vscode.commands.registerCommand(`code-for-ibmi.showAdditionalSettings`, async (server?: Server, tab?: string) => {
         const connectionSettings = GlobalConfiguration.get<ConnectionConfiguration.Parameters[]>(`connectionSettings`);
         const connection = instance.getConnection();
-        const passwordAuthorisedExtensions: string[] = instance.getStorage()?.getAuthorizedExtensions() || [];
+        const passwordAuthorisedExtensions = instance.getStorage()?.getAuthorisedExtensions() || [];
 
         let config: ConnectionConfiguration.Parameters;
 
@@ -211,7 +211,7 @@ export class SettingsUI {
 
           passwordAuthTab
             .addParagraph(`The following extensions are authorized to use the password for this connection.`)
-            .addParagraph(`<ul>${passwordAuthorisedExtensions.map(ext => `<li>✅ <code>${ext}</code></li>`).join(``)}</ul>`)
+            .addParagraph(`<ul>${passwordAuthorisedExtensions.map(authExtension => `<li>✅ <code>${authExtension.displayName || authExtension.id}</code> - since ${new Date(authExtension.since).toDateString()} - last access on ${new Date(authExtension.lastAccess).toDateString()}</li>`).join(``)}</ul>`)
             .addButtons({ id: `clearAllowedExts`, label: `Clear list` })
 
           tabs.push({ label: `Extension Auth`, fields: passwordAuthTab.fields });
@@ -238,10 +238,7 @@ export class SettingsUI {
                 break;
 
               case `clearAllowedExts`:
-                const storage = instance.getStorage();
-                if (storage) {
-                  storage.removeAuthorizedExtension(storage.getAuthorizedExtensions());
-                }
+                instance.getStorage()?.removeAllAuthorisedExtension();
                 break;
 
               default:

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -32,10 +32,9 @@ export class SettingsUI {
       vscode.commands.registerCommand(`code-for-ibmi.showAdditionalSettings`, async (server?: Server, tab?: string) => {
         const connectionSettings = GlobalConfiguration.get<ConnectionConfiguration.Parameters[]>(`connectionSettings`);
         const connection = instance.getConnection();
+        const passwordAuthorisedExtensions: string[] = instance.getStorage()?.authorizedExtensions() || [];
 
         let config: ConnectionConfiguration.Parameters;
-
-        let passwordAuthorisedExtensions: string[] = [];
 
         if (connectionSettings && server) {
           config = await ConnectionConfiguration.load(server.name);
@@ -45,7 +44,6 @@ export class SettingsUI {
           if (connection && config) {
             // Reload config to initialize any new config parameters.
             config = await ConnectionConfiguration.load(config.name);
-            passwordAuthorisedExtensions = instance.getStorage()?.authorizedExtensions() || [];
           } else {
             vscode.window.showErrorMessage(`No connection is active.`);
             return;


### PR DESCRIPTION
### Changes

* Removes old way of getting secrets from the connection
* Adds new command API, `getPassword`, which requests access from the user before allowing the extension to use the password. Alternatively, the user can deny an extension the password.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
