### PR TITLE
Remove debug walkthrough logic

### DIFF
--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -100,15 +100,6 @@ export async function initialize(context: ExtensionContext) {
 
             startDebug(instance, debugOpts);
           }
-        } else {
-          if (isManaged()) {
-            vscode.window.showInformationMessage(`Looks like the Debug Service is not setup on this IBM i server. Please contact your system administrator.`);
-          } else {
-            const openTut = await vscode.window.showInformationMessage(`Looks like you do not have the debug PTF installed. Do you want to see the Walkthrough to set it up?`, `Take me there`);
-            if (openTut === `Take me there`) {
-              vscode.commands.executeCommand(`workbench.action.openWalkthrough`, `halcyontechltd.vscode-ibmi-walkthroughs#code-ibmi-debug`);
-            }
-          }
         }
       }
 


### PR DESCRIPTION
### Changes

Legacy logic to trigger the debug setup walkthrough, which as of 2.10.0 will no longer exist.

### How to test this PR

Examples:

1. Ensure you don't see the message when connected to a system with no debugger running.

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)