### PR TITLE
Update startBatchJobCommand to include CPYENVVAR(*YES)

### DIFF
--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -490,7 +490,7 @@ export async function startDebug(instance: Instance, options: DebugOptions) {
         "subType": "batch",
         "library": options.library.toUpperCase(),
         "program": options.object.toUpperCase(),
-        "startBatchJobCommand": `SBMJOB CMD(${currentCommand}) INLLIBL(${options.libraries.libraryList.join(` `)}) CURLIB(${options.libraries.currentLibrary}) JOBQ(QSYSNOMAX) MSGQ(*USRPRF)`,
+        "startBatchJobCommand": `SBMJOB CMD(${currentCommand}) INLLIBL(${options.libraries.libraryList.join(` `)}) CURLIB(${options.libraries.currentLibrary}) JOBQ(QSYSNOMAX) MSGQ(*USRPRF) CPYENVVAR(*YES)`,
         "updateProductionFiles": updateProductionFiles,
         "trace": enableDebugTracing,
       };


### PR DESCRIPTION
### Changes

Fixes #2011 and adds the `CPYENVVAR` to `SBMJOB` when batch debugging.

### How to test this PR

Examples:

1. Attempt the batch debug and expect it to work as normal.

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)