### PR TITLE
Fixed quick filter creation for listing libraries

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -541,7 +541,7 @@ export default class IBMi {
           // We need to check if our remote programs are installed.
           remoteApps.push(
             {
-              path: `/QSYS.lib/${this.config.tempLibrary.toUpperCase()}.lib/`,
+              path: `/QSYS.lib/${this.upperCaseName(this.config.tempLibrary)}.lib/`,
               names: [`GETNEWLIBL.PGM`],
               specific: `GE*.PGM`
             }

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -141,7 +141,7 @@ export async function initialize(context: ExtensionContext) {
 
       if (qualifiedPath.object) {
         // Remove .pgm ending potentially
-        qualifiedPath.object = qualifiedPath.object.toUpperCase();
+        qualifiedPath.object = connection.upperCaseName(qualifiedPath.object);
         if (qualifiedPath.object.endsWith(`.PGM`))
           qualifiedPath.object = qualifiedPath.object.substring(0, qualifiedPath.object.length - 4);
       }
@@ -523,8 +523,8 @@ export async function startDebug(instance: Instance, options: DebugOptions) {
       "port": port,
       "secure": secure,  // Enforce secure mode
       "ignoreCertificateErrors": true,
-      "library": options.library.toUpperCase(),
-      "program": options.object.toUpperCase(),
+      "library": connection!.upperCaseName(options.library),
+      "program": connection!.upperCaseName(options.object),
       "startBatchJobCommand": `SBMJOB CMD(${currentCommand}) INLLIBL(${options.libraries.libraryList.join(` `)}) CURLIB(${options.libraries.currentLibrary}) JOBQ(QSYSNOMAX) MSGQ(*USRPRF)`,
       "updateProductionFiles": updateProductionFiles,
       "trace": enableDebugTracing,

--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -77,11 +77,13 @@ export class QSysFS implements vscode.FileSystemProvider {
     }
 
     stat(uri: vscode.Uri): vscode.FileStat {
+        let type = uri.path.split(`/`).length > 3 ? vscode.FileType.File : vscode.FileType.Directory;
+
         return {
             ctime: 0,
             mtime: 0,
             size: 0,
-            type: vscode.FileType.File,
+            type,
             permissions: getFilePermission(uri)
         }
     }

--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -30,12 +30,12 @@ export class ExtendedIBMiContent {
   async downloadMemberContentWithDates(asp: string | undefined, lib: string, spf: string, mbr: string) {
     const content = instance.getContent();
     const config = instance.getConfig();
+    const connection = instance.getConnection();
+    if (connection && config && content) {
+      lib = connection.upperCaseName(lib);
+      spf = connection.upperCaseName(spf);
+      mbr = connection.upperCaseName(mbr);
 
-    lib = lib.toUpperCase();
-    spf = spf.toUpperCase();
-    mbr = mbr.toUpperCase();
-
-    if (config && content) {
       const sourceColourSupport = GlobalConfiguration.get<boolean>(`showSeuColors`);
       const tempLib = config.tempLibrary;
       const alias = getAliasName(lib, spf, mbr);

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -196,7 +196,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       const connection = instance.getConnection();
       let starRemoved: boolean = false;
 
-      if (!storage && !content) return;
+      if (!storage && !content && !connection) return;
       let list: string[] = [];
 
       // Get recently opened files - cut if limit has been reduced.
@@ -265,14 +265,14 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
           );
           filteredItems = [];
         } else {
-          if (!starRemoved && !list.includes(quickPick.value.toUpperCase())) {
-            quickPick.items = [quickPick.value.toUpperCase(), ...list].map(label => ({ label }));
+          if (!starRemoved && !list.includes(connection!.upperCaseName(quickPick.value))) {
+            quickPick.items = [connection!.upperCaseName(quickPick.value), ...list].map(label => ({ label }));
           }
         }
 
         // autosuggest
         if (config && config.enableSQL && (!quickPick.value.startsWith(`/`)) && quickPick.value.endsWith(`*`)) {
-          const selectionSplit = quickPick.value.toUpperCase().split('/');
+          const selectionSplit = connection!.upperCaseName(quickPick.value).split('/');
           const lastPart = selectionSplit[selectionSplit.length - 1];
           let filterText = lastPart.substring(0, lastPart.indexOf(`*`));
 
@@ -427,7 +427,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
             );
             vscode.window.showInformationMessage(`Cleared cached files.`);
           } else {
-            const selectionSplit = selection.toUpperCase().split('/')
+            const selectionSplit = connection!.upperCaseName(selection).split('/')
             if (selectionSplit.length === 3 || selection.startsWith(`/`)) {
               if (config && config.enableSQL && !selection.startsWith(`/`)) {
                 const lib = `${connection!.sysNameInAmerican(selectionSplit[0])}`;
@@ -463,12 +463,12 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
                   vscode.window.showWarningMessage(`${selection} does not exist or is not a file.`);
                   return;
                 }
-                selection = selection.toUpperCase() === quickPick.value.toUpperCase() ? quickPick.value : selection;
+                selection = connection!.upperCaseName(selection) === connection!.upperCaseName(quickPick.value) ? quickPick.value : selection;
               }
               vscode.commands.executeCommand(`code-for-ibmi.openEditable`, selection, { readonly });
               quickPick.hide();
             } else {
-              quickPick.value = selection.toUpperCase() + '/'
+              quickPick.value = connection!.upperCaseName(selection) + '/'
             }
           }
         }

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -430,15 +430,18 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
             const selectionSplit = connection!.upperCaseName(selection).split('/')
             if (selectionSplit.length === 3 || selection.startsWith(`/`)) {
               if (config && config.enableSQL && !selection.startsWith(`/`)) {
-                const lib = `${connection!.sysNameInAmerican(selectionSplit[0])}`;
-                const file = `${connection!.sysNameInAmerican(selectionSplit[1])}`;
-                const member = path.parse(`${connection!.sysNameInAmerican(selectionSplit[2])}`);
+                const libUS = connection!.sysNameInAmerican(selectionSplit[0]);
+                const fileUS = connection!.sysNameInAmerican(selectionSplit[1]);
+                const memberUS = path.parse(connection!.sysNameInAmerican(selectionSplit[2]));
+                const lib = selectionSplit[0];
+                const file = selectionSplit[1];
+                const member = path.parse(selectionSplit[2]);
                 member.ext = member.ext.substring(1);
                 const fullMember = await content!.runSQL(`
                   select rtrim( cast( SYSTEM_TABLE_MEMBER as char( 10 ) for bit data ) ) as MEMBER
                        , rtrim( coalesce( SOURCE_TYPE, '' ) ) as TYPE
                     from QSYS2.SYSPARTITIONSTAT
-                   where ( SYSTEM_TABLE_SCHEMA, SYSTEM_TABLE_NAME, SYSTEM_TABLE_MEMBER ) = ( '${lib}', '${file}', '${member.name}' )
+                   where ( SYSTEM_TABLE_SCHEMA, SYSTEM_TABLE_NAME, SYSTEM_TABLE_MEMBER ) = ( '${libUS}', '${fileUS}', '${memberUS.name}' )
                    limit 1
                 `).then((resultSet) => {
                   return resultSet.length !== 1 ? {} :

--- a/src/testing/connection.ts
+++ b/src/testing/connection.ts
@@ -151,13 +151,13 @@ export const ConnectionSuite: TestSuite = {
       name: `Test runCommand (ILE)`, test: async () => {
         const connection = instance.getConnection();
 
-        const result = await connection?.runCommand({
-          command: `DSPLIBL`,
+        const result = await connection!.runCommand({
+          command: `DSPJOB OPTION(*DFNA)`,
           environment: `ile`
         });
 
         assert.strictEqual(result?.code, 0);
-        assert.strictEqual(result.stdout.includes(`Library List`), true);
+        assert.strictEqual(["JOBPTY", "OUTPTY", "ENDSEV","DDMCNV", "BRKMSG", "STSMSG", "DEVRCYACN", "TSEPOOL", "PRTKEYFMT", "SRTSEQ"].every(attribute => result.stdout.includes(attribute)), true);
       }
     },
 
@@ -275,8 +275,8 @@ export const ConnectionSuite: TestSuite = {
       name: `Test withTempDirectory`, test: async () => {
         const connection = instance.getConnection()!;
         let temp;
-        const countFiles = async(dir:string) => {
-          const countResult = await connection.sendCommand({command: `find ${dir} -type f | wc -l`});
+        const countFiles = async (dir: string) => {
+          const countResult = await connection.sendCommand({ command: `find ${dir} -type f | wc -l` });
           assert.strictEqual(countResult.code, 0);
           return Number(countResult.stdout);
         };
@@ -284,24 +284,24 @@ export const ConnectionSuite: TestSuite = {
         await connection.withTempDirectory(async tempDir => {
           temp = tempDir;
           //Directory must exist
-          assert.strictEqual((await connection.sendCommand({command: `[ -d ${tempDir} ]`})).code, 0);
+          assert.strictEqual((await connection.sendCommand({ command: `[ -d ${tempDir} ]` })).code, 0);
 
           //Directory must be empty
           assert.strictEqual(await countFiles(tempDir), 0);
 
           const toCreate = 10;
-          for(let i = 0; i < toCreate; i++){
-            assert.strictEqual((await connection.sendCommand({command: `echo "Test ${i}" >> ${tempDir}/file${i}`})).code, 0);
+          for (let i = 0; i < toCreate; i++) {
+            assert.strictEqual((await connection.sendCommand({ command: `echo "Test ${i}" >> ${tempDir}/file${i}` })).code, 0);
           }
 
-          const newCountResult = await connection.sendCommand({command: `ls -l ${tempDir} | wc -l`});
+          const newCountResult = await connection.sendCommand({ command: `ls -l ${tempDir} | wc -l` });
           assert.strictEqual(newCountResult.code, 0);
           assert.strictEqual(await countFiles(tempDir), toCreate);
         });
 
-        if(temp){
+        if (temp) {
           //Directory must be gone
-          assert.strictEqual((await connection.sendCommand({command: `[ -d ${temp} ]`})).code, 1);
+          assert.strictEqual((await connection.sendCommand({ command: `[ -d ${temp} ]` })).code, 1);
         }
       }
     }

--- a/src/testing/connection.ts
+++ b/src/testing/connection.ts
@@ -157,7 +157,7 @@ export const ConnectionSuite: TestSuite = {
         });
 
         assert.strictEqual(result?.code, 0);
-        assert.strictEqual(["JOBPTY", "OUTPTY", "ENDSEV","DDMCNV", "BRKMSG", "STSMSG", "DEVRCYACN", "TSEPOOL", "PRTKEYFMT", "SRTSEQ"].every(attribute => result.stdout.includes(attribute)), true);
+        assert.strictEqual(["JOBPTY", "OUTPTY", "ENDSEV", "DDMCNV", "BRKMSG", "STSMSG", "DEVRCYACN", "TSEPOOL", "PRTKEYFMT", "SRTSEQ"].every(attribute => result.stdout.includes(attribute)), true);
       }
     },
 
@@ -302,6 +302,32 @@ export const ConnectionSuite: TestSuite = {
         if (temp) {
           //Directory must be gone
           assert.strictEqual((await connection.sendCommand({ command: `[ -d ${temp} ]` })).code, 1);
+        }
+      }
+    },
+    {
+      name: `Test upperCaseName`, test: async () => {
+        const connection = instance.getConnection()!;
+        const variantsBackup = connection.variantChars.local;
+                
+        try{
+          const checkVariants = () => connection.variantChars.local !== connection.variantChars.local.toLocaleUpperCase();
+          //CCSID 297 variants
+          connection.variantChars.local = '£à$';
+          connection.dangerousVariants = checkVariants();
+          assert.strictEqual(connection.dangerousVariants, true);
+          assert.strictEqual(connection.upperCaseName("àTesT£ye$"), "àTEST£YE$");
+          assert.strictEqual(connection.upperCaseName("test_cAsE"), "TEST_CASE");
+
+          //CCSID 37 variants
+          connection.variantChars.local = '#@$';
+          connection.dangerousVariants = checkVariants();
+          assert.strictEqual(connection.dangerousVariants, false);
+          assert.strictEqual(connection.upperCaseName("@TesT#ye$"), "@TEST#YE$");
+          assert.strictEqual(connection.upperCaseName("test_cAsE"), "TEST_CASE");
+        }
+        finally{
+          connection.variantChars.local = variantsBackup;
         }
       }
     }

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -3,7 +3,6 @@ import tmp from 'tmp';
 import util from 'util';
 import { Uri, workspace } from "vscode";
 import { TestSuite } from ".";
-import IBMiContent from "../api/IBMiContent";
 import { Tools } from "../api/Tools";
 import { instance } from "../instantiate";
 import { CommandResult } from "../typings";
@@ -555,7 +554,7 @@ export const ContentSuite: TestSuite = {
     },
     {
       name: `To CL`, test: async () => {
-        const command = IBMiContent.toCl("TEST", {
+        const command = instance.getContent()!.toCl("TEST", {
           ZERO: 0,
           NONE:'*NONE',
           EMPTY: `''`,

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -66,20 +66,6 @@ export const ContentSuite: TestSuite = {
     },
 
     {
-      name: `Test memberResolve with bad name`, test: async () => {
-        const content = instance.getContent();
-
-        const member = await content?.memberResolve(`BOOOP`, [
-          { library: `QSYSINC`, name: `MIH` }, // Doesn't exist here
-          { library: `NOEXIST`, name: `SUP` }, // Doesn't exist here
-          { library: `QSYSINC`, name: `H` } // Doesn't exist here
-        ]);
-
-        assert.deepStrictEqual(member, undefined);
-      }
-    },
-
-    {
       name: `Test objectResolve .FILE`, test: async () => {
         const content = instance.getContent();
 

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -494,9 +494,9 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
           const filter = {
             name: `Filter ${objectFilters.length + 1}`,
             filterType: 'simple',
-            library: `QSYS`,
-            object: `${parsedFilter.lib}*`,
-            types: [`*LIB`],
+            library: `${parsedFilter.lib}*`,
+            object: `*`,
+            types: [`*ALL`],
             member: `*`,
             memberType: `*`,
             protected: false

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -472,6 +472,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand(`code-for-ibmi.createQuickFilter`, async () => {
       const config = getConfig();
+      const connection = getConnection();
       const objectFilters = config.objectFilters;
 
       const LIBRARY_REGEX = /^(?<lib>[^/.() ]+)\*$/;
@@ -481,14 +482,14 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         prompt: `Enter filter as LIB* or LIB/OBJ/MBR.MBRTYPE (OBJTYPE) where each parameter is optional except the library`,
         value: ``,
         validateInput: newFilter => {
-          const libraryRegex = LIBRARY_REGEX.exec(newFilter.toUpperCase());
-          const filterRegex = FILTER_REGEX.exec(newFilter.toUpperCase());
+          const libraryRegex = LIBRARY_REGEX.exec(connection.upperCaseName(newFilter));
+          const filterRegex = FILTER_REGEX.exec(connection.upperCaseName(newFilter));
           if (!libraryRegex && !filterRegex) return `Invalid filter: ${newFilter}. Use format LIB* or LIB/OBJ/MBR.MBRTYPE (OBJTYPE) where each parameter is optional except the library`;
         }
       });
 
       if (newFilter) {
-        let regex = LIBRARY_REGEX.exec(newFilter.toUpperCase());
+        let regex = LIBRARY_REGEX.exec(connection.upperCaseName(newFilter));
         const parsedFilter = regex?.groups;
         if (regex && parsedFilter) {
           const filter = {
@@ -503,7 +504,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
           } as ConnectionConfiguration.ObjectFilters;
           objectFilters.push(filter);
         } else {
-          regex = FILTER_REGEX.exec(newFilter.toUpperCase());
+          regex = FILTER_REGEX.exec(connection.upperCaseName(newFilter));
           const parsedFilter = regex?.groups;
           if (regex && parsedFilter) {
             const filter = {

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -400,7 +400,7 @@ class ObjectBrowserMemberItem extends ObjectBrowserItem implements MemberItem {
     this.command = {
       command: "code-for-ibmi.openWithDefaultMode",
       title: `Open Member`,
-      arguments: [{path: this.path}, (readonly ? "browse" : undefined) as DefaultOpenMode]
+      arguments: [{ path: this.path }, (readonly ? "browse" : undefined) as DefaultOpenMode]
     };
 
     this.readonly = readonly;
@@ -561,7 +561,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand(`code-for-ibmi.createMember`, async (node: ObjectBrowserSourcePhysicalFileItem, fullName?: string) => {
       const connection = getConnection();
-      const toPath = (value: string) => `${node.path}/${value}`.toUpperCase();
+      const toPath = (value: string) => connection.upperCaseName(`${node.path}/${value}`);
       fullName = await vscode.window.showInputBox({
         prompt: t(`objectBrowser.createMember.prompt`),
         value: fullName,
@@ -603,7 +603,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
       }
     }),
 
-    vscode.commands.registerCommand(`code-for-ibmi.copyMember`, async (node: ObjectBrowserMemberItem, fullPath) => {
+    vscode.commands.registerCommand(`code-for-ibmi.copyMember`, async (node: ObjectBrowserMemberItem, fullPath?: string) => {
       const connection = getConnection();
       const oldMember = node.member;
       fullPath = await vscode.window.showInputBox({
@@ -662,7 +662,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
             }
 
             if (GlobalConfiguration.get(`autoOpenFile`)) {
-              vscode.commands.executeCommand(`code-for-ibmi.openEditable`, memberPath);
+              vscode.commands.executeCommand(`code-for-ibmi.openEditable`, fullPath);
             }
 
             if (oldMember.library.toLocaleLowerCase() === memberPath.library.toLocaleLowerCase()) {
@@ -728,7 +728,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         newBasename = await vscode.window.showInputBox({
           value: newBasename,
           prompt: t(`objectBrowser.renameMember.prompt`, oldMember.basename),
-          validateInput: value => value.toUpperCase() === oldMember.basename ? t("objectBrowser.renameMember.invalid.input") : undefined
+          validateInput: value => connection.upperCaseName(value) === oldMember.basename ? t("objectBrowser.renameMember.invalid.input") : undefined
         });
 
         if (newBasename) {
@@ -928,7 +928,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         });
 
         if (input) {
-          const path = input.trim().toUpperCase().split(`/`);
+          const path = connection.upperCaseName(input.trim()).split(`/`);
           parameters.path = [path[0], path[1]].join('/');
         }
       }
@@ -1053,7 +1053,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         if (fileName) {
           const connection = getConnection();
           const library = node.library;
-          const uriPath = `${library}/${fileName.toUpperCase()}`
+          const uriPath = `${library}/${connection.upperCaseName(fileName)}`
 
           vscode.window.showInformationMessage(t(`objectBrowser.createSourceFile.infoMessage`, uriPath));
           const createResult = await connection.runCommand({

--- a/src/webviews/filters/index.ts
+++ b/src/webviews/filters/index.ts
@@ -4,6 +4,7 @@ import { Tools } from "../../api/Tools";
 import { instance } from "../../instantiate";
 
 export async function editFilter(filter?: ConnectionConfiguration.ObjectFilters, copy = false) {
+  const connection = instance.getConnection();
   const config = instance.getConfig();
   if (config) {
     const objectFilters = config.objectFilters;
@@ -76,7 +77,7 @@ export async function editFilter(filter?: ConnectionConfiguration.ObjectFilters,
           case `object`:
             data[key] = (String(data[key].trim()) || `*`)
               .split(',')
-              .map(o => useRegexFilters ? o : o.toLocaleUpperCase())
+              .map(o => useRegexFilters ? o : connection?.upperCaseName(o))
               .filter(Tools.distinct)
               .join(",");
             break;

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -259,7 +259,7 @@ export class SettingsUI {
                     case `protectedPaths`:
                       data[key] = String(data[key]).split(`,`)
                         .map(item => item.trim())
-                        .map(item => item.startsWith('/') ? item : item.toUpperCase())
+                        .map(item => item.startsWith('/') ? item : connection?.upperCaseName(item) || item.toUpperCase())
                         .filter(item => item !== ``)
                         .filter(Tools.distinct);
                       break;


### PR DESCRIPTION
### Changes
This PR fixes the filters using the `Create Quick Filter...` action that would create a filter with wrong values for listing libraries.

### How to test this PR
1. Create a quick filter with value `Q*`
2. It must lists all the libraries starting with Q when expanded

### Checklist
* [x] have tested my change