### PR TITLE
Added "Duplicate connection" action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1035,6 +1035,11 @@
 				"category": "IBM i"
 			},
 			{
+				"command": "code-for-ibmi.duplicateConnection",
+				"title": "Duplicate...",
+				"category": "IBM i"
+			},
+			{
 				"command": "code-for-ibmi.disconnect",
 				"enablement": "code-for-ibmi:connected",
 				"title": "Disconnect",
@@ -1829,6 +1834,10 @@
 					"when": "never"
 				},
 				{
+					"command": "code-for-ibmi.duplicateConnection",
+					"when": "never"
+				},
+				{
 					"command": "code-for-ibmi.disconnect",
 					"when": "code-for-ibmi:connected"
 				},
@@ -2273,9 +2282,14 @@
 					"group": "2_delete@1"
 				},
 				{
+					"command": "code-for-ibmi.duplicateConnection",
+					"when": "view == connectionBrowser && !listMultiSelection && viewItem == server",
+					"group": "2_delete@2"
+				},
+				{
 					"command": "code-for-ibmi.deleteConnection",
 					"when": "view == connectionBrowser && viewItem == server",
-					"group": "2_delete@2"
+					"group": "2_delete@3"
 				},
 				{
 					"command": "code-for-ibmi.showAdditionalSettings",

--- a/src/locale/ids/da.ts
+++ b/src/locale/ids/da.ts
@@ -66,6 +66,9 @@ export const da: Locale = {
   'connectionBrowser.deleteConnection.multiple.warning': `Er du sikker på at du vil slette disse {0} forbindelser?`,
   'connectionBrowser.ServerItem.tooltip': ` (forrige forbindelse)`,
   'connectionBrowser.ServerItem.title': `Forbind`,
+  'connectionBrowser.duplicateConnection.prompt':'Duplicate connection {0}',
+  'connectionBrowser.duplicateConnection.placeholder':'New connection name',
+  'connectionBrowser.duplicateConnection.already.exists':'Connection {0} already exists',
   // helpView:
   'helpView.getStarted': `Dokumentation`,
   'helpView.officialForum': `Forum`,

--- a/src/locale/ids/en.ts
+++ b/src/locale/ids/en.ts
@@ -66,6 +66,9 @@ export const en: Locale = {
   'connectionBrowser.deleteConnection.multiple.warning': `Are you sure you want to delete these {0} connections?`,
   'connectionBrowser.ServerItem.tooltip': ` (previous connection)`,
   'connectionBrowser.ServerItem.title': `Connect`,
+  'connectionBrowser.duplicateConnection.prompt':'Duplicate connection {0}',
+  'connectionBrowser.duplicateConnection.placeholder':'New connection name',
+  'connectionBrowser.duplicateConnection.already.exists':'Connection {0} already exists',
   // helpView:
   'helpView.getStarted': `Get started`,
   'helpView.officialForum': `Open official Forum`,

--- a/src/locale/ids/fr.ts
+++ b/src/locale/ids/fr.ts
@@ -66,6 +66,9 @@ export const fr: Locale = {
   'connectionBrowser.deleteConnection.multiple.warning': `Êtes vous sûr de vouloir supprimer ces {0} connexions?`,
   'connectionBrowser.ServerItem.tooltip': ` (précédente connexion)`,
   'connectionBrowser.ServerItem.title': `Se Connecter`,
+  'connectionBrowser.duplicateConnection.prompt':'Dupliquer la connextion {0}',
+  'connectionBrowser.duplicateConnection.placeholder':'Nouveau nom de connexion',
+  'connectionBrowser.duplicateConnection.already.exists':'La connexion {0} existe déjà',
   // helpView:
   'helpView.getStarted': `Pour commencer`,
   'helpView.officialForum': `Forum officiel`,


### PR DESCRIPTION
### Changes
Resolves https://github.com/codefori/vscode-ibmi/issues/1925

This PR adds the `Duplicate...` action on the connections browser items:
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/88a254df-463b-433b-8df8-6a09fe8a7398)

When run, it will prompt the user for the new connection name. If a new, non existing name is provided, the login settings will be duplicated as well as the connection parameters, except the following fields:
- `homeDirectory`
- `currentLibrary`
- `libraryList`
- `objectFilters`
- `ifsShortcuts`
- `customVariables`
- `commandProfiles`
- `connectionProfiles`

But maybe this should be optional to keep them when duplicating? 🤔
@chrjorgensen your Danish translations will be much appreciated 😉

### How to test this PR
1. Run the action on a connection
2. Check it doesn't allow to use an existing name for the new connection
3. Check if the settings have been duplicated (except filters, profiles, etc)
4. Check if the new connection works

### Checklist
* [x] have tested my change