### PR TITLE
Added Keepalive interval login settings

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -123,7 +123,7 @@ export default class IBMi {
   async connect(connectionObject: ConnectionData, reconnecting?: boolean, reloadServerSettings: boolean = false): Promise<{ success: boolean, error?: any }> {
     return await Tools.withContext("code-for-ibmi:connecting", async () => {
       try {
-        connectionObject.keepaliveInterval = 35000;
+        connectionObject.keepaliveInterval = connectionObject.keepaliveInterval === undefined ? 35000 : connectionObject.keepaliveInterval;
 
         configVars.replaceAll(connectionObject);
 

--- a/src/locale/ids/da.json
+++ b/src/locale/ids/da.json
@@ -198,7 +198,7 @@
   "JOB_USER": "Job bruger",
   "jvm.info": "JVM information",
   "keepaliveInterval":"Keepalive interval",
-  "keepaliveInterval.description":"How often (in milliseconds) to send SSH-level keepalive packets to the server. Set to 0 to disable.",
+  "keepaliveInterval.description":"Frekvens (millisekunder) for afsendelsen af SSH keepalive pakker til serveren. Sæt til 0 for at deaktivere.",
   "length": "Længde",
   "LibraryListView.addToLibraryList.addedLib": "Bibliotek {0} blev tilføjet til bibliotekslisten.",
   "LibraryListView.addToLibraryList.alreadyInList": "Bibliotek {0} er allerede i bibliotekslisten.",

--- a/src/locale/ids/da.json
+++ b/src/locale/ids/da.json
@@ -197,6 +197,8 @@
   "JOB_STATUS": "Job status",
   "JOB_USER": "Job bruger",
   "jvm.info": "JVM information",
+  "keepaliveInterval":"Keepalive interval",
+  "keepaliveInterval.description":"How often (in milliseconds) to send SSH-level keepalive packets to the server. Set to 0 to disable.",
   "length": "Længde",
   "LibraryListView.addToLibraryList.addedLib": "Bibliotek {0} blev tilføjet til bibliotekslisten.",
   "LibraryListView.addToLibraryList.alreadyInList": "Bibliotek {0} er allerede i bibliotekslisten.",

--- a/src/locale/ids/en.json
+++ b/src/locale/ids/en.json
@@ -197,6 +197,8 @@
   "JOB_STATUS": "Job status",
   "JOB_USER": "Job user",
   "jvm.info": "JVM information",
+  "keepaliveInterval":"Keepalive interval",
+  "keepaliveInterval.description":"How often (in milliseconds) to send SSH-level keepalive packets to the server. Set to 0 to disable.",
   "length": "Length",
   "LibraryListView.addToLibraryList.addedLib": "Library {0} was added to the library list.",
   "LibraryListView.addToLibraryList.alreadyInList": "Library {0} was already in the library list.",

--- a/src/locale/ids/fr.json
+++ b/src/locale/ids/fr.json
@@ -197,6 +197,8 @@
   "JOB_STATUS": "Status du job",
   "JOB_USER": "Utilisateur",
   "jvm.info": "Information JVM",
+  "keepaliveInterval":"Intervalle keepalive",
+  "keepaliveInterval.description":"Définit l'intervalle (en millisecondes) entre deux envois au serveur SSH du signal keepalive. Mettre 0 pour désactiver.",
   "length": "Longueur",
   "LibraryListView.addToLibraryList.addedLib": "La bibliohtèque {0} a été ajoutée à la liste des bibliothèques.",
   "LibraryListView.addToLibraryList.alreadyInList": "La bibliohtèque {0} est déjà dans la liste des bibliothèques.",

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -1,10 +1,10 @@
 import vscode from "vscode";
-import { ConnectionConfiguration, ConnectionManager, GlobalConfiguration } from "../../api/Configuration";
+import { ConnectionConfiguration, ConnectionManager } from "../../api/Configuration";
 import { CustomUI, Section } from "../../api/CustomUI";
 import IBMi from "../../api/IBMi";
 import { disconnect, instance } from "../../instantiate";
-import { ConnectionData } from '../../typings';
 import { t } from "../../locale";
+import { ConnectionData } from '../../typings';
 
 type NewLoginSettings = ConnectionData & {
   savePassword: boolean
@@ -30,6 +30,7 @@ export class Login {
       .addInput(`host`, t(`login.host`), undefined, { minlength: 1 })
       .addInput(`port`, t(`login.port`), ``, { default: `22`, minlength: 1, maxlength: 5, regexTest: `^\\d+$` })
       .addInput(`username`, t(`username`), undefined, { minlength: 1, maxlength: 10 })
+      .addInput(`keepaliveInterval`, t('keepaliveInterval'), t('keepaliveInterval.description'), { default: '35000', regexTest: `^\\d*$` })
       .addParagraph(t(`login.authDecision`))
       .addPassword(`password`, t(`password`))
       .addCheckbox(`savePassword`, t(`login.savePassword`))
@@ -55,6 +56,7 @@ export class Login {
       page.panel.dispose();
 
       data.port = Number(data.port);
+      data.keepaliveInterval = Number(data.keepaliveInterval);
       data.privateKeyPath = data.privateKeyPath?.trim() ? data.privateKeyPath : undefined;
       if (data.name) {
         const existingConnection = ConnectionManager.getByName(data.name);

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -69,6 +69,7 @@ export class Login {
             name: data.name,
             host: data.host,
             port: data.port,
+            keepaliveInterval: data.keepaliveInterval,
             username: data.username,
             privateKeyPath: data.privateKeyPath
           };

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -369,7 +369,7 @@ export class SettingsUI {
 
                   default:
                     if (data.password) {
-                      delete data.privateKeyPath;
+                      data.privateKeyPath = undefined;
                       if (data.password !== storedPassword) {
                         // New password was entered, so store the password
                         // and remove the private key path from the data
@@ -382,9 +382,6 @@ export class SettingsUI {
                       // use the keypath instead
                       await ConnectionManager.deleteStoredPassword(context, name);
                       vscode.window.showInformationMessage(t(`login.privateKey.updated`, name));
-                    }
-                    else{
-                      delete data.privateKeyPath;
                     }
                     break;
                 }

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -343,6 +343,7 @@ export class SettingsUI {
               .addInput(`host`, t(`login.host`), undefined, { default: stored.host, minlength: 1 })
               .addInput(`port`, t(`login.port`), undefined, { default: String(stored.port), minlength: 1, maxlength: 5, regexTest: `^\\d+$` })
               .addInput(`username`, t(`username`), undefined, { default: stored.username, minlength: 1 })
+              .addInput(`keepaliveInterval`, t('keepaliveInterval'), t('keepaliveInterval.description'), { default: String(stored.keepaliveInterval !== undefined ? stored.keepaliveInterval : 35000), regexTest: `^\\d*$` })
               .addParagraph(t(`login.authDecision`))
               .addPassword(`password`, `${t(`password`)}${storedPassword ? ` (${t(`stored`)})` : ``}`, t(`login.password.label`))
               .addFile(`privateKeyPath`, `${t(`privateKey`)}${stored.privateKeyPath ? ` (${t(`current`)}: ${stored.privateKeyPath})` : ``}`, t(`login.privateKey.label`) + ' ' + t(`login.privateKey.support`))
@@ -368,7 +369,7 @@ export class SettingsUI {
 
                   default:
                     if (data.password) {
-                      data.privateKeyPath = undefined;
+                      delete data.privateKeyPath;
                       if (data.password !== storedPassword) {
                         // New password was entered, so store the password
                         // and remove the private key path from the data
@@ -382,11 +383,15 @@ export class SettingsUI {
                       await ConnectionManager.deleteStoredPassword(context, name);
                       vscode.window.showInformationMessage(t(`login.privateKey.updated`, name));
                     }
+                    else{
+                      delete data.privateKeyPath;
+                    }
                     break;
                 }
 
                 //Fix values before assigning the data
                 data.port = Number(data.port);
+                data.keepaliveInterval = Number(data.keepaliveInterval);
                 delete data.password;
                 delete data.buttons;
 


### PR DESCRIPTION
### Changes
Resolves https://github.com/codefori/vscode-ibmi/issues/2074

This PR adds a new input to the Logins settings to let the user define a custom SSH `Keepalive interval`.
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/d72f2ede-d7d3-4a1b-b8d2-757d0807a3d0)

### How to test this PR
Set a breakpoint in src/api/IBMi.ts on line 126.

1. Open an existing connection
2. Define a custom Keepalive interval
3. Connect
4. Check the `connectionObject.keepaliveInterval` field is set with the custom value.

### Checklist
* [x] have tested my change