### PR TITLE
Add 5250 keyboard reset button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1666,7 +1666,7 @@
 			},
 			{
 				"command": "code-for-ibmi.term5250.systemAttention",
-				"title": "5250 Attention Request",
+				"title": "Reset keyboard",
 				"category": "IBM i",
 				"icon": "$(warning)",
 				"enablement": "code-for-ibmi:connected"

--- a/package.json
+++ b/package.json
@@ -1665,10 +1665,10 @@
 				"enablement": "code-for-ibmi:connected"
 			},
 			{
-				"command": "code-for-ibmi.term5250.systemAttention",
+				"command": "code-for-ibmi.term5250.resetPosition",
 				"title": "Reset keyboard",
 				"category": "IBM i",
-				"icon": "$(warning)",
+				"icon": "$(keyboard)",
 				"enablement": "code-for-ibmi:connected"
 			}
 		],
@@ -2363,7 +2363,7 @@
 					"when": "view == ibmiDebugBrowser"
 				},
 				{
-					"command": "code-for-ibmi.term5250.systemAttention",
+					"command": "code-for-ibmi.term5250.resetPosition",
 					"group": "navigation",
 					"when": "code-for-ibmi:term5250Halted"
 				}

--- a/package.json
+++ b/package.json
@@ -1663,6 +1663,13 @@
 				"category": "IBM i",
 				"icon": "$(search-fuzzy)",
 				"enablement": "code-for-ibmi:connected"
+			},
+			{
+				"command": "code-for-ibmi.term5250.systemRequest",
+				"title": "5250 System Request",
+				"category": "IBM i",
+				"icon": "$(warning)",
+				"enablement": "code-for-ibmi:connected"
 			}
 		],
 		"keybindings": [
@@ -2354,6 +2361,11 @@
 					"command": "code-for-ibmi.debug.refresh",
 					"group": "navigation@99",
 					"when": "view == ibmiDebugBrowser"
+				},
+				{
+					"command": "code-for-ibmi.term5250.systemRequest",
+					"group": "navigation",
+					"when": "code-for-ibmi:term5250Halted"
 				}
 			],
 			"editor/title": [

--- a/package.json
+++ b/package.json
@@ -1665,8 +1665,8 @@
 				"enablement": "code-for-ibmi:connected"
 			},
 			{
-				"command": "code-for-ibmi.term5250.systemRequest",
-				"title": "5250 System Request",
+				"command": "code-for-ibmi.term5250.systemAttention",
+				"title": "5250 Attention Request",
 				"category": "IBM i",
 				"icon": "$(warning)",
 				"enablement": "code-for-ibmi:connected"
@@ -2363,7 +2363,7 @@
 					"when": "view == ibmiDebugBrowser"
 				},
 				{
-					"command": "code-for-ibmi.term5250.systemRequest",
+					"command": "code-for-ibmi.term5250.systemAttention",
 					"group": "navigation",
 					"when": "code-for-ibmi:term5250Halted"
 				}

--- a/src/api/Terminal.ts
+++ b/src/api/Terminal.ts
@@ -104,7 +104,7 @@ export namespace Terminal {
     }
   }
 
-  const HALTED = `II`;
+  const HALTED = ` II`;
 
   async function createTerminal(connection: IBMi, terminalSettings: TerminalSettings) {
     const writeEmitter = new vscode.EventEmitter<string>();

--- a/src/api/Terminal.ts
+++ b/src/api/Terminal.ts
@@ -36,7 +36,9 @@ export namespace Terminal {
     commands.executeCommand(`setContext`, `code-for-ibmi:term5250Halted`, state);
   }
 
+  const BACKSPACE = 127;
   const RESET = 18;
+  const ATTENTION = 1;
   const TAB = 9;
 
   export function registerTerminalCommands() {
@@ -135,14 +137,19 @@ export namespace Terminal {
             const buffer = Buffer.from(data);
 
             switch (buffer[0]) {
-              case 127: //Backspace
+              case BACKSPACE: //Backspace
                 //Move back one, space, move back again - deletes a character
                 channel.stdin.write(Buffer.from([
                   27, 79, 68, //Move back one
                   27, 91, 51, 126 //Delete character
                 ]));
                 break;
+
               default:
+                if (buffer[0] === RESET || buffer[0] === ATTENTION) {
+                  setHalted(false);
+                }
+
                 channel.stdin.write(data);
                 break;
             }

--- a/src/api/Terminal.ts
+++ b/src/api/Terminal.ts
@@ -36,7 +36,7 @@ export namespace Terminal {
     commands.executeCommand(`setContext`, `code-for-ibmi:term5250Halted`, state);
   }
 
-  const CONTROL_A = 1;
+  const RESET = 18;
   const TAB = 9;
 
   export function registerTerminalCommands() {
@@ -54,10 +54,10 @@ export namespace Terminal {
         }
       }),
 
-      vscode.commands.registerCommand(`code-for-ibmi.term5250.systemAttention`, () => {
+      vscode.commands.registerCommand(`code-for-ibmi.term5250.resetPosition`, () => {
         const term = vscode.window.activeTerminal;
         if (term) {
-          term.sendText(Buffer.from([CONTROL_A, TAB]).toString(), false);
+          term.sendText(Buffer.from([RESET, TAB]).toString(), false);
           setHalted(false);
         }
       })
@@ -104,8 +104,7 @@ export namespace Terminal {
     }
   }
 
-  const HALT_START = `[24;2H(B[0;1m[37m[40m`;
-  const HALT_END = `[38X[5;53H(B[m[39;49m[37m[40m`;
+  const HALTED = `II`;
 
   async function createTerminal(connection: IBMi, terminalSettings: TerminalSettings) {
     const writeEmitter = new vscode.EventEmitter<string>();
@@ -115,7 +114,7 @@ export namespace Terminal {
     channel.stdout.on(`data`, (data: any) => {
       const dataString: string = data.toString();
       if (dataString.trim().indexOf(paseWelcomeMessage) === -1) {
-        if (dataString.startsWith(HALT_START) && dataString.endsWith(HALT_END)) {
+        if (dataString.includes(HALTED)) {
           setHalted(true);
         }
         writeEmitter.fire(String(data));

--- a/src/api/Terminal.ts
+++ b/src/api/Terminal.ts
@@ -36,6 +36,9 @@ export namespace Terminal {
     commands.executeCommand(`setContext`, `code-for-ibmi:term5250Halted`, state);
   }
 
+  const CONTROL_A = 1;
+  const TAB = 9;
+
   export function registerTerminalCommands() {
     return [
       vscode.commands.registerCommand(`code-for-ibmi.launchTerminalPicker`, () => {
@@ -54,7 +57,7 @@ export namespace Terminal {
       vscode.commands.registerCommand(`code-for-ibmi.term5250.systemAttention`, () => {
         const term = vscode.window.activeTerminal;
         if (term) {
-          term.sendText(Buffer.from([1, 9]).toString(), false);
+          term.sendText(Buffer.from([CONTROL_A, TAB]).toString(), false);
           setHalted(false);
         }
       })

--- a/src/api/Terminal.ts
+++ b/src/api/Terminal.ts
@@ -51,7 +51,7 @@ export namespace Terminal {
         }
       }),
 
-      vscode.commands.registerCommand(`code-for-ibmi.term5250.systemRequest`, () => {
+      vscode.commands.registerCommand(`code-for-ibmi.term5250.systemAttention`, () => {
         const term = vscode.window.activeTerminal;
         if (term) {
           term.sendText(Buffer.from([1, 9]).toString(), false);

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -1,6 +1,6 @@
 import { Tools } from './api/Tools';
 
-import path, { dirname } from 'path';
+import path from 'path';
 import * as vscode from "vscode";
 import { CompileTools } from './api/CompileTools';
 import { ConnectionConfiguration, ConnectionManager, DefaultOpenMode, GlobalConfiguration, onCodeForIBMiConfigurationChange } from "./api/Configuration";
@@ -598,18 +598,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       }
     }),
 
-    vscode.commands.registerCommand(`code-for-ibmi.launchTerminalPicker`, () => {
-      return Terminal.selectAndOpen(instance);
-    }),
-
-    vscode.commands.registerCommand(`code-for-ibmi.openTerminalHere`, async (ifsNode) => {
-      const content = instance.getContent();
-      if (content) {
-        const path = (await content.isDirectory(ifsNode.path)) ? ifsNode.path : dirname(ifsNode.path);
-        const terminal = await Terminal.selectAndOpen(instance, Terminal.TerminalType.PASE);
-        terminal?.sendText(`cd ${path}`);
-      }
-    }),
+    ...Terminal.registerTerminalCommands(),
 
     vscode.commands.registerCommand(`code-for-ibmi.getPassword`, async (extensionId: string, reason?: string) => {
       if (extensionId) {


### PR DESCRIPTION
### Changes

Adds a button to the terminal view that is displayed when the user attempts to type in an area where they cannot in 5250.

Not many users know the tn5250 shortcut (Control+R) to do a reset, so I added a button to the UI for it.

### How to test this PR

Examples:

1. Connect and launch a 5250
2. Sign in
3. Attempt to write outside an input field
4. See the button appear in the terminal tab
5. Click the button and see the cursor position reset

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)