### PR TITLE
Fix/project debug

### DIFF
--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -7,12 +7,12 @@ import * as vscode from 'vscode';
 import { instance } from "../../instantiate";
 import { ObjectItem } from "../../typings";
 import { ILELibrarySettings } from "../CompileTools";
+import { ConnectionManager } from "../Configuration";
 import { Tools } from "../Tools";
-import { getEnvConfig } from "../local/env";
+import { Env, getEnvConfig } from "../local/env";
 import * as certificates from "./certificates";
 import { DEBUG_CONFIG_FILE, getDebugServiceDetails, resetDebugServiceDetails } from "./config";
 import * as server from "./server";
-import { ConnectionManager } from "../Configuration";
 
 const debugExtensionId = `IBM.ibmidebug`;
 
@@ -43,7 +43,7 @@ const debugExtensionAvailable = () => {
 
 export async function initialize(context: ExtensionContext) {
 
-  const startDebugging = async (type: DebugType, objectType: DebugObjectType, objectLibrary: string, objectName: string, workspaceFolder?: vscode.WorkspaceFolder) => {
+  const startDebugging = async (type: DebugType, objectType: DebugObjectType, objectLibrary: string, objectName: string, env?: Env) => {
     if (debugExtensionAvailable()) {
       const connection = instance.getConnection();
       const config = instance.getConfig();
@@ -58,8 +58,7 @@ export async function initialize(context: ExtensionContext) {
 
           // If we are debugging from a workspace, perhaps
           // the user has a custom CURLIB and LIBL setup.
-          if (workspaceFolder) {
-            const env = await getEnvConfig(workspaceFolder);
+          if (env) {
             if (env[`CURLIB`]) {
               objectLibrary = env[`CURLIB`];
               libraries.currentLibrary = env[`CURLIB`];
@@ -133,9 +132,8 @@ export async function initialize(context: ExtensionContext) {
     }
   }
 
-  const getObjectFromUri = (uri: Uri) => {
+  const getObjectFromUri = (uri: Uri, env?: Env) => {
     const connection = instance.getConnection();
-
     const configuration = instance.getConfig();
 
     const qualifiedPath: {
@@ -153,12 +151,12 @@ export async function initialize(context: ExtensionContext) {
           break;
         case `streamfile`:
           const streamfilePath = path.parse(uri.path);
-          qualifiedPath.library = configuration.currentLibrary;
+          qualifiedPath.library = env?.CURLIB || configuration.currentLibrary;
           qualifiedPath.object = streamfilePath.name;
           break;
         case `file`:
           const localPath = path.parse(uri.path);
-          qualifiedPath.library = configuration.currentLibrary;
+          qualifiedPath.library = env?.CURLIB || configuration.currentLibrary;
           qualifiedPath.object = localPath.name;
           break;
       }
@@ -196,6 +194,12 @@ export async function initialize(context: ExtensionContext) {
     return password;
   }
 
+  const validateWorkspaceFolder = (maybeFolder?: vscode.WorkspaceFolder) => {
+    if (maybeFolder && "uri" in maybeFolder && "name" in maybeFolder && "index" in maybeFolder) {
+      return maybeFolder;
+    }
+  }
+
   context.subscriptions.push(
     vscode.commands.registerCommand(`code-for-ibmi.debug.extension`, () => {
       vscode.commands.executeCommand('extension.open', debugExtensionId);
@@ -221,32 +225,31 @@ export async function initialize(context: ExtensionContext) {
       }
     }),
 
-    vscode.commands.registerCommand(`code-for-ibmi.debug.batch`, (node?: ObjectItem | Uri) => {
-      vscode.commands.executeCommand(`code-for-ibmi.debug`, `batch`, node);
+    vscode.commands.registerCommand(`code-for-ibmi.debug.batch`, (node?: ObjectItem | Uri, wsFolder?: vscode.WorkspaceFolder) => {
+      vscode.commands.executeCommand(`code-for-ibmi.debug`, `batch`, node, validateWorkspaceFolder(wsFolder));
     }),
 
-    vscode.commands.registerCommand(`code-for-ibmi.debug.sep`, (node?: ObjectItem | Uri) => {
-      vscode.commands.executeCommand(`code-for-ibmi.debug`, `sep`, node);
+    vscode.commands.registerCommand(`code-for-ibmi.debug.sep`, (node?: ObjectItem | Uri, wsFolder?: vscode.WorkspaceFolder) => {
+      vscode.commands.executeCommand(`code-for-ibmi.debug`, `sep`, node, validateWorkspaceFolder(wsFolder));
     }),
 
-    vscode.commands.registerCommand(`code-for-ibmi.debug`, async (debugType?: DebugType, node?: ObjectItem | Uri) => {
+    vscode.commands.registerCommand(`code-for-ibmi.debug`, async (debugType?: DebugType, node?: ObjectItem | Uri, wsFolder?: vscode.WorkspaceFolder) => {
       if (debugType && node) {
+        const workspaceFolder = wsFolder || (node instanceof Uri ? vscode.workspace.getWorkspaceFolder(node) : undefined);
+        const env = workspaceFolder ? await getEnvConfig(workspaceFolder) : undefined;
         if (node instanceof Uri) {
-          const workspaceFolder = [`member`, `streamfile`].includes(node.scheme) ? undefined : vscode.workspace.getWorkspaceFolder(node);
-
-          const qualifiedObject = getObjectFromUri(node);
-
+          const qualifiedObject = getObjectFromUri(node, env);
           if (qualifiedObject.library && qualifiedObject.object) {
             const objectType = await getObjectType(qualifiedObject.library, qualifiedObject.object);
             if (objectType) {
-              startDebugging(debugType, objectType, qualifiedObject.library, qualifiedObject.object, workspaceFolder);
+              startDebugging(debugType, objectType, qualifiedObject.library, qualifiedObject.object, env);
             } else {
               vscode.window.showErrorMessage(`Failed to determine object type. Ensure the object exists and is a program (*PGM)${debugType === "sep" ? " or service program (*SRVPGM)" : ""}.`);
             }
           }
         } else {
           const { library, name, type } = node.object
-          startDebugging(debugType, type as DebugObjectType, library, name);
+          startDebugging(debugType, type as DebugObjectType, library, name, env);
         }
       }
     }),

--- a/src/api/local/env.ts
+++ b/src/api/local/env.ts
@@ -1,7 +1,9 @@
-import { workspace, WorkspaceFolder } from "vscode";
 import * as path from "path";
+import { workspace, WorkspaceFolder } from "vscode";
 
 import { str } from "crc-32/crc32c";
+
+export type Env = Record<string, string>;
 
 async function envExists(currentWorkspace: WorkspaceFolder) {
   const folderUri = currentWorkspace.uri;
@@ -16,7 +18,7 @@ async function envExists(currentWorkspace: WorkspaceFolder) {
 }
 
 export async function getEnvConfig(currentWorkspace: WorkspaceFolder) {
-  let env: {[key: string]: string} = {};
+  const env: Env = {};
 
   if (await envExists(currentWorkspace)) {
     const folderUri = currentWorkspace.uri;
@@ -40,10 +42,9 @@ export async function getEnvConfig(currentWorkspace: WorkspaceFolder) {
     });
   }
 
-  // @ts-ignore
   return env;
 }
 
 export function getBranchLibraryName(currentBranch: string) {
-  return `VS${(str(currentBranch, 0)>>>0).toString(16).toUpperCase()}`;
+  return `VS${(str(currentBranch, 0) >>> 0).toString(16).toUpperCase()}`;
 }


### PR DESCRIPTION
### Changes
Resolves https://github.com/codefori/vscode-ibmi/issues/2078

This PR enhances the debug command to:
- take into account the `.env` file content when a local file is debugged or if a workspace is used with the debug command
- allow a workspace folder to be used as a parameter when invoking the debug command

These changes allow the debug command to take into account the CURLIB and LIBL when debugging a local file or starting a debug from the Project Explorer browser.

### How to test this PR
With a workspace folder loaded into VSCode, containing an .env file and the Project Explorer extension loaded (the library list must be disabled):
1. Open a local file for a program (the program object must exist in the CURLIB defined in the `.env` file)
2. Click on the debug action in the editor
3. The program object must be found in the CURLIB defined in the `.env` file
4. The debug must start normally

Testing from the Project Explorer Browser requires another PR to be applied: https://github.com/IBM/vscode-ibmi-projectexplorer/pull/478

### Checklist
* [x] have tested my change