### PR TITLE
Don't use library list to validate current library change

### DIFF
--- a/src/views/LibraryListView.ts
+++ b/src/views/LibraryListView.ts
@@ -4,7 +4,7 @@ import { instance } from "../instantiate";
 import { t } from "../locale";
 import { WithLibrary } from "../typings";
 
-export class LibraryListProvider implements vscode.TreeDataProvider<LibraryListNode>{
+export class LibraryListProvider implements vscode.TreeDataProvider<LibraryListNode> {
   private readonly _emitter: vscode.EventEmitter<LibraryListNode | undefined | null | void> = new vscode.EventEmitter();
   readonly onDidChangeTreeData: vscode.Event<LibraryListNode | undefined | null | void> = this._emitter.event;;
 
@@ -312,7 +312,7 @@ async function changeCurrentLibrary(library: string) {
   const config = instance.getConfig();
   const storage = instance.getStorage();
   if (connection && config && storage) {
-    const commandResult = await connection.runCommand({ command: `CHGCURLIB ${library}` });
+    const commandResult = await connection.runCommand({ command: `CHGCURLIB ${library}`, noLibList: true });
     if (commandResult.code === 0) {
       const currentLibrary = connection.upperCaseName(config.currentLibrary);
       config.currentLibrary = library;


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/2031

When changing the current library, `CHGCURLIB` is run to validate the new current library. If for some reason, the current `current library` cannot be accessed, `CHGCURLIB` will fail as the library list is wrong (i.e. it contains a library that cannot be accessed). This prevents the current library from being changed to fix the library list.

This PR changes the way `CHGCURLIB` is called so it doesn't use the library list.

### How to test this PR

Examples:
1. Create a temporary library
2. Set it as the current library
3. Delete the temporary library
4. Reconnect
5. Change the current library

Before the PR, step 5 would fail. With the PR, step 5 runs fine.

### Checklist
* [x] have tested my change