### PR TITLE
Fix object library being overwritten to current library for debug

### DIFF
--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -60,7 +60,6 @@ export async function initialize(context: ExtensionContext) {
           // the user has a custom CURLIB and LIBL setup.
           if (env) {
             if (env[`CURLIB`]) {
-              objectLibrary = env[`CURLIB`];
               libraries.currentLibrary = env[`CURLIB`];
             }
 


### PR DESCRIPTION
### Changes

@sebjulliand In relation to the changes in https://github.com/codefori/vscode-ibmi/pull/2079, we noticed in Project Explorer (https://github.com/IBM/vscode-ibmi-projectexplorer/issues/486) that the current library was always being used to debug a program even though it belonged to another library.

### How to test this PR

1. Run debug from Project Explorer.
2. Run debug from Object Browser.
3. Run debug from active editor (local file, stream file, member).

### Checklist

* [x] have tested my change