### PR TITLE
Only show server ports in Debug Service tooltip

### DIFF
--- a/src/api/debug/server.ts
+++ b/src/api/debug/server.ts
@@ -112,7 +112,7 @@ export async function stopService(connection: IBMi) {
 export async function getDebugServiceJob() {
   const connection = instance.getConnection();
   if (connection) {
-    const rows = await connection.runSQL(`select distinct job_name, local_port from qsys2.netstat_job_info j where job_name = (select job_name from qsys2.netstat_job_info j where local_port = ${connection.config?.debugPort || 8005} and remote_address = '0.0.0.0' fetch first row only) and remote_port = 0`);
+    const rows = await connection.runSQL(`select job_name, local_port from qsys2.netstat_job_info j where job_name = (select job_name from qsys2.netstat_job_info j where local_port = ${connection.config?.debugPort || 8005} and remote_address = '0.0.0.0' fetch first row only) and remote_address = '0.0.0.0'`);
     if (rows && rows.length) {
       return {
         name: String(rows[0].JOB_NAME),

--- a/src/api/debug/server.ts
+++ b/src/api/debug/server.ts
@@ -112,7 +112,7 @@ export async function stopService(connection: IBMi) {
 export async function getDebugServiceJob() {
   const connection = instance.getConnection();
   if (connection) {
-    const rows = await connection.runSQL(`select distinct job_name, local_port from qsys2.netstat_job_info j where job_name = (select job_name from qsys2.netstat_job_info j where local_port = ${connection.config?.debugPort || 8005} and remote_address = '0.0.0.0' fetch first row only)`);
+    const rows = await connection.runSQL(`select distinct job_name, local_port from qsys2.netstat_job_info j where job_name = (select job_name from qsys2.netstat_job_info j where local_port = ${connection.config?.debugPort || 8005} and remote_address = '0.0.0.0' fetch first row only) and remote_port = 0`);
     if (rows && rows.length) {
       return {
         name: String(rows[0].JOB_NAME),


### PR DESCRIPTION
### Changes
In its current state, the `Debug Service` item tooltip in the `IBM i Debugger` view shows too many ports:
![toomany](https://github.com/codefori/vscode-ibmi/assets/11096890/077e5002-b0b7-4c06-94f8-b3588a7727a1)

The ports besides 8001 and 8005 are those used by the Service when it connects to the local TCP servers; they only appear once the Debug Service has been used at least once to debug a program:
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/524741f7-53aa-411f-b206-98fbacd18f15)

This PR fixes the query used to fetch the Service ports to only get the server ports.
![Code_Z7F1bRUJgk](https://github.com/codefori/vscode-ibmi/assets/11096890/70b16cba-3abb-49c7-9282-7aa891cf16e9)

### How to test this PR
1. Connect to an IBM i where the Debug Service runs and has been used at least once
2. Go to the `IBM i Debugger` view
3. Hover over the `Debug Service` item
4. Only two ports must be shown at the top of the tooltip

### Checklist
* [x] have tested my change