### PR TITLE
Don't show context sensitive commands in Command Palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -1838,7 +1838,7 @@
 				},
 				{
 					"command": "code-for-ibmi.selectForCompare",
-					"when": "code-for-ibmi:connected"
+					"when": "never"
 				},
 				{
 					"command": "code-for-ibmi.compareWithSelected",
@@ -2035,7 +2035,88 @@
 				{
 					"command": "code-for-ibmi.addToLibraryList.prompt",
 					"when": "!code-for-ibmi:libraryListDisabled"
-				}
+				},
+        {
+          "command": "code-for-ibmi.showLoginSettings",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.connect",
+          "when": "!code-for-ibmi:connected"
+        },
+        {
+          "command": "code-for-ibmi.collapseSearchView",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.closeSearchView",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.removeFromLibraryList",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.debug.program",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.copyFilter",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.objectBrowser.delete",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.maintainFilter",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.sortFilters",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.moveFilterUp",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.moveFilterDown",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.sortIFSShortcuts",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.uploadStreamfile",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.moveLibraryUp",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.moveLibraryDown",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.refreshLibraryListView",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.refreshMemberBrowser",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.refreshIFSBrowserItem",
+          "when": "never"
+        },
+        {
+          "command": "code-for-ibmi.refreshObjectBrowser",
+          "when": "never"
+        }
+
 			],
 			"view/title": [
 				{


### PR DESCRIPTION
### Changes

This PR will stop Command Palette from showing IBM i commands, which are context sensitive and should not be available as a command:
- `IBM i: New Connection` is only available when not connected (when connected it would disconnect the current connection without warning)
- the following commands are removed:
  `IBM i: Login Settings`
  `IBM i: Close` (search view)
  `IBM i: Collapse All` (search view)
  `IBM i: Debug Program`
  `IBM i: Delete...` (in object browser)
  `IBM i: Select for Compare`
  `IBM i: Change...` (filter)
  `IBM i: Sort Filters`
  `IBM i: Move Up` (filter)
  `IBM i: Move Down` (filter)
  `IBM i: Sort Shortcuts`
  `IBM i: Upload...` (streamfile)
  `IBM i: Move Up` (library)
  `IBM i: Move Down` (library)
  `IBM i: Remove from Library List`
  `IBM i: Refresh` (library list view)
  `IBM i: Refresh` (member browser)
  `IBM i: Refresh` (IFS browser item)
  `IBM i: Refresh` (object browser view)

### Checklist

* [x] have tested my change
