### PR TITLE
Fix remove shortcut text and add additional protection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1364,7 +1364,7 @@
 			{
 				"command": "code-for-ibmi.removeIFSShortcut",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Remove Shortcut...",
+				"title": "Remove Shortcut",
 				"category": "IBM i",
 				"icon": "$(remove)"
 			},

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -14,7 +14,7 @@ import { BrowserItem, BrowserItemParameters, FocusOptions, IFSFile, IFS_BROWSER_
 
 const URI_LIST_MIMETYPE = "text/uri-list";
 const URI_LIST_SEPARATOR = "\r\n";
-const PROTECTED_DIRS = /^(\/|\/QOpenSys|\/QSYS\.LIB|\/QDLS|\/QOPT|\/QNTC|\/QFileSvr\.400|\/QIBM|\/bin|\/dev|\/home|\/tmp|\/usr|\/var)$/i;
+const PROTECTED_DIRS = /^(\/|\/QOpenSys|\/QSYS\.LIB|\/QDLS|\/QOPT|\/QNTC|\/QFileSvr\.400|\/QIBM|\/QSR|\/QTCPTMM|\/bin|\/dev|\/home|\/tmp|\/usr|\/var)$/i;
 const ALWAYS_SHOW_FILES = /^(\.gitignore|\.vscode|\.deployignore)$/i;
 type DragNDropAction = "move" | "copy";
 type DragNDropBehavior = DragNDropAction | "ask";


### PR DESCRIPTION
### Changes

This PR will remove the dots from the "Remove Shortcut..." men item text, since there is no additional dialog.
It will also add protection for /QSR and /QTCPTMM directories.

### How to test this PR

1. Expand the IFS browser and right-click a shortcut. The menu item should read `Remove Shortcut` without any dots.
2. Expand `/` in the IFS browser and right-click `QSR` and `QTCPTMM`. Verify no menu option `Delete...` is available.

### Checklist

* [x] have tested my change