### PR TITLE
Fixed privatekeypath update

### DIFF
--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -368,7 +368,7 @@ export class SettingsUI {
 
                   default:
                     if (data.password) {
-                      data.privateKeyPath = undefined;
+                      delete data.privateKeyPath;
                       if (data.password !== storedPassword) {
                         // New password was entered, so store the password
                         // and remove the private key path from the data
@@ -381,6 +381,9 @@ export class SettingsUI {
                       // use the keypath instead
                       await ConnectionManager.deleteStoredPassword(context, name);
                       vscode.window.showInformationMessage(t(`login.privateKey.updated`, name));
+                    }
+                    else{
+                      delete data.privateKeyPath;
                     }
                     break;
                 }


### PR DESCRIPTION
### Changes
This PR fixes an issue where the settings' `privateKeyPath` would be set to `''` instead of `undefined` after an update, crashing the connection process afterwards with this message:
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/b9fb6990-97d6-4027-925a-0b029ec3843f)


### How to test this PR
Before the PR, making any change not related to the password or private key in the settings would make the next password connection attempts to crash.

After the PR, connection attempts are OK after a change in the settings.

### Checklist
* [x] have tested my change