### PR TITLE
Fixed drag crashing for streamfiles

### DIFF
--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -138,10 +138,12 @@ class IFSFileItem extends IFSItem {
     this.contextValue = "streamfile";
     this.iconPath = vscode.ThemeIcon.File;
 
-    this.resourceUri = vscode.Uri.parse(this.path).with({ scheme: `streamfile` }); this.command = {
+    this.resourceUri = vscode.Uri.parse(this.path).with({ scheme: `streamfile` });
+    
+    this.command = {
       command: "code-for-ibmi.openWithDefaultMode",
       title: `Open Streamfile`,
-      arguments: [this]
+      arguments: [{path: this.path}]
     };
   }
 

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -400,7 +400,7 @@ class ObjectBrowserMemberItem extends ObjectBrowserItem implements MemberItem {
     this.command = {
       command: "code-for-ibmi.openWithDefaultMode",
       title: `Open Member`,
-      arguments: [this, (readonly ? "browse" : undefined) as DefaultOpenMode]
+      arguments: [{path: this.path}, (readonly ? "browse" : undefined) as DefaultOpenMode]
     };
 
     this.readonly = readonly;


### PR DESCRIPTION
### Changes
This fixes an issue preventing streamfiles from being dragged and dropped from the IFS browser.
Dragging a streamfile would trigger the following error, shown in the developer console:
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/d9cf3feb-9bb2-43b2-a688-d435dd2ac756)

That happened during the item JSON serialization finding a circular reference (i.e. `IFSFileItem`'s `command` would reference `this`, which indeed creates a circular reference).

To fix this, the command won't reference `this` anymore but only the required field to call the command (i.e. `this.path`).

The same fix has been applied on `ObjectBrowserMemberItem` to prevent the same problem in case it gets serialized.

### How to test this PR
1. Confirm drag'n'drop fails for a single streamfile without the PR (checkout the developer console to confirm the error)
2. Checkout the PR
3. Confirm drag'n'drop succeeds for a single streamfile
4. Opening a streamfile for browse/edit must work
5. Opening a source member for browse/edit must work

### Checklist
* [x] have tested my change