### PR TITLE
Abstract API for running multiple statements

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -246,6 +246,14 @@ export default class IBMiContent {
   }
 
   /**
+   * @param statements Either an SQL statement or CL statement. CL statements start with @
+   * @returns result set
+   */
+  runStatements(statements: string[]): Promise<Tools.DB2Row[]> {
+    return this.runSQL(statements.map(s => s.trimEnd().endsWith(`;`) ? s : `${s};`).join(`\n`));
+  }
+
+  /**
    * Run SQL statements.
    * Each statement must be separated by a semi-colon and a new line (i.e. ;\n).
    * If a statement starts with @, it will be run as a CL command.
@@ -374,10 +382,11 @@ export default class IBMiContent {
    * @param table : the name of the table expected to be found in QTEMP
    * @returns : the table's content
    */
-  async getQTempTable(prepareQueries: string[], table: string): Promise<Tools.DB2Row[]> {
-    prepareQueries.push(`Select * From QTEMP.${table}`);
-    const fullQuery = prepareQueries.map(query => query.endsWith(';') ? query : `${query};`).join("\n");
-    return await this.runSQL(fullQuery);
+  getQTempTable(prepareQueries: string[], table: string): Promise<Tools.DB2Row[]> {
+    return this.runStatements([
+      ...prepareQueries,
+      `select * from QTEMP.${table}`
+    ])
   }
 
   /**

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -595,10 +595,18 @@ export const ContentSuite: TestSuite = {
       name: `Test @clCommand + select statement`, test: async () => {
         const content = instance.getContent()!;
         
-        const [result] = await content.runSQL(`@CRTSAVF FILE(QTEMP/UNITTEST) TEXT('Code for i test');\nSelect * From Table(QSYS2.OBJECT_STATISTICS('QTEMP', '*FILE')) Where OBJATTRIBUTE = 'SAVF';`);
+        const [resultA] = await content.runSQL(`@CRTSAVF FILE(QTEMP/UNITTEST) TEXT('Code for i test');\nSelect * From Table(QSYS2.OBJECT_STATISTICS('QTEMP', '*FILE')) Where OBJATTRIBUTE = 'SAVF';`);
         
-        assert.deepStrictEqual(result.OBJNAME, "UNITTEST");
-        assert.deepStrictEqual(result.OBJTEXT, "Code for i test");
+        assert.deepStrictEqual(resultA.OBJNAME, "UNITTEST");
+        assert.deepStrictEqual(resultA.OBJTEXT, "Code for i test");
+        
+        const [resultB] = await content.runStatements([
+          `@CRTSAVF FILE(QTEMP/UNITTEST) TEXT('Code for i test')`,
+          `Select * From Table(QSYS2.OBJECT_STATISTICS('QTEMP', '*FILE')) Where OBJATTRIBUTE = 'SAVF'`
+        ]);
+        
+        assert.deepStrictEqual(resultB.OBJNAME, "UNITTEST");
+        assert.deepStrictEqual(resultB.OBJTEXT, "Code for i test");
       }
     },
   ]


### PR DESCRIPTION
### Changes

I have added an API called `runStatements`, which just allows us to pass an array of statements, be it SQL or CL, to be executed in the same job.

I also changed `getQtempTable` to use this API as an example of how it works.

### Checklist

* [x] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
