### PR TITLE
Update tab conversion; address issue #996

### DIFF
--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -225,7 +225,7 @@ function escapeString(val: string): string {
       case `\b`:
         return `\\b`;
       case `\t`:
-        return `  `;
+        return `' || x'05' || '`;
       case `\x1a`:
         return `\\Z`;
       case `'`:

--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -225,7 +225,7 @@ function escapeString(val: string): string {
       case `\b`:
         return `\\b`;
       case `\t`:
-        return `\\t`;
+        return `  `;
       case `\x1a`:
         return `\\Z`;
       case `'`:


### PR DESCRIPTION
### Changes

* Updated the escapeString function in extendedContent.ts to convert the UTF-8 tab character `\t` to `0x05` (the EBCDIC tab character).

### How to test this PR

1. Open VS Code. Connect to any IBM i machine.
2. In the connection settings under **Source Code**, turn on **Enable Source Dates** and set **Source Date tracking mode** to "Diff mode."
3. Create a new source member.
4. Run the "Indent Using Tabs" VS Code command to configure the behavior of the Tab key.
5. At the beginning of any line, press the Tab key; the UTF-8 tab character `\t` (not a series of individual spaces) should be prepended to the line.
6. Save the source member, then close it.
7. Open Access Client Solutions. Use the 5250 emulator to connect to the same IBM i machine as before. 
8. Run SEU. Open the newly-created source member.
9. Verify that SEU renders the previously-inserted tab character as a blank space (not as a backslash followed by a lowercase t).
10. Close SEU. Return to VS Code.
11. Reopen the new member. Verify that VS Code renders the previously-inserted tab character as it did before. 

### Checklist

* [x] have tested my change
* [x] have created one or more test cases
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)