### PR TITLE
Fix/debug_version_path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1813,7 +1813,7 @@
 			"code-for-ibmi.debug.group": [
 				{
 					"command": "code-for-ibmi.debug.batch",
-					"when": "code-for-ibmi:debug && viewItem =~ /^object.pgm.*/"
+					"when": "code-for-ibmi:debug && (viewItem =~ /^object.pgm.*/ || editorFocus)"
 				},
 				{
 					"command": "code-for-ibmi.debug.sep",

--- a/src/api/debug/server.ts
+++ b/src/api/debug/server.ts
@@ -53,7 +53,7 @@ export async function getDebugServiceDetails(): Promise<DebugServiceDetails> {
   };
 
   const detailFilePath = path.posix.join(directory, detailFile);
-  const detailExists = await content.testStreamFile(detailFile, "r");
+  const detailExists = await content.testStreamFile(detailFilePath, "r");
   if (detailExists) {
     try {
       const fileContents = (await content.downloadStreamfileRaw(detailFilePath)).toString("utf-8");


### PR DESCRIPTION
Luckily no major problems because SEP isn't out yet.

### Changes

* Start batch debug was missing from the active editor
* When starting the debug service, it was failing to get the correct Java version because it was testing for file existing against the wrong variable.

### How to test this PR

Examples:

1. Run the test cases
2. Ensure the debug service starts up
3. Can batch debug from the Object Browser and the active editor

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)