### PR TITLE
Fix types generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2831,7 +2831,7 @@
 		"vscode:prepublish": "webpack --mode production",
 		"webpack": "webpack --mode development",
 		"webpack-dev": "webpack --mode development --watch",
-		"typings": "npx -p typescript tsc ./src/extension.ts --declaration --allowJs --emitDeclarationOnly --outDir types --esModuleInterop -t es2022 --moduleResolution node"
+		"typings": "npx -p typescript tsc ./src/extension.ts --declaration --allowJs --emitDeclarationOnly --outDir types --esModuleInterop -t es2022 --moduleResolution node --resolveJsonModule"
 	},
 	"devDependencies": {
 		"@types/glob": "^7.1.3",


### PR DESCRIPTION
### Changes
Adds the `--resolveJsonModule` flag to the command generating the types to fix this error:
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/0893b956-64a6-414c-94cf-816eddc09745)

### How to test this PR
1. Apply the PR
2. Run `npm run typings` from a terminal
3. Types must be generated

### Checklist
* [x] have tested my change