### PR TITLE
Set CCSID of deployed files to 1208 if needed

### DIFF
--- a/src/api/local/deployment.ts
+++ b/src/api/local/deployment.ts
@@ -23,6 +23,8 @@ export namespace Deployment {
   export const button = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
   export const workspaceChanges: Map<vscode.WorkspaceFolder, Map<string, vscode.Uri>> = new Map;
 
+  let fixCCSID: boolean | undefined;
+
   export function initialize(context: vscode.ExtensionContext) {
     button.command = {
       command: `code-for-ibmi.launchDeploy`,
@@ -89,6 +91,7 @@ export namespace Deployment {
     });
 
     instance.onEvent("disconnected", () => {
+      fixCCSID = undefined;
       button.hide();
     })
   }
@@ -228,6 +231,17 @@ export namespace Deployment {
       tar.t({ sync: true, file: localTarball.name, onentry: entry => entries.push(entry.path) });
       deploymentLog.appendLine(`${entries.length} file(s) uploaded to ${parameters.remotePath}`);
       entries.sort().map(e => `\t${e}`).forEach(deploymentLog.appendLine);
+
+      if (await mustFixCCSID()) {
+        progress?.report({ message: 'Fixing files CCSID...' });
+        const fix = await connection.sendCommand({ command: `setccsid -R 1208 ${parameters.remotePath}` });
+        if (fix.code === 0) {
+          deploymentLog.appendLine(`Deployed files' CCSID set to 1208`);
+        }
+        else {
+          deploymentLog.appendLine(`Failed to set deployed files' CCSID to 1208: ${fix.stderr}`);
+        }
+      }
     }
     finally {
       deploymentLog.appendLine('');
@@ -237,5 +251,18 @@ export namespace Deployment {
       localTarball.removeCallback();
       deploymentLog.appendLine(`${localTarball.name} deleted`);
     }
+  }
+
+  /**
+   * Check if default CCSID of created/deployed files is not 1208 (utf-8).
+   * 
+   * @returns `true` if the default CCSID of IFS files is not 1208.
+   */
+  async function mustFixCCSID() {
+    if (fixCCSID === undefined) {
+      fixCCSID = (await getConnection().sendCommand({ command: 'touch codeforiccsidtest && attr codeforiccsidtest CCSID && rm codeforiccsidtest' })).stdout !== "1208";
+    }
+
+    return fixCCSID;
   }
 }

--- a/src/api/local/deployment.ts
+++ b/src/api/local/deployment.ts
@@ -258,11 +258,11 @@ export namespace Deployment {
    * 
    * @returns `true` if the default CCSID of IFS files is not 1208.
    */
-  async function mustFixCCSID() {    
+  async function mustFixCCSID() {
     if (fixCCSID === undefined) {
       const connection = getConnection();
-      fixCCSID = Boolean(connection.remoteFeatures.attr) && 
-          Boolean(connection.remoteFeatures.setccsid) &&
+      fixCCSID = Boolean(connection.remoteFeatures.attr) &&
+        Boolean(connection.remoteFeatures.setccsid) &&
         (await connection.sendCommand({ command: `touch codeforiccsidtest && ${connection.remoteFeatures.attr} codeforiccsidtest CCSID && rm codeforiccsidtest` })).stdout !== "1208";
     }
 


### PR DESCRIPTION
### Changes
Resolves https://github.com/codefori/vscode-ibmi/issues/1995

On systems <= 7.3, the deployed files are created with a CCSID 819 (or at least different from 1208).
This PR checks (once per connection, during the first deployment - the check result is cached) if the CCSID needs to be set to 1208 after a successful deployment and runs the `setccsid` command if needed.

### How to test this PR
Here is a query to list files with CCSID != 1208:
```sql
select path_name, ccsid
from table(qsys2.ifs_object_statistics( 
           start_path_name => '/deployment/path',
           subtree_directories => 'yes'))
where ccsid != 1208
```

This should be tested on two systems:
* [x] On a system where stream files are created with CCSID 819 (IBM i OS <= 7.3)
1. Deploy the local workspace
2. Check the progress says `Fixing files CCSID...`
3. If running an action, check the following log appear in the task log: `Deployed files' CCSID set to 1208`
4. The SQL query above should not return any result

* [x] On a system where stream files are created with CCSID 1208
1. Deploy the local workspace
2. Nothing should be logged about fixing the CCSID
3. The SQL query above should not return any result

### Checklist
* [x] have tested my change