### PR TITLE
Change library validation logic

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -484,10 +484,12 @@ export default class IBMiContent {
       return true;
     });
 
+    const sanitized = Tools.sanitizeLibraryNames(newLibl);
+
     const result = await this.ibmi.sendQsh({
       command: [
         `liblist -d ` + Tools.sanitizeLibraryNames(this.ibmi.defaultUserLibraries).join(` `),
-        ...newLibl.map(lib => `liblist -a ` + Tools.sanitizeLibraryNames([lib]))
+        ...sanitized.map(lib => `liblist -a ` + lib)
       ].join(`; `)
     });
 
@@ -495,10 +497,13 @@ export default class IBMiContent {
       const lines = result.stderr.split(`\n`);
 
       lines.forEach(line => {
-        const badLib = newLibl.find(lib => line.includes(`ibrary ${lib} `) || line.includes(`ibrary ${Tools.sanitizeLibraryNames([lib])} `));
+        const isNotFound = line.includes(`CPF2110`);
+        if (isNotFound) {
+          const libraryReference = sanitized.find(lib => line.includes(lib));
 
-        // If there is an error about the library, remove it
-        if (badLib) badLibs.push(badLib);
+          // If there is an error about the library, remove it
+          if (libraryReference) badLibs.push(libraryReference);
+        }
       });
     }
 

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -502,7 +502,9 @@ export default class IBMiContent {
           const libraryReference = sanitized.find(lib => line.includes(lib));
 
           // If there is an error about the library, remove it
-          if (libraryReference) badLibs.push(libraryReference);
+          if (libraryReference) {
+            badLibs.push(libraryReference);
+          }
         }
       });
     }

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -294,10 +294,11 @@ export const ContentSuite: TestSuite = {
       name: `Test validateLibraryList`, test: async () => {
         const content = instance.getContent();
 
-        const badLibs = await content?.validateLibraryList([`QSYSINC`, `BEEPBOOP`]);
+        const badLibs = await content?.validateLibraryList([`SCOOBY`, `QSYSINC`, `BEEPBOOP`]);
 
         assert.strictEqual(badLibs?.includes(`BEEPBOOP`), true);
         assert.strictEqual(badLibs?.includes(`QSYSINC`), false);
+        assert.strictEqual(badLibs?.includes(`SCOOBY`), true);
       }
     },
 


### PR DESCRIPTION
### Changes

Fixes #1879. Prior to this PR, we were checking invalid libraries by looking for a text string that was specific to EN. That meant `validateLibraryList` did not work for non EN languages.

### How to test this PR

1. Run the test cases (we have a test case for `validateLibraryList`)
2. Add non existing libraries to the user library list and expect a warning that it does not exist
    * Specifically trying this on multiple different locales

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)