### PR TITLE
Added support for .deployignore

### DIFF
--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -15,7 +15,7 @@ import { BrowserItem, BrowserItemParameters, FocusOptions, IFSFile, IFS_BROWSER_
 const URI_LIST_MIMETYPE = "text/uri-list";
 const URI_LIST_SEPARATOR = "\r\n";
 const PROTECTED_DIRS = /^(\/|\/QOpenSys|\/QSYS\.LIB|\/QDLS|\/QOPT|\/QNTC|\/QFileSvr\.400|\/bin|\/dev|\/home|\/tmp|\/usr|\/var)$/i;
-const ALWAYS_SHOW_FILES = /^(\.gitignore|\.vscode)$/i;
+const ALWAYS_SHOW_FILES = /^(\.gitignore|\.vscode|\.deployignore)$/i;
 type DragNDropAction = "move" | "copy";
 type DragNDropBehavior = DragNDropAction | "ask";
 const getDragDropBehavior = () => GlobalConfiguration.get<DragNDropBehavior>(`IfsBrowser.DragAndDropDefaultBehavior`) || "ask";


### PR DESCRIPTION
### Changes
Resolves https://github.com/codefori/vscode-ibmi/issues/1951

This adds the support for a `.deployignore` file that can be put at the root of a workspace to define patterns for files that should not be deployed by Code for IBM i when deploying a workspace. Files ignored during deployment can also be defined in `.gitignore`, but if `.deployignore` exists, it replaces `.gitignore` for this.

`.deployignore` supports the exact same format as `.gitignore`.

### How to test this PR
1. Run the test case `Test .deployignore` under `Deploy Tools API tests`
2. Create a `.deployignore` file in the workspace
3. Add a pattern to ignore something different from `.gitignore`
4. Deploy
5. Check the rules from `.deployignore` superseds `.gitignore`'s

### Checklist

* [x] have tested my change
* [x] have created one or more test cases