### PR TITLE
Add shortcut to search object and IFS browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1640,9 +1640,9 @@
 			},
 			{
 				"command": "code-for-ibmi.searchIFSBrowser",
-				"title": "Search",
+				"title": "Highlight",
 				"category": "IBM i",
-				"icon": "$(search)",
+				"icon": "$(search-fuzzy)",
 				"enablement": "code-for-ibmi:connected"
 			}
 		],

--- a/package.json
+++ b/package.json
@@ -1630,6 +1630,20 @@
 				"category": "IBM i",
 				"icon": "$(settings-gear)",
 				"enablement": "!code-for-ibmi:debugWorking"
+			},
+			{
+				"command": "code-for-ibmi.searchObjectBrowser",
+				"title": "Search",
+				"category": "IBM i",
+				"icon": "$(search)",
+				"enablement": "code-for-ibmi:connected"
+			},
+			{
+				"command": "code-for-ibmi.searchIFSBrowser",
+				"title": "Search",
+				"category": "IBM i",
+				"icon": "$(search)",
+				"enablement": "code-for-ibmi:connected"
 			}
 		],
 		"keybindings": [
@@ -2171,6 +2185,14 @@
 				{
 					"command": "code-for-ibmi.debug.open.service.config",
 					"when": "never"
+				},
+				{
+					"command": "code-for-ibmi.searchObjectBrowser",
+					"when": "never"
+				},
+				{
+					"command": "code-for-ibmi.searchIFSBrowser",
+					"when": "never"
 				}
 			],
 			"view/title": [
@@ -2270,8 +2292,13 @@
 					"when": "view == ifsBrowser"
 				},
 				{
-					"command": "code-for-ibmi.refreshIFSBrowser",
+					"command": "code-for-ibmi.searchIFSBrowser",
 					"group": "navigation@1",
+					"when": "view == ifsBrowser"
+				},
+				{
+					"command": "code-for-ibmi.refreshIFSBrowser",
+					"group": "navigation@2",
 					"when": "view == ifsBrowser"
 				},
 				{
@@ -2281,12 +2308,17 @@
 				},
 				{
 					"command": "code-for-ibmi.refreshObjectBrowser",
-					"group": "navigation@6",
+					"group": "navigation@7",
 					"when": "view == objectBrowser"
 				},
 				{
 					"command": "code-for-ibmi.sortFilters",
 					"group": "navigation@5",
+					"when": "view == objectBrowser"
+				},
+				{
+					"command": "code-for-ibmi.searchObjectBrowser",
+					"group": "navigation@6",
 					"when": "view == objectBrowser"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -1633,9 +1633,9 @@
 			},
 			{
 				"command": "code-for-ibmi.searchObjectBrowser",
-				"title": "Search",
+				"title": "Highlight",
 				"category": "IBM i",
-				"icon": "$(search)",
+				"icon": "$(search-fuzzy)",
 				"enablement": "code-for-ibmi:connected"
 			},
 			{

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -801,6 +801,11 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(`code-for-ibmi.ifs.copyPath`, async (node: IFSItem) => {
       await vscode.env.clipboard.writeText(node.path);
     }),
+
+    vscode.commands.registerCommand(`code-for-ibmi.searchIFSBrowser`, async() => {
+        vscode.commands.executeCommand('ifsBrowser.focus');
+        vscode.commands.executeCommand('list.find');
+    })
   )
 }
 

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -1294,6 +1294,11 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
           }
         }
       }
+    }),
+
+    vscode.commands.registerCommand(`code-for-ibmi.searchObjectBrowser`, async() => {
+        vscode.commands.executeCommand('objectBrowser.focus');
+        vscode.commands.executeCommand('list.find');
     })
   );
 }


### PR DESCRIPTION
### Changes
Adds a shortcut to the Object Browser and IFS Browser to search the lists
Completes #2028 

### How to test this PR
1. Connect to a system
2. Click the Search icon on either the Object or IFS Browser

### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md) 