### PR TITLE
Fixed file extension when downloading a single IFS file

### DIFF
--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -748,7 +748,7 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
           const remoteFilepath = path.join(ibmi.getLastDownloadLocation(), path.basename(node.path));
           downloadLocation = (await vscode.window.showSaveDialog({
             defaultUri: vscode.Uri.file(remoteFilepath),
-            filters: { 'Streamfile': [extname(node.path) || '*'] }
+            filters: { 'Streamfile': [extname(node.path).substring(1) || '*'] }
           }))?.path;
         }
 
@@ -760,7 +760,7 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
               for (const item of items) {
                 const targetPath = item.path;
                 task.report({ message: targetPath, increment });
-                if (saveIntoDirectory) {                  
+                if (saveIntoDirectory) {
                   const target = path.join(Tools.fixWindowsPath(downloadLocation!), path.basename(targetPath));
                   if (item.file.type === "directory") {
                     let proceed = !existsSync(target);
@@ -782,7 +782,7 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
                     }
                   }
                 }
-                else{
+                else {
                   await ibmi.downloadFile(downloadLocation!, targetPath);
                 }
               }
@@ -871,6 +871,6 @@ async function showOpenDialog() {
 /**
  * Filters the content of an IFSItem array to keep only items whose parent are not in the array
  */
-function reduceIFSPath(item: IFSItem, index: number, array: IFSItem[]) {  
-    return !array.filter(i => i.file.type === "directory" && i !== item).some(folder => item.file.path.startsWith(folder.file.path));
+function reduceIFSPath(item: IFSItem, index: number, array: IFSItem[]) {
+  return !array.filter(i => i.file.type === "directory" && i !== item).some(folder => item.file.path.startsWith(folder.file.path));
 }


### PR DESCRIPTION
### Changes
When downloading a single IFS file, the extension in the File selection dialog is not right (it starts with `.`) and the dialog doesn't show the files with this extension:
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/310ec46b-8ab2-4c65-8666-6a40606bba50)

This PR removes the `.` in the extension name and fixes this issue:
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/4a954918-d722-42c6-920e-da362dc1ac64)


### How to test this PR
1. With version 2.8.0: try downloading a single file from the IFS browser: extension is wrong, no existing files with the extension are shown.
2. With the PR checked out: try downloading a single file from the IFS browser: extension is OK, files with the same extension in the folder are shown.

### Checklist
* [x] have tested my change