### PR TITLE
Changes/debugger_certs

### DIFF
--- a/package.json
+++ b/package.json
@@ -937,13 +937,13 @@
 			},
 			{
 				"command": "code-for-ibmi.debug.setup.remote",
-				"title": "Setup Remote Certificates",
+				"title": "Setup Service Certificate",
 				"category": "IBM i Debug",
 				"enablement": "code-for-ibmi:connected && code-for-ibmi:debugManaged != true"
 			},
 			{
 				"command": "code-for-ibmi.debug.setup.local",
-				"title": "Import Local Certificate",
+				"title": "Import Client Certificate",
 				"category": "IBM i Debug",
 				"enablement": "code-for-ibmi:connected && code-for-ibmi:debugManaged != true"
 			},

--- a/src/api/Configuration.ts
+++ b/src/api/Configuration.ts
@@ -2,6 +2,7 @@ import os from "os";
 import * as vscode from 'vscode';
 import { DeploymentMethod } from '../typings';
 import { FilterType } from './Filter';
+import { DEFAULT_CERT_DIRECTORY } from "./debug/certificates";
 
 export type SourceDateMode = "edit" | "diff";
 export type DefaultOpenMode = "browse" | "edit";
@@ -134,7 +135,7 @@ export namespace ConnectionConfiguration {
       connectringStringFor5250: parameters.connectringStringFor5250 || `localhost`,
       autoSaveBeforeAction: (parameters.autoSaveBeforeAction === true),
       showDescInLibList: (parameters.showDescInLibList === true),
-      debugCertDirectory: (parameters.debugCertDirectory || "/QIBM/ProdData/IBMiDebugService/bin/certs"),
+      debugCertDirectory: (parameters.debugCertDirectory || DEFAULT_CERT_DIRECTORY),
       debugPort: (parameters.debugPort || "8005"),
       debugIsSecure: (parameters.debugIsSecure === true),
       debugUpdateProductionFiles: (parameters.debugUpdateProductionFiles === true),

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -16,7 +16,9 @@ import * as configVars from './configVars';
 export interface MemberParts extends IBMiMember {
   basename: string
 }
+
 const CCSID_SYSVAL = -2;
+const bashShellPath = '/QOpenSys/pkgs/bin/bash';
 
 const remoteApps = [ // All names MUST also be defined as key in 'remoteFeatures' below!!
   {
@@ -58,6 +60,7 @@ export default class IBMi {
   variantChars: { american: string, local: string };
   lastErrors: object[];
   config?: ConnectionConfiguration.Parameters;
+  shell?: string;
 
   commandsExecuted: number = 0;
 
@@ -447,6 +450,14 @@ export default class IBMi {
             });
         }
 
+        const commandShellResult = await this.sendCommand({
+          command: `echo $SHELL`
+        });
+
+        if (commandShellResult.code === 0) {
+          this.shell = commandShellResult.stdout.trim();
+        }
+
         // Check for bad data areas?
         if (quickConnect === true && cachedServerSettings?.badDataAreasChecked === true) {
           // Do nothing, bad data areas are already checked.
@@ -686,13 +697,9 @@ export default class IBMi {
         if (this.remoteFeatures[`bash`]) {
           try {
             //check users default shell
-            const bashShellPath = '/QOpenSys/pkgs/bin/bash';
-            const commandShellResult = await this.sendCommand({
-              command: `echo $SHELL`
-            });
 
             if (!commandShellResult.stderr) {
-              let usesBash = commandShellResult.stdout.trim() === bashShellPath;
+              let usesBash = this.shell === bashShellPath;
               if (!usesBash) {
                 // make sure chsh is installed
                 if (this.remoteFeatures[`chsh`]) {
@@ -914,6 +921,10 @@ export default class IBMi {
     finally {
       ConnectionConfiguration.update(this.config!);
     }
+  }
+
+  usingBash() {
+    return this.shell === bashShellPath;
   }
 
   /**

--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -28,7 +28,7 @@ function resolveHostnameToIP(hostName: string): Promise<string | undefined> {
   });
 }
 
-async function getExtFileConent(host: string, connection: IBMi) {
+async function getExtFileContent(host: string, connection: IBMi) {
   const ipRegexExp = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/gi;
   let hostname = undefined;
   let ipAddr = undefined;
@@ -90,7 +90,7 @@ export async function remoteServerCertExists(connection: IBMi, legacy = false) {
  */
 export async function setup(connection: IBMi) {
   const host = connection.currentHost;
-  const extFileContent = await getExtFileConent(host, connection);
+  const extFileContent = await getExtFileContent(host, connection);
 
   if (!connection.usingBash()) {
     if (connection.remoteFeatures[`bash`]) {

--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -11,7 +11,7 @@ const clientCertName = `debug_service.crt`;
 export const LEGACY_CERT_DIRECTORY = `/QIBM/ProdData/IBMiDebugService/bin/certs`;
 export const DEFAULT_CERT_DIRECTORY = `/QIBM/UserData/IBMiDebugService/certs`;
 
-function getRemoteCertDirectory(connection: IBMi) {
+export function getRemoteCertDirectory(connection: IBMi) {
   return connection.config?.debugCertDirectory!;
 }
 

--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -113,11 +113,9 @@ export async function setup(connection: IBMi) {
   }
 
   const commands = [
-    `openssl genrsa -out debug_service_ca.key 2048`,
-    `openssl req -x509 -new -nodes -key debug_service_ca.key -sha256 -days 1825 -out debug_service_ca.pem -subj '/CN=${host}'`,
     `openssl genrsa -out debug_service.key 2048`,
     `openssl req -new -key debug_service.key -out debug_service.csr -subj '/CN=${host}'`,
-    `openssl x509 -req -in debug_service.csr -CA debug_service_ca.pem -CAkey debug_service_ca.key -CAcreateserial -out debug_service.crt -days 1095 -sha256 -sha256 -req -extfile <(printf "${extFileContent}")`,
+    `openssl x509 -req -in debug_service.csr -signkey debug_service.key -out debug_service.crt -days 1095 -sha256 -sha256 -req -extfile <(printf "${extFileContent}")`,
     `openssl pkcs12 -export -out debug_service.pfx -inkey debug_service.key -in debug_service.crt -password pass:${host}`
   ];
 

--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -104,6 +104,14 @@ export async function setup(connection: IBMi) {
   const host = connection.currentHost;
   const extFileContent = await getExtFileConent(host, connection);
 
+  if (!connection.usingBash()) {
+    if (connection.remoteFeatures[`bash`]) {
+      throw new Error(`Bash is installed on the IBM i, but it is not your default shell. Please switch to bash to setup the debug service.`);
+    } else {
+      throw new Error(`The debug service setup requires bash to be installed on the IBM i. Please install bash and try again.`);
+    }
+  }
+
   const commands = [
     `openssl genrsa -out debug_service_ca.key 2048`,
     `openssl req -x509 -new -nodes -key debug_service_ca.key -sha256 -days 1825 -out debug_service_ca.pem -subj '/CN=${host}'`,

--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -8,6 +8,9 @@ import {window} from "vscode";
 const serverCertName = `debug_service.pfx`;
 const clientCertName = `debug_service.crt`;
 
+export const LEGACY_CERT_DIRECTORY = `/QIBM/ProdData/IBMiDebugService/bin/certs`;
+export const DEFAULT_CERT_DIRECTORY = `/QIBM/UserData/IBMiDebugService/certs`;
+
 function getRemoteCertDirectory(connection: IBMi) {
   return connection.config?.debugCertDirectory!;
 }

--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -60,6 +60,10 @@ async function getExtFileConent(host: string, connection: IBMi) {
   return extFileContent;
 }
 
+function getLegacyCertPath() {
+  return path.posix.join(LEGACY_CERT_DIRECTORY, serverCertName);
+}
+
 export function getRemoteServerCertPath(connection: IBMi) {
   return path.posix.join(getRemoteCertDirectory(connection), serverCertName);
 }
@@ -68,8 +72,8 @@ export function getRemoteClientCertPath(connection: IBMi) {
   return path.posix.join(getRemoteCertDirectory(connection), clientCertName);
 }
 
-export async function remoteServerCertExists(connection: IBMi) {
-  const pfxPath = getRemoteServerCertPath(connection);
+export async function remoteServerCertExists(connection: IBMi, legacy = false) {
+  const pfxPath = legacy ? getLegacyCertPath() : getRemoteServerCertPath(connection);
 
   const dirList = await connection.sendCommand({
     command: `ls -p ${pfxPath}`

--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -116,7 +116,9 @@ export async function setup(connection: IBMi) {
     `openssl genrsa -out debug_service.key 2048`,
     `openssl req -new -key debug_service.key -out debug_service.csr -subj '/CN=${host}'`,
     `openssl x509 -req -in debug_service.csr -signkey debug_service.key -out debug_service.crt -days 1095 -sha256 -sha256 -req -extfile <(printf "${extFileContent}")`,
-    `openssl pkcs12 -export -out debug_service.pfx -inkey debug_service.key -in debug_service.crt -password pass:${host}`
+    `openssl pkcs12 -export -out debug_service.pfx -inkey debug_service.key -in debug_service.crt -password pass:${host}`,
+    `rm debug_service.key debug_service.csr`, 
+    `chmod 444 debug_service.pfx`
   ];
 
   const directory = getRemoteCertDirectory(connection);

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -58,6 +58,22 @@ export async function initialize(context: ExtensionContext) {
             }
           }
 
+          if (config.debugIsSecure) {
+            if (!await certificates.localClientCertExists(connection)) {
+              vscode.window.showInformationMessage(`Debug Service Certificates`, {
+                modal: true,
+                detail: `Debug client certificate is not setup.`
+              },
+                `Setup`
+              ).then(result => {
+                if (result === `Setup`) {
+                  vscode.commands.executeCommand(`code-for-ibmi.debug.setup.local`);
+                }
+              });
+              return;
+            }
+          }
+
           if (password) {
             const debugOpts: DebugOptions = {
               password,
@@ -240,11 +256,6 @@ export async function initialize(context: ExtensionContext) {
                 vscode.window.showInformationMessage(`Certificates successfully generated on server.`);
                 remoteCertsOk = true;
                 remoteCertsAreNew = true;
-              }
-
-              // Download the client certificates to the device if setup correctly.
-              if (remoteCertsOk) {
-                vscode.commands.executeCommand(`code-for-ibmi.debug.setup.local`);
               }
             } catch (e: any) {
               vscode.window.showErrorMessage(e.message || e);
@@ -433,11 +444,10 @@ export async function initialize(context: ExtensionContext) {
             }
           }
         } else {
-          const openTut = await vscode.window.showInformationMessage(`${
-            existingDebugService ? 
-            `Looks like the Debug Service was started by an external service. This may impact your VS Code experience.` : 
+          const openTut = await vscode.window.showInformationMessage(`${existingDebugService ?
+            `Looks like the Debug Service was started by an external service. This may impact your VS Code experience.` :
             `Looks like you have the debug PTF but don't have it configured.`
-          } Do you want to see the Walkthrough to set it up?`, `Take me there`);
+            } Do you want to see the Walkthrough to set it up?`, `Take me there`);
 
           if (openTut === `Take me there`) {
             vscode.commands.executeCommand(`workbench.action.openWalkthrough`, `halcyontechltd.vscode-ibmi-walkthroughs#code-ibmi-debug`);
@@ -450,12 +460,12 @@ export async function initialize(context: ExtensionContext) {
   vscode.commands.executeCommand(`setContext`, `code-for-ibmi:debugManaged`, isManaged());
 }
 
-function validateIPv4address(ipaddress: string) {  
-  if (/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(ipaddress)) {  
-    return (true)  
+function validateIPv4address(ipaddress: string) {
+  if (/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(ipaddress)) {
+    return (true)
   }
-  return (false)  
-}  
+  return (false)
+}
 
 interface DebugOptions {
   password: string;

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -505,7 +505,7 @@ export async function startDebug(instance: Instance, options: DebugOptions) {
       "host": connection!.currentHost,
       "port": port,
       "secure": secure,  // Enforce secure mode
-      "ignoreCertificateErrors": !secure,
+      "ignoreCertificateErrors": true,
       "library": options.library.toUpperCase(),
       "program": options.object.toUpperCase(),
       "startBatchJobCommand": `SBMJOB CMD(${currentCommand}) INLLIBL(${options.libraries.libraryList.join(` `)}) CURLIB(${options.libraries.currentLibrary}) JOBQ(QSYSNOMAX) MSGQ(*USRPRF)`,

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -411,26 +411,27 @@ export async function initialize(context: ExtensionContext) {
         // We need to migrate away from using the old legacy directory to a new one if
         // the user has the old directory configured but isn't running the server
         const usingLegacyCertPath = (certificates.getRemoteCertDirectory(connection) === certificates.LEGACY_CERT_DIRECTORY);
+        const certsExistAtConfig = await certificates.remoteServerCertExists(connection);
+
+        let changeCertDirConfig: string|undefined;
 
         if (usingLegacyCertPath) {
-          let changeCertDirConfig = false;
           if (existingDebugService) {
             // The server is running and they still have the legacy path configured. Do certs exist inside of the legacy path?
-            const legacyCertsExist = await certificates.remoteServerCertExists(connection);
 
             // If the legacy certs do exist, it might be using them!
 
             // If not...
-            if (!legacyCertsExist) {
+            if (!certsExistAtConfig) {
               // The server is running but the certs don't exist in the legacy path. 
               // Let's change their default path from the legacy path to the new default path!
-              changeCertDirConfig = true;
+              changeCertDirConfig = certificates.DEFAULT_CERT_DIRECTORY;
             }
 
           } else {
             // The server isn't running. Let's change their default path from the legacy path
             // to the new default path! And even.. let's try and delete the old certs directory!
-            changeCertDirConfig = true;
+            changeCertDirConfig = certificates.DEFAULT_CERT_DIRECTORY;
 
             // To be safe, let's try to delete the old directory.
             // We don't care if it fails really.
@@ -438,13 +439,26 @@ export async function initialize(context: ExtensionContext) {
               command: `rm -rf ${certificates.LEGACY_CERT_DIRECTORY}`,
             })
           }
+        } else {
+          // If the config isn't using the legacy path, we should check if the legacy certificates exist
 
-          if (changeCertDirConfig) {
-            await ConnectionConfiguration.update({
-              ...connection.config!,
-              debugCertDirectory: certificates.DEFAULT_CERT_DIRECTORY
-            })
+          if (existingDebugService) {
+            if (!certsExistAtConfig) {
+              // The server is running but the certs don't exist in the new path, let's
+              // check if they exist at the legacy path and switch back to that
+              const legacyCertsExist = await certificates.remoteServerCertExists(connection, true);
+              if (legacyCertsExist) {
+                changeCertDirConfig = certificates.LEGACY_CERT_DIRECTORY;
+              }
+            }
           }
+        }
+
+        if (changeCertDirConfig) {
+          await ConnectionConfiguration.update({
+            ...connection.config!,
+            debugCertDirectory: changeCertDirConfig
+          })
         }
 
         const remoteCertsExist = await certificates.remoteServerCertExists(connection);

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -58,7 +58,7 @@ export async function initialize(context: ExtensionContext) {
             }
           }
 
-          if (config.debugIsSecure) {
+          if (config.debugIsSecure && !isManaged()) {
             if (!await certificates.localClientCertExists(connection)) {
               vscode.window.showInformationMessage(`Debug Service Certificates`, {
                 modal: true,

--- a/src/api/debug/server.ts
+++ b/src/api/debug/server.ts
@@ -25,7 +25,7 @@ export async function startup(connection: IBMi) {
 
   const password = encryptResult.stdout;
 
-  const keystorePath = certificates.getRemoteServerCertPath(connection);
+  const keystorePath = certificates.getRemoteServerCertificatePath(connection);
 
   connection.sendCommand({
     command: `${MY_JAVA_HOME} DEBUG_SERVICE_KEYSTORE_PASSWORD="${password}" DEBUG_SERVICE_KEYSTORE_FILE="${keystorePath}" /QOpenSys/usr/bin/nohup "${path.posix.join(serverDirectory, `startDebugService.sh`)}"`

--- a/src/api/debug/server.ts
+++ b/src/api/debug/server.ts
@@ -5,14 +5,14 @@ import IBMi from "../IBMi";
 import IBMiContent from "../IBMiContent";
 import * as certificates from "./certificates";
 
-const directory = `/QIBM/ProdData/IBMiDebugService/bin/`;
+const serverDirectory = `/QIBM/ProdData/IBMiDebugService/bin/`;
 const MY_JAVA_HOME = `MY_JAVA_HOME="/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit"`;
 
 export async function startup(connection: IBMi) {
   const host = connection.currentHost;
 
   const encryptResult = await connection.sendCommand({
-    command: `${MY_JAVA_HOME} DEBUG_SERVICE_KEYSTORE_PASSWORD="${host}" ${path.posix.join(directory, `encryptKeystorePassword.sh`)} | /usr/bin/tail -n 1`
+    command: `${MY_JAVA_HOME} DEBUG_SERVICE_KEYSTORE_PASSWORD="${host}" ${path.posix.join(serverDirectory, `encryptKeystorePassword.sh`)} | /usr/bin/tail -n 1`
   });
 
   if ((encryptResult.code || 0) >= 1) {
@@ -28,7 +28,7 @@ export async function startup(connection: IBMi) {
   const keystorePath = certificates.getRemoteServerCertPath(connection);
 
   connection.sendCommand({
-    command: `${MY_JAVA_HOME} DEBUG_SERVICE_KEYSTORE_PASSWORD="${password}" DEBUG_SERVICE_KEYSTORE_FILE="${keystorePath}" /QOpenSys/usr/bin/nohup "${path.posix.join(directory, `startDebugService.sh`)}"`
+    command: `${MY_JAVA_HOME} DEBUG_SERVICE_KEYSTORE_PASSWORD="${password}" DEBUG_SERVICE_KEYSTORE_FILE="${keystorePath}" /QOpenSys/usr/bin/nohup "${path.posix.join(serverDirectory, `startDebugService.sh`)}"`
   }).then(startResult => {
     if ((startResult.code || 0) >= 1) {
       window.showErrorMessage(startResult.stdout || startResult.stderr);
@@ -40,7 +40,7 @@ export async function startup(connection: IBMi) {
 
 export async function stop(connection: IBMi) {
   const endResult = await connection.sendCommand({
-    command: `${path.posix.join(directory, `stopDebugService.sh`)}`
+    command: `${path.posix.join(serverDirectory, `stopDebugService.sh`)}`
   });
 
   if (endResult.code === 0) {
@@ -58,7 +58,7 @@ export async function getRunningJob(localPort: string, content: IBMiContent): Pr
 
 export async function end(connection: IBMi): Promise<void> {
   const endResult = await connection.sendCommand({
-    command: `${MY_JAVA_HOME} ${path.posix.join(directory, `stopDebugService.sh`)}`
+    command: `${MY_JAVA_HOME} ${path.posix.join(serverDirectory, `stopDebugService.sh`)}`
   });
 
   if (endResult.code && endResult.code >= 0) {


### PR DESCRIPTION
### Changes

High level API:

* Adds new `usingBash` method to the `IBMi` class

Debug specific:

* [x] Changes default location for debugger certificates out of ProdData
* [x] Logic written to support uses who are already using the legacy debug certificate directory (inside ProdData)
* [x] Require bash setup before generating certificates
* [x] No longer use a CA when generating certificates
* [x] Documentation PR created and attached to this PR: https://github.com/codefori/docs/pull/27

The walkthroughs need to be updated too, but that will be done in another PR after this as we plan on migrating all walkthroughs to this extension.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
