### PR TITLE
Update connection's configuration before saving it

### DIFF
--- a/src/api/Instance.ts
+++ b/src/api/Instance.ts
@@ -36,8 +36,10 @@ export default class Instance {
   }
 
   async setConfig(newConfig: ConnectionConfiguration.Parameters) {
+    if (this.connection) {
+      this.connection.config = newConfig;
+    }
     await ConnectionConfiguration.update(newConfig);
-    if (this.connection) this.connection.config = newConfig;
   }
 
   getConfig() {


### PR DESCRIPTION
### Changes
This PR makes sure the connection's configuration gets updated before it gets saved, so the functions triggered by `onCodeForIBMiConfigurationChange` who access the current configuration (i.e. using `instance.getConfig()`) gets the updated configuration (and not the one before it gets updated).

### How to test this PR
1. Open the connection settings
2. Got to the Source Code tab
3. Change the `Read only mode` checkbox

* [ ] Without the PR: the connection's icon in the status bar doesn't get update to reflect the read only mode state. It updates if another the settings are re-opened and saved again.
* [x] With the PR: the icon gets updated immediately after the settings are saved.

### Checklist

* [x] have tested my change