### PR TITLE
Do not allow debug batch on *SRVPGM / Allow multiple debug sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2297,7 +2297,7 @@
 			"editor/title": [
 				{
 					"submenu": "code-for-ibmi.debug.group",
-					"when": "code-for-ibmi:connected && !inDebugMode && editorLangId =~ /^rpgle$|^rpg$|^cobol$|^cl$/i",
+					"when": "code-for-ibmi:connected && editorLangId =~ /^rpgle$|^rpg$|^cobol$|^cl$/i",
 					"group": "navigation@1"
 				},
 				{
@@ -2499,7 +2499,7 @@
 				},
 				{
 					"submenu": "code-for-ibmi.debug.group",
-					"when": "view == objectBrowser && !inDebugMode && (viewItem =~ /^object.pgm.*/ || viewItem =~ /^object.srvpgm.*/)",
+					"when": "view == objectBrowser && viewItem =~ /^object.(pgm|srvpgm).*/",
 					"group": "2_debug@1"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -1813,7 +1813,7 @@
 			"code-for-ibmi.debug.group": [
 				{
 					"command": "code-for-ibmi.debug.batch",
-					"when": "code-for-ibmi:debug"
+					"when": "code-for-ibmi:debug && viewItem =~ /^object.pgm.*/"
 				},
 				{
 					"command": "code-for-ibmi.debug.sep",

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -254,7 +254,7 @@ export async function initialize(context: ExtensionContext) {
             if (objectType) {
               startDebugging(debugType, objectType, qualifiedObject.library, qualifiedObject.object, workspaceFolder);
             } else {
-              vscode.window.showErrorMessage(`Failed to determine object type. Ensure the object exists and is a program (*PGM) or service program (*SRVPGM).`);
+              vscode.window.showErrorMessage(`Failed to determine object type. Ensure the object exists and is a program (*PGM)${debugType === "sep" ? " or service program (*SRVPGM)" : ""}.`);
             }
           }
         } else {


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/1987
Fixes https://github.com/codefori/vscode-ibmi/issues/1988

This PR fixes the two issues above:
- It allows for multiple IBM i debug sessions to be run simultaneously
- It restricts batch debug to *PGM only

### How to test this PR

Examples:

1. Check that `Debug as Batch` only shows on `.PGM` objects
2. Check that the `Start Debugging` menu shows even if a debug session is already ongoing

### Checklist

* [x] have tested my change