### PR TITLE
Hide debug setup when being managed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1755,7 +1755,7 @@
 				{
 					"id": "ibmiDebugBrowser",
 					"name": "IBM i debugger",
-					"when": "code-for-ibmi:connected && code-for-ibmi:debug",
+					"when": "code-for-ibmi:connected && code-for-ibmi:debug && !code-for-ibmi:debugManaged",
 					"visibility": "collapsed"
 				}
 			]


### PR DESCRIPTION
### Changes

Hide debug setup view when running Code for IBM i in managed mode

### How to test this PR

Examples:

1. Run Code for IBM i and expect to see the debug setup view
2. Run Code for IBM i in 'managed mode' and expect the debug setup view to be hidden

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)