### PR TITLE
Correctly handle source members with variant characters in their name

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -1044,12 +1044,13 @@ export default class IBMi {
       }
   }
 
-  parserMemberPath(string: string): MemberParts {
+  parserMemberPath(string: string): MemberParts {    
     const variant_chars_local = this.variantChars.local;
     const validQsysName = new RegExp(`^[A-Z0-9${variant_chars_local}][A-Z0-9_${variant_chars_local}.]{0,9}$`);
 
     // Remove leading slash
-    const path = string.startsWith(`/`) ? string.substring(1).toUpperCase().split(`/`) : string.toUpperCase().split(`/`);
+    const upperCasedString = this.upperCaseName(string);
+    const path = upperCasedString.startsWith(`/`) ? upperCasedString.substring(1).split(`/`) : upperCasedString.split(`/`);
 
     const basename = path[path.length - 1];
     const file = path[path.length - 2];
@@ -1191,5 +1192,23 @@ export default class IBMi {
     else {
       throw new Error(`Failed to create temporary directory ${tempDirectory}: ${prepareDirectory.stderr}`);
     }
+  }
+
+  /**
+   * Uppercases an object name, keeping the variant chars case intact
+   * @param name
+   */
+  upperCaseName(name : string){    
+    const upperCased = [];
+    for(const char of name){
+      const upChar = char.toLocaleUpperCase();
+      if(new RegExp(`[A-Z${this.variantChars.local}]`).test(upChar)){
+        upperCased.push(upChar);
+      }
+      else{
+        upperCased.push(char);
+      }
+    }
+    return upperCased.join("");
   }
 }

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -153,7 +153,7 @@ export default class IBMiContent {
     const tempRmt = this.getTempRemote(path);
     while (true) {
       let copyResult: CommandResult;
-      if (new RegExp(`[${this.ibmi.variantChars.local}]`).test(path)) {
+      if (this.ibmi.dangerousVariants && new RegExp(`[${this.ibmi.variantChars.local}]`).test(path)) {
         copyResult = { code: 0, stdout: '', stderr: '' };
         try {
           await this.runSQL([
@@ -228,7 +228,7 @@ export default class IBMiContent {
 
       while (true) {
         let copyResult: CommandResult;
-        if (new RegExp(`[${this.ibmi.variantChars.local}]`).test(path)) {
+        if (this.ibmi.dangerousVariants && new RegExp(`[${this.ibmi.variantChars.local}]`).test(path)) {
           copyResult = { code: 0, stdout: '', stderr: '' };
           try {
             await this.runSQL([

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -152,10 +152,25 @@ export default class IBMiContent {
     let path = Tools.qualifyPath(library, sourceFile, member, asp);
     const tempRmt = this.getTempRemote(path);
     while (true) {
-      const copyResult = await this.ibmi.runCommand({
-        command: `CPYTOSTMF FROMMBR('${path}') TOSTMF('${tempRmt}') STMFOPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
-        noLibList: true
-      });
+      let copyResult: CommandResult;
+      if (new RegExp(`[${this.ibmi.variantChars.local}]`).test(path)) {
+        copyResult = { code: 0, stdout: '', stderr: '' };
+        try {
+          await this.runSQL([
+            `@QSYS/CPYF FROMFILE(${library}/${sourceFile}) TOFILE(QTEMP/QTEMPSRC) FROMMBR(${member}) TOMBR(TEMPMEMBER) MBROPT(*REPLACE) CRTFILE(*YES);`,
+            `@QSYS/CPYTOSTMF FROMMBR('${Tools.qualifyPath("QTEMP", "QTEMPSRC", "TEMPMEMBER", undefined)}') TOSTMF('${tempRmt}') STMFOPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID});`
+          ].join("\n"));
+        } catch (error: any) {
+          copyResult.code = -1;
+          copyResult.stderr = String(error);
+        }
+      }
+      else {
+        copyResult = await this.ibmi.runCommand({
+          command: `QSYS/CPYTOSTMF FROMMBR('${path}') TOSTMF('${tempRmt}') STMFOPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
+          noLibList: true
+        });
+      }
 
       if (copyResult.code === 0) {
         if (!localPath) {
@@ -212,10 +227,26 @@ export default class IBMiContent {
       await client.putFile(tmpobj, tempRmt);
 
       while (true) {
-        const copyResult = await this.ibmi.runCommand({
-          command: `QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${path}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
-          noLibList: true
-        });
+        let copyResult: CommandResult;
+        if (new RegExp(`[${this.ibmi.variantChars.local}]`).test(path)) {
+          copyResult = { code: 0, stdout: '', stderr: '' };
+          try {
+            await this.runSQL([
+              `@QSYS/CPYF FROMFILE(${library}/${sourceFile}) FROMMBR(${member}) TOFILE(QTEMP/QTEMPSRC) TOMBR(TEMPMEMBER) MBROPT(*REPLACE) CRTFILE(*YES);`,
+              `@QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${Tools.qualifyPath("QTEMP", "QTEMPSRC", "TEMPMEMBER", undefined)}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
+              `@QSYS/CPYF FROMFILE(QTEMP/QTEMPSRC) FROMMBR(TEMPMEMBER) TOFILE(${library}/${sourceFile}) TOMBR(${member}) MBROPT(*REPLACE);`
+            ].join("\n"));
+          } catch (error: any) {
+            copyResult.code = -1;
+            copyResult.stderr = String(error);
+          }
+        }
+        else {
+          copyResult = await this.ibmi.runCommand({
+            command: `QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${path}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
+            noLibList: true
+          });
+        }
 
         if (copyResult.code === 0) {
           const messages = Tools.parseMessages(copyResult.stderr);

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -144,9 +144,9 @@ export default class IBMiContent {
    */
   async downloadMemberContent(asp: string | undefined, library: string, sourceFile: string, member: string, localPath?: string) {
     asp = asp || this.config.sourceASP;
-    library = library.toUpperCase();
-    sourceFile = sourceFile.toUpperCase();
-    member = member.toUpperCase();
+    library = this.ibmi.upperCaseName(library);
+    sourceFile = this.ibmi.upperCaseName(sourceFile);
+    member = this.ibmi.upperCaseName(member);
 
     let retry = false;
     let path = Tools.qualifyPath(library, sourceFile, member, asp);
@@ -197,9 +197,9 @@ export default class IBMiContent {
    */
   async uploadMemberContent(asp: string | undefined, library: string, sourceFile: string, member: string, content: string | Uint8Array) {
     asp = asp || this.config.sourceASP;
-    library = library.toUpperCase();
-    sourceFile = sourceFile.toUpperCase();
-    member = member.toUpperCase();
+    library = this.ibmi.upperCaseName(library);
+    sourceFile = this.ibmi.upperCaseName(sourceFile);
+    member = this.ibmi.upperCaseName(member);
 
     const client = this.ibmi.client;
     const tmpobj = await tmpFile();

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -146,9 +146,8 @@ export namespace Tools {
    * @param iasp Optional: an iASP name
    */
   export function qualifyPath(library: string, object: string, member: string, iasp?: string, sanitise?: boolean) {
-    library = library.toUpperCase();
     const libraryPath = library === `QSYS` ? `QSYS.LIB` : `QSYS.LIB/${Tools.sanitizeLibraryNames([library]).join(``)}.LIB`;
-    const memberPath = `${object.toUpperCase()}.FILE/${member.toUpperCase()}.MBR`
+    const memberPath = `${object}.FILE/${member}.MBR`
     const memberSubpath = sanitise ? Tools.escapePath(memberPath) : memberPath;
 
     const result = (iasp && iasp.length > 0 ? `/${iasp}` : ``) + `/${libraryPath}/${memberSubpath}`;


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/1935

Member names used to be uppercased regarless of the variant characters they may contain. Turns out that `à` is one of CCSID 297 (French) variant chars and it gets uppercased to `À`, which raises a `member not found` error.

This PR adds a new `upperCaseName` method to the `IBMi` class to correctly uppercase names, preservingthe variant chars case.

### How to test this PR
1. Set PASE_LANG environment variable to `FR_FR`
2. Open a connection with a profile whose CCSID is `297`
3. Try to open a member with one or more `à` in its name

### Checklist
* [x] have tested my change
* [ ] have created one or more test cases