### PR TITLE
Use interfaces instead of classes for type checking

### DIFF
--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -792,7 +792,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
 
     }),
 
-    vscode.commands.registerCommand(`code-for-ibmi.downloadMemberAsFile`, async (node: BrowserItem, nodes?: BrowserItem[]) => {
+    vscode.commands.registerCommand(`code-for-ibmi.downloadMemberAsFile`, async (node: ObjectItem | MemberItem, nodes?: (ObjectItem | MemberItem)[]) => {
       const contentApi = getContent();
       const connection = getConnection();
       const config = getConfig();
@@ -800,10 +800,10 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
       //Gather all the members
       const members: IBMiMember[] = [];
       for (const item of (nodes || [node])) {
-        if (item instanceof ObjectBrowserSourcePhysicalFileItem) {
+        if ("object" in item) {
           members.push(...await contentApi.getMemberList({ library: item.object.library, sourceFile: item.object.name }));
         }
-        else if (item instanceof ObjectBrowserMemberItem) {
+        else if ("member" in item) {
           members.push(item.member);
         }
       }


### PR DESCRIPTION
### Changes
Fixes https://github.com/IBM/vscode-ibmi-projectexplorer/issues/422 (cc @edmundreinhardt)

The parameter types for the `code-for-ibmi.downloadMemberAsFile` command were recently changed to `BrowserItem` type, which prevented other extensions from using it without passing an object of this type.

By changing the expected type to `ObjectItem | MemberItem`, it allows other extensions to use this command again.

### How to test this PR
1. Download a member from the `Object Explorer`
2. Download a member from the [Project Explorer ](https://marketplace.visualstudio.com/items?itemName=IBM.vscode-ibmi-projectexplorer) Library List node.

### Checklist
* [x] have tested my change