### PR TITLE
Delete stale cached server settings

### DIFF
--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -395,8 +395,8 @@ export class SettingsUI {
 
                 stored = Object.assign(stored, data);
                 await ConnectionManager.updateByIndex(index, stored);
+                GlobalStorage.get().deleteServerSettingsCache(server.name);
                 vscode.commands.executeCommand(`code-for-ibmi.refreshConnections`);
-
               }
             });
           }


### PR DESCRIPTION
### Changes

- Fixed bullet 3 of https://github.com/codefori/vscode-ibmi/issues/2088 by updating the current listener on `code-for-ibmi.connections` to detect and delete stale cached server settings. Also, refresh the connection browser to remove any deleted connections
- Delete cached server settings when login settings are changed 

### How to test this PR

Examples:

1. Create a new connection and connect so there exists some cached server settings.
2. Manually delete the connection from the `settings.json` file.
3. Observe that the connection is removed from the connection browser view.
4. Create a new connection with the same name.
5. Debug the extension and observe that connecting to the new connection does not reuse the old cached server settings. 
6. Disconnect and use the `Login Settings` action to change to another host or user profile.
7. Repeat step 5.

### Checklist

* [x] have tested my change
* [x] Remove any/all `console.log`s I added