### PR TITLE
Fix member and object resolve with variants

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -822,7 +822,7 @@ export default class IBMiContent {
   }
 
   async objectResolve(object: string, libraries: string[]): Promise<string | undefined> {
-    const command = `for f in ${libraries.map(lib => `/QSYS.LIB/${this.ibmi.upperCaseName(lib)}.LIB/${this.ibmi.upperCaseName(object)}.*`).join(` `)}; do if [ -f $f ] || [ -d $f ]; then echo $f; break; fi; done`;
+    const command = `for f in ${libraries.map(lib => `/QSYS.LIB/${this.ibmi.sysNameInAmerican(lib)}.LIB/${this.ibmi.sysNameInAmerican(object)}.*`).join(` `)}; do if [ -f $f ] || [ -d $f ]; then echo $f; break; fi; done`;
 
     const result = await this.ibmi.sendCommand({
       command,
@@ -832,7 +832,7 @@ export default class IBMiContent {
       const firstMost = result.stdout;
 
       if (firstMost) {
-        const lib = Tools.unqualifyPath(firstMost);
+        const lib = this.ibmi.sysNameInLocal(Tools.unqualifyPath(firstMost));
 
         return lib.split('/')[1];
       }

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -53,6 +53,43 @@ export const ContentSuite: TestSuite = {
     },
 
     {
+      name: `Test memberResolve with variants`, test: async () => {
+        const content = instance.getContent();
+        const config = instance.getConfig();
+        const connection = instance.getConnection();
+        const tempLib = config!.tempLibrary,
+              tempSPF = `O_ABC`.concat(connection!.variantChars.local),
+              tempMbr = `O_ABC`.concat(connection!.variantChars.local);
+
+        const result = await connection!.runCommand({
+          command: `CRTSRCPF ${tempLib}/${tempSPF} MBR(${tempMbr})`,
+          environment: `ile`
+        });
+
+        const member = await content?.memberResolve(tempMbr, [
+          { library: `QSYSINC`, name: `MIH` }, // Doesn't exist here
+          { library: `NOEXIST`, name: `SUP` }, // Doesn't exist here
+          { library: tempLib, name: tempSPF } // Doesn't exist here
+        ]);
+
+        assert.deepStrictEqual(member, {
+          asp: undefined,
+          library: tempLib,
+          file: tempSPF,
+          name: tempMbr,
+          extension: `MBR`,
+          basename: `${tempMbr}.MBR`
+        });
+
+        // Cleanup...
+        await connection!.runCommand({
+          command: `DLTF ${tempLib}/${tempSPF}`,
+          environment: `ile`
+        });
+      }
+    },
+
+    {
       name: `Test memberResolve with bad name`, test: async () => {
         const content = instance.getContent();
 

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -130,6 +130,35 @@ export const ContentSuite: TestSuite = {
     },
 
     {
+      name: `Test objectResolve .DTAARA with variants`, test: async () => {
+        const content = instance.getContent();
+        const config = instance.getConfig();
+        const connection = instance.getConnection();
+        const tempLib = config!.tempLibrary,
+              tempObj = `O_ABC`.concat(connection!.variantChars.local);
+
+        await connection!.runCommand({
+          command: `CRTDTAARA ${tempLib}/${tempObj} TYPE(*CHAR)`,
+          environment: `ile`
+        });
+
+        const lib = await content?.objectResolve(tempObj, [
+          "QSYSINC", // Doesn't exist here
+          "QSYS2", // Doesn't exist here
+          tempLib // Does exist here
+        ]);
+
+        assert.strictEqual(lib, tempLib);
+
+        // Cleanup...
+        await connection!.runCommand({
+          command: `DLTDTAARA ${tempLib}/${tempObj}`,
+          environment: `ile`
+        });
+      }
+    },
+
+    {
       name: `Test objectResolve with bad name`, test: async () => {
         const content = instance.getContent();
 


### PR DESCRIPTION
### Changes

Fixes resolving members and objects having variant characters in their name.
Tests have been added to verify member and object resolve with variant characters.

Before this would not work:

![billede](https://github.com/codefori/vscode-ibmi/assets/13275072/9a86e440-38a8-4a69-8d55-b0f201505f04)

After this fix the member resolution now works:

![billede](https://github.com/codefori/vscode-ibmi/assets/13275072/ad543c48-7d83-4ce2-9833-4e3b303fe791)

### How to test this PR

1. create a source member with variant characters in the name
2. open another source member and add /COPY or /INCLUDE referencing the source member with variant characters
3. Press `Alt-F12` with the cursor in the referenced member name.
4. Verify the referenced member content is shown.
5. Run the test cases

### Checklist

* [x] have tested my change