### PR TITLE
Fix clearing of multiple diagnostics

### DIFF
--- a/src/api/errors/diagnostics.ts
+++ b/src/api/errors/diagnostics.ts
@@ -52,13 +52,8 @@ export function clearDiagnostic(uri: vscode.Uri, changeRange: vscode.Range) {
   const currentList = ileDiagnostics.get(uri);
 
   if (currentList) {
-    const existing = currentList.findIndex(d => d.range.contains(changeRange));
-
-    if (existing >= 0) {
-      const newList = [...currentList.slice(0, existing), ...currentList.slice(existing + 1)];
-
-      ileDiagnostics.set(uri, newList);
-    }
+    const newList = currentList.filter(d => !d.range.contains(changeRange));
+    ileDiagnostics.set(uri, newList);
   }
 }
 


### PR DESCRIPTION
### Changes

Fixes #2084

With this PR, whenever the `Clear Diagnostic on Edit` setting is enabled and a text document is changed, **all** (instead of just the first one) diagnostics are cleared when the diagnostics range contains the text document's change range.

### How to test this PR

1. Enable the `Clear Diagnostic on Edit` setting
2. Git clone [ibmi-company_system](https://github.com/IBM/ibmi-company_system)
3. Create an error on line 7 (refer to the linked issue)
4. Compile the file and observe 2 diagnostics in this range.
5. Fix the error and the 2 diagnostics should be cleared.

### Checklist

* [x] have tested my change
* [x] Remove any/all `console.log`s I added