### PR TITLE
Get asp name when listing objects

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -530,7 +530,8 @@ export default class IBMiContent {
         `  'PF'                as ATTRIBUTE,`,
         `  t.TABLE_TEXT        as TEXT,`,
         `  1                   as IS_SOURCE,`,
-        `  t.ROW_LENGTH        as SOURCE_LENGTH`,
+        `  t.ROW_LENGTH        as SOURCE_LENGTH,`,
+        `  t.IASP_NUMBER       as IASP_NUMBER`,
         `from QSYS2.SYSTABLES as t`,
         `where t.table_schema = '${library}' and t.file_type = 'S'${objectNameLike()}`,
       ];
@@ -543,6 +544,7 @@ export default class IBMiContent {
         `  OBJATTRIBUTE     as ATTRIBUTE,`,
         `  OBJTEXT          as TEXT,`,
         `  0                as IS_SOURCE,`,
+        `  IASP_NUMBER      as IASP_NUMBER,`,
         `  OBJSIZE          as SIZE,`,
         `  extract(epoch from (OBJCREATED))*1000       as CREATED,`,
         `  extract(epoch from (CHANGE_TIMESTAMP))*1000 as CHANGED,`,
@@ -571,6 +573,7 @@ export default class IBMiContent {
         `    OBJATTRIBUTE      as ATTRIBUTE,`,
         `    OBJTEXT           as TEXT,`,
         `    0                 as IS_SOURCE,`,
+        `    IASP_NUMBER       as IASP_NUMBER,`,
         `    OBJSIZE           as SIZE,`,
         `    extract(epoch from (OBJCREATED))*1000       as CREATED,`,
         `    extract(epoch from (CHANGE_TIMESTAMP))*1000 as CHANGED,`,
@@ -585,6 +588,7 @@ export default class IBMiContent {
         `  o.TEXT,`,
         `  case when s.IS_SOURCE is not null then s.IS_SOURCE else o.IS_SOURCE end as IS_SOURCE,`,
         `  s.SOURCE_LENGTH,`,
+        `  o.IASP_NUMBER,`,
         `  o.SIZE,`,
         `  o.CREATED,`,
         `  o.CHANGED,`,
@@ -609,6 +613,7 @@ export default class IBMiContent {
       changed: new Date(Number(object.CHANGED)),
       created_by: object.CREATED_BY,
       owner: object.OWNER,
+      asp: this.ibmi.aspInfo[Number(object.IASP_NUMBER)]
     } as IBMiObject))
       .filter(object => !typeFilter || typeFilter(object.type))
       .filter(object => objectFilter || nameFilter.test(object.name))

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -332,7 +332,7 @@ export namespace Tools {
   export function generateTooltipHtmlTable(header: string, rows: Record<string, any>) {
     return `<table>`
       .concat(`${header ? `<thead>${header}</thead>` : ``}`)
-      .concat(`${Object.entries(rows).map(([key, value]) => `<tr><td>${t(key)}:</td><td>&nbsp;${value}</td></tr>`).join(``)}`)
+      .concat(`${Object.entries(rows).filter(([key, value]) => value !== undefined).map(([key, value]) => `<tr><td>${t(key)}:</td><td>&nbsp;${value}</td></tr>`).join(``)}`)
       .concat(`</table>`);
   }
 

--- a/src/locale/ids/da.json
+++ b/src/locale/ids/da.json
@@ -131,6 +131,7 @@
   "helpView.officialForum": "Forum",
   "helpView.reportIssue": "Opret en fejlrapport",
   "helpView.reviewIssues": "Se fejlrapporter",
+  "iasp": "IASP",
   "ifsBrowser.addIFSShortcut.error": "{0} er ikke en mappe.",
   "ifsBrowser.addIFSShortcut.errorMessage": "Fejl ved oprettelse af IFS genvej! {0}",
   "ifsBrowser.addIFSShortcut.prompt": "Sti til IFS mappe",

--- a/src/locale/ids/en.json
+++ b/src/locale/ids/en.json
@@ -131,6 +131,7 @@
   "helpView.officialForum": "Open official Forum",
   "helpView.reportIssue": "Report an Issue",
   "helpView.reviewIssues": "Review Issues",
+  "iasp": "IASP",
   "ifsBrowser.addIFSShortcut.error": "{0} is not a directory.",
   "ifsBrowser.addIFSShortcut.errorMessage": "Error creating IFS shortcut! {0}",
   "ifsBrowser.addIFSShortcut.prompt": "Path to IFS directory",

--- a/src/locale/ids/fr.json
+++ b/src/locale/ids/fr.json
@@ -131,6 +131,7 @@
   "helpView.officialForum": "Forum officiel",
   "helpView.reportIssue": "Déclarer un incident",
   "helpView.reviewIssues": "Voir les incidents",
+  "iasp": "IASP",
   "ifsBrowser.addIFSShortcut.error": "{0} n'est pas un répertoire.",
   "ifsBrowser.addIFSShortcut.errorMessage": "Erreur lors de la création du raccourci IFS! {0}",
   "ifsBrowser.addIFSShortcut.prompt": "Chemin du répertoire IFS",

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -317,7 +317,8 @@ class ObjectBrowserSourcePhysicalFileItem extends ObjectBrowserItem implements O
       text: this.object.text,
       members: await content.countMembers(this.object),
       length: this.object.sourceLength,
-      CCSID: (await content.getAttributes(this.object, "CCSID"))?.CCSID || '?'
+      CCSID: (await content.getAttributes(this.object, "CCSID"))?.CCSID || '?',
+      iasp: this.object.asp
     }));
 
     tooltip.supportHtml = true;
@@ -350,6 +351,7 @@ class ObjectBrowserObjectItem extends ObjectBrowserItem implements ObjectItem, W
       changed: object.changed?.toISOString().slice(0, 19).replace(`T`, ` `),
       created_by: object.created_by,
       owner: object.owner,
+      iasp: object.asp
     }));
     this.tooltip.supportHtml = true;
 


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/2039

This PR updates the queries used when listing objects so the IASP name can be resolved if needed.
It also adds the IASP name in the tooltip, if not undefined:
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/9c32de80-9384-44c3-9fe8-ce6ea034236e)


### How to test this PR
1. Connect to a system with an IASP
2. Expand a filter that lists physical source files
3. Display the physical source files tooltip.
4. The members count and CCSID must be OK

With the PR, the members count is wrong and CCSID shows `?`

### Checklist
* [x] have tested my change