### PR TITLE
'Add to library list' and 'Set as current library' actions on browsers items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1138,9 +1138,16 @@
 				"category": "IBM i"
 			},
 			{
-				"command": "code-for-ibmi.addToLibraryList",
+				"command": "code-for-ibmi.addToLibraryList.prompt",
 				"enablement": "code-for-ibmi:connected",
 				"title": "Add to Library List...",
+				"category": "IBM i",
+				"icon": "$(add)"
+			},
+			{
+				"command": "code-for-ibmi.addToLibraryList",
+				"enablement": "code-for-ibmi:connected",
+				"title": "Add to Library List",
 				"category": "IBM i",
 				"icon": "$(add)"
 			},
@@ -2049,7 +2056,7 @@
 					"when": "view == libraryListView"
 				},
 				{
-					"command": "code-for-ibmi.addToLibraryList",
+					"command": "code-for-ibmi.addToLibraryList.prompt",
 					"group": "navigation",
 					"when": "view == libraryListView"
 				},

--- a/package.json
+++ b/package.json
@@ -1108,7 +1108,7 @@
 				"command": "code-for-ibmi.setCurrentLibrary",
 				"enablement": "code-for-ibmi:connected",
 				"title": "Set as Current Library",
-				"category": "IBM i"				
+				"category": "IBM i"
 			},
 			{
 				"command": "code-for-ibmi.changeUserLibraryList",
@@ -2031,8 +2031,7 @@
 				{
 					"command": "code-for-ibmi.addToLibraryList",
 					"when": "never"
-				}
-				,
+				},
 				{
 					"command": "code-for-ibmi.addToLibraryList.prompt",
 					"when": "!code-for-ibmi:libraryListDisabled"

--- a/package.json
+++ b/package.json
@@ -1107,7 +1107,7 @@
 			{
 				"command": "code-for-ibmi.setCurrentLibrary",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Set as current library",
+				"title": "Set as Current Library",
 				"category": "IBM i"				
 			},
 			{

--- a/package.json
+++ b/package.json
@@ -2027,6 +2027,15 @@
 				{
 					"command": "code-for-ibmi.setCurrentLibrary",
 					"when": "never"
+				},
+				{
+					"command": "code-for-ibmi.addToLibraryList",
+					"when": "never"
+				}
+				,
+				{
+					"command": "code-for-ibmi.addToLibraryList.prompt",
+					"when": "!code-for-ibmi:libraryListDisabled"
 				}
 			],
 			"view/title": [

--- a/package.json
+++ b/package.json
@@ -2354,12 +2354,12 @@
 				},
 				{
 					"command": "code-for-ibmi.addToLibraryList",
-					"when": "!code-for-ibmi:libraryListDisabled && view == objectBrowser && viewItem =~ /^(filter|object.lib).*/",
+					"when": "!code-for-ibmi:libraryListDisabled && view == objectBrowser && viewItem =~ /library/",
 					"group": "2_library@1"
 				},
 				{
 					"command": "code-for-ibmi.setCurrentLibrary",
-					"when": "!code-for-ibmi:libraryListDisabled && view == objectBrowser && viewItem =~ /^(filter|object.lib).*/",
+					"when": "!code-for-ibmi:libraryListDisabled && view == objectBrowser && viewItem =~ /library/",
 					"group": "2_library@2"
 				},
 				{
@@ -2559,7 +2559,7 @@
 				},
 				{
 					"command": "code-for-ibmi.createSourceFile",
-					"when": "view == objectBrowser && viewItem == filter",
+					"when": "view == objectBrowser && viewItem =~ /library/",
 					"group": "1_LibActions@1"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -1105,6 +1105,12 @@
 				"icon": "$(root-folder)"
 			},
 			{
+				"command": "code-for-ibmi.setCurrentLibrary",
+				"enablement": "code-for-ibmi:connected",
+				"title": "Set as current library",
+				"category": "IBM i"				
+			},
+			{
 				"command": "code-for-ibmi.changeUserLibraryList",
 				"enablement": "code-for-ibmi:connected",
 				"title": "Change Library List...",
@@ -2010,6 +2016,10 @@
 				{
 					"command": "code-for-ibmi.removeIFSShortcut",
 					"when": "never"
+				},
+				{
+					"command": "code-for-ibmi.setCurrentLibrary",
+					"when": "never"
 				}
 			],
 			"view/title": [
@@ -2233,9 +2243,14 @@
 					"group": "libraryChangeCurrent@1"
 				},
 				{
+					"command": "code-for-ibmi.setCurrentLibrary",
+					"when": "view == libraryListView && viewItem == library",
+					"group": "01libraryActions@01"
+				},
+				{
 					"command": "code-for-ibmi.removeFromLibraryList",
 					"when": "view == libraryListView && viewItem == library",
-					"group": "libraryRemove@1"
+					"group": "02libraryActions@01"
 				},
 				{
 					"command": "code-for-ibmi.saveConnectionProfile",
@@ -2336,6 +2351,16 @@
 					"command": "code-for-ibmi.debug.program",
 					"when": "view == objectBrowser && !inDebugMode && viewItem =~ /^object.pgm.*/",
 					"group": "2_debug@1"
+				},
+				{
+					"command": "code-for-ibmi.addToLibraryList",
+					"when": "!code-for-ibmi:libraryListDisabled && view == objectBrowser && viewItem =~ /^(filter|object.lib).*/",
+					"group": "2_library@1"
+				},
+				{
+					"command": "code-for-ibmi.setCurrentLibrary",
+					"when": "!code-for-ibmi:libraryListDisabled && view == objectBrowser && viewItem =~ /^(filter|object.lib).*/",
+					"group": "2_library@2"
 				},
 				{
 					"command": "code-for-ibmi.updateMemberText",

--- a/src/locale/ids/da.ts
+++ b/src/locale/ids/da.ts
@@ -149,6 +149,7 @@ export const da: Locale = {
   'LibraryListView.removeFromLibraryList.removedLib': `Bibliotek {0} blev fjernet fra bibliotekslisten.`,
   'LibraryListView.cleanupLibraryList.removedLibs': `De følgende biblioteker blev fjernet fra den opdaterede biblioteksliste, da de ikke er gyldige: {0}`,
   'LibraryListView.cleanupLibraryList.validated': `Bibliotekslisten blev valideret uden fejl.`,
+  'LibraryListView.setCurrentLibrary.failed':'Failed to set {0} as current library: {1}',
   // objectBrowser:
   'objectBrowser.delete.confirm':'Er du sikker på at du vil slette {0}?',
   'objectBrowser.delete.multiple.confirm':'Er du sikker på at du vil slette de {0} valgte elementer?',

--- a/src/locale/ids/da.ts
+++ b/src/locale/ids/da.ts
@@ -149,7 +149,7 @@ export const da: Locale = {
   'LibraryListView.removeFromLibraryList.removedLib': `Bibliotek {0} blev fjernet fra bibliotekslisten.`,
   'LibraryListView.cleanupLibraryList.removedLibs': `De følgende biblioteker blev fjernet fra den opdaterede biblioteksliste, da de ikke er gyldige: {0}`,
   'LibraryListView.cleanupLibraryList.validated': `Bibliotekslisten blev valideret uden fejl.`,
-  'LibraryListView.setCurrentLibrary.failed':'Failed to set {0} as current library: {1}',
+  'LibraryListView.setCurrentLibrary.failed':'Fejl ved skift til {0} som aktuelt bibliotek: {1}',
   // objectBrowser:
   'objectBrowser.delete.confirm':'Er du sikker på at du vil slette {0}?',
   'objectBrowser.delete.multiple.confirm':'Er du sikker på at du vil slette de {0} valgte elementer?',

--- a/src/locale/ids/en.ts
+++ b/src/locale/ids/en.ts
@@ -149,6 +149,7 @@ export const en: Locale = {
   'LibraryListView.removeFromLibraryList.removedLib': `Library {0} was removed from the library list.`,
   'LibraryListView.cleanupLibraryList.removedLibs': `The following libraries were removed from the updated library list as they are invalid: {0}`,
   'LibraryListView.cleanupLibraryList.validated': `Library list were validated without any errors.`,
+  'LibraryListView.setCurrentLibrary.failed':'Failed to set {0} as current library: {1}',
   // objectBrowser:
   'objectBrowser.delete.confirm':'Are you sure you want to delete {0}?',
   'objectBrowser.delete.multiple.confirm':'Are you sure you want to delete these {0} elements?',

--- a/src/locale/ids/fr.ts
+++ b/src/locale/ids/fr.ts
@@ -149,6 +149,7 @@ export const fr: Locale = {
   'LibraryListView.removeFromLibraryList.removedLib': `La bibliohtèque {0} a été retirée de la liste des bibliothèques.`,
   'LibraryListView.cleanupLibraryList.removedLibs': `Les bibliothèques suivantes ont été retirées de la liste des bibliothèques mise à jour car elles sont invalides: {0}`,
   'LibraryListView.cleanupLibraryList.validated': `La liste des bibliothèques a été validée avec succès.`,
+  'LibraryListView.setCurrentLibrary.failed':'La bibliothèque {0} ne peut pas devenir la bibliothèque en cours: {1}',
   // objectBrowser:
   'objectBrowser.delete.confirm':'Êtes-vous sûr de vouloir supprimer {0}?',
   'objectBrowser.delete.multiple.confirm':'Êtes-vous sûr de vouloir supprimer les {0} éléments sélectionnés?',

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -158,7 +158,7 @@ export interface WithPath {
 }
 
 export interface WithLibrary {
-  library:string
+  library: string
 }
 
 export type FocusOptions = { select?: boolean; focus?: boolean; expand?: boolean | number }

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -157,7 +157,9 @@ export interface WithPath {
   path: string
 }
 
-export interface Library extends WithPath { }
+export interface WithLibrary {
+  library:string
+}
 
 export type FocusOptions = { select?: boolean; focus?: boolean; expand?: boolean | number }
 

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -12,7 +12,7 @@ import { Tools } from "../api/Tools";
 import { getMemberUri } from "../filesystems/qsys/QSysFs";
 import { instance, setSearchResults } from "../instantiate";
 import { t } from "../locale";
-import { BrowserItem, BrowserItemParameters, CommandResult, FilteredItem, FocusOptions, IBMiMember, IBMiObject, MemberItem, OBJECT_BROWSER_MIMETYPE, ObjectItem } from "../typings";
+import { BrowserItem, BrowserItemParameters, CommandResult, FilteredItem, FocusOptions, IBMiMember, IBMiObject, MemberItem, OBJECT_BROWSER_MIMETYPE, ObjectItem, WithLibrary } from "../typings";
 import { editFilter } from "../webviews/filters";
 
 const URI_LIST_SEPARATOR = "\r\n";
@@ -160,10 +160,12 @@ class CreateFilterItem extends BrowserItem {
   }
 }
 
-class ObjectBrowserFilterItem extends ObjectBrowserItem {
+class ObjectBrowserFilterItem extends ObjectBrowserItem implements WithLibrary {
+  readonly library: string;
   constructor(filter: ConnectionConfiguration.ObjectFilters) {
     super(filter, filter.name, { icon: filter.protected ? `lock-small` : '', state: vscode.TreeItemCollapsibleState.Collapsed });
-    this.contextValue = `filter${this.isProtected() ? `_readonly` : ``}`;
+    this.library = parseFilter(filter.library, filter.filterType).noFilter ? filter.library : '';
+    this.contextValue = `filter${this.library ? "_library" : ''}${this.isProtected() ? `_readonly` : ``}`;
     this.description = `${filter.library}/${filter.object}/${filter.member}.${filter.memberType || `*`} (${filter.types.join(`, `)})`;
     this.tooltip = ``;
   }
@@ -308,8 +310,9 @@ class ObjectBrowserSourcePhysicalFileItem extends ObjectBrowserItem implements O
   }
 }
 
-class ObjectBrowserObjectItem extends ObjectBrowserItem implements ObjectItem {
+class ObjectBrowserObjectItem extends ObjectBrowserItem implements ObjectItem, WithLibrary {
   readonly path: string;
+  readonly library: string;
 
   constructor(parent: ObjectBrowserFilterItem, readonly object: IBMiObject) {
     const type = object.type.startsWith(`*`) ? object.type.substring(1) : object.type;
@@ -317,10 +320,11 @@ class ObjectBrowserObjectItem extends ObjectBrowserItem implements ObjectItem {
     const isLibrary = type === 'LIB';
     super(parent.filter, correctCase(`${object.name}.${type}`), { icon, parent, state: isLibrary ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None });
 
+    this.library = isLibrary ? object.name : '';
     this.path = [object.library, object.name].join(`/`);
     this.updateDescription();
 
-    this.contextValue = `object.${type.toLowerCase()}${object.attribute ? `.${object.attribute}` : ``}${this.isProtected() ? `_readonly` : ``}`;
+    this.contextValue = `object.${type.toLowerCase()}${object.attribute ? `.${object.attribute}` : ``}${isLibrary ? '_library' : ''}${this.isProtected() ? `_readonly` : ``}`;
     this.tooltip = new vscode.MarkdownString(Tools.generateTooltipHtmlTable(this.path, {
       type: object.type,
       attribute: object.attribute,
@@ -798,7 +802,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         if (item instanceof ObjectBrowserSourcePhysicalFileItem) {
           members.push(...await contentApi.getMemberList({ library: item.object.library, sourceFile: item.object.name }));
         }
-        else if(item instanceof ObjectBrowserMemberItem) {
+        else if (item instanceof ObjectBrowserMemberItem) {
           members.push(item.member);
         }
       }
@@ -1038,28 +1042,29 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
       }
     }),
 
-    vscode.commands.registerCommand(`code-for-ibmi.createSourceFile`, async (node: ObjectBrowserFilterItem) => {
-      const filter = node.filter;
-      const fileName = await vscode.window.showInputBox({
-        prompt: t(`objectBrowser.createSourceFile.prompt`),
-        validateInput: (fileName => fileName.length > 10 ? t('objectBrowser.createSourceFile.errorMessage2') : undefined)
-      });
-
-      if (fileName) {
-        const connection = getConnection();
-        const library = filter.library;
-        const uriPath = `${library}/${fileName.toUpperCase()}`
-
-        vscode.window.showInformationMessage(t(`objectBrowser.createSourceFile.infoMessage`, uriPath));
-        const createResult = await connection.runCommand({
-          command: `CRTSRCPF FILE(${uriPath}) RCDLEN(112)`,
-          noLibList: true
+    vscode.commands.registerCommand(`code-for-ibmi.createSourceFile`, async (node: ObjectBrowserFilterItem | ObjectBrowserObjectItem) => {
+      if (node.library) {
+        const fileName = await vscode.window.showInputBox({
+          prompt: t(`objectBrowser.createSourceFile.prompt`),
+          validateInput: (fileName => fileName.length > 10 ? t('objectBrowser.createSourceFile.errorMessage2') : undefined)
         });
 
-        if (createResult.code === 0) {
-          objectBrowser.refresh(node);
-        } else {
-          vscode.window.showErrorMessage(t(`objectBrowser.createSourceFile.errorMessage`, createResult.stderr));
+        if (fileName) {
+          const connection = getConnection();
+          const library = node.library;
+          const uriPath = `${library}/${fileName.toUpperCase()}`
+
+          vscode.window.showInformationMessage(t(`objectBrowser.createSourceFile.infoMessage`, uriPath));
+          const createResult = await connection.runCommand({
+            command: `CRTSRCPF FILE(${uriPath}) RCDLEN(112)`,
+            noLibList: true
+          });
+
+          if (createResult.code === 0) {
+            objectBrowser.refresh(node);
+          } else {
+            vscode.window.showErrorMessage(t(`objectBrowser.createSourceFile.errorMessage`, createResult.stderr));
+          }
         }
       }
     }),

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -1,7 +1,6 @@
 import fs, { existsSync } from "fs";
 import os from "os";
 import path, { basename, dirname } from "path";
-import util from "util";
 import vscode from "vscode";
 import { ConnectionConfiguration, DefaultOpenMode, GlobalConfiguration } from "../api/Configuration";
 import { parseFilter } from "../api/Filter";
@@ -18,7 +17,6 @@ import { editFilter } from "../webviews/filters";
 
 const URI_LIST_SEPARATOR = "\r\n";
 
-const writeFileAsync = util.promisify(fs.writeFile);
 const objectNamesLower = () => GlobalConfiguration.get<boolean>(`ObjectBrowser.showNamesInLowercase`);
 const objectSortOrder = () => GlobalConfiguration.get<SortOrder>(`ObjectBrowser.sortObjectsByName`) ? `name` : `type`;
 

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -1032,7 +1032,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
           .then(async result => {
             switch (result) {
               case t(`Yes`):
-                await vscode.commands.executeCommand(`code-for-ibmi.addToLibraryList`, newLibrary);
+                await vscode.commands.executeCommand(`code-for-ibmi.addToLibraryList`, { library: newLibrary });
                 if (autoRefresh) {
                   vscode.commands.executeCommand(`code-for-ibmi.refreshLibraryListView`);
                 }


### PR DESCRIPTION
### Changes
This PR adds a new `Set as current library` action, available from:
- Libraries in the `User Library List` view
- Single library Filters and .lib objects from the `Object Browser`

It adds the `Add to library list` action on:
- Single library Filters and .lib objects from the `Object Browser`

![image](https://github.com/codefori/vscode-ibmi/assets/11096890/fa9521c3-f1cb-4290-9bb3-b0159630b24d)

It also allows to run `Create source file` action on:
- Single library  Filters and .lib objects from the `Object Browser`

Finally, it removes `Add to library list...` from command palette when library list view is disabled

@chrjorgensen, I'll need your help for one translation 😄 

### How to test
- Try `Add to library list` action from:
  - A library from the `User Library List` view
  - A filter from the `Object Browser`
  - A .lib object from the `Object Browser`
  - The `User Library List` view's title
- Try `Set as current library` action from:
  - A library from the `User Library List` view
  - A filter from the `Object Browser`
  - A .lib object from the `Object Browser`

### Checklist
* [x] have tested my change