### PR TITLE
Change where manage debug context is set

### DIFF
--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -363,7 +363,9 @@ export async function initialize(context: ExtensionContext) {
       //Enable service entry points related commands
       vscode.commands.executeCommand(`setContext`, debugSEPContext, await server.isSEPSupported());
 
-      if (!isManaged()) {
+      const isDebugManaged = isManaged();
+      vscode.commands.executeCommand(`setContext`, `code-for-ibmi:debugManaged`, isDebugManaged);
+      if (!isDebugManaged) {
         const isSecure = connection.config!.debugIsSecure;
 
         if (validateIPv4address(connection.currentHost) && isSecure) {
@@ -379,8 +381,6 @@ export async function initialize(context: ExtensionContext) {
     vscode.commands.executeCommand(`setContext`, debugContext, false);
     vscode.commands.executeCommand(`setContext`, debugSEPContext, false);
   });
-
-  vscode.commands.executeCommand(`setContext`, `code-for-ibmi:debugManaged`, isManaged());
 }
 
 function validateIPv4address(ipaddress: string) {


### PR DESCRIPTION
### Changes

On the edge case when other extensions are setting the `DEBUG_MANAGED` variable, we now set the context when the connection is made.

### How to test this PR

Examples:

1. Set the environment variable `DEBUG_MANAGED` before connecting to a system and expect the debug setup view to be hidden.

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)