### PR TITLE
Add tooltips to libraries in the user library list view

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import tmp from 'tmp';
 import util from 'util';
-import { window } from 'vscode';
+import { MarkdownString, window } from 'vscode';
 import { ObjectTypes } from '../filesystems/qsys/Objects';
 import { AttrOperands, CommandResult, IBMiError, IBMiMember, IBMiObject, IFSFile, QsysPath } from '../typings';
 import { ConnectionConfiguration } from './Configuration';
@@ -359,32 +359,55 @@ export default class IBMiContent {
    * @returns an array of libraries as IBMiObject
    */
   async getLibraryList(libraries: string[]): Promise<IBMiObject[]> {
-    let results: Tools.DB2Row[];
-
+    let objects: IBMiObject[];
     if (this.ibmi.enableSQL) {
       const statement = `
-        select os.OBJNAME as ODOBNM
-             , coalesce(os.OBJTEXT, '') as ODOBTX
-             , os.OBJATTRIBUTE as ODOBAT
-          from table( SYSTOOLS.SPLIT( INPUT_LIST => '${libraries.toString()}', DELIMITER => ',' ) ) libs
-             , table( QSYS2.OBJECT_STATISTICS( OBJECT_SCHEMA => 'QSYS', OBJTYPELIST => '*LIB', OBJECT_NAME => libs.ELEMENT ) ) os
+        SELECT
+          os.OBJNAME AS NAME,
+          os.OBJTYPE AS TYPE,
+          os.OBJATTRIBUTE AS ATTRIBUTE,
+          OBJTEXT AS TEXT,
+          os.IASP_NUMBER AS IASP_NUMBER,
+          os.OBJSIZE AS SIZE,
+          EXTRACT(EPOCH FROM (os.OBJCREATED)) * 1000 AS CREATED,
+          EXTRACT(EPOCH FROM (os.CHANGE_TIMESTAMP)) * 1000 AS CHANGED,
+          os.OBJOWNER AS OWNER,
+          os.OBJDEFINER AS CREATED_BY
+        from table( SYSTOOLS.SPLIT( INPUT_LIST => '${libraries.toString()}', DELIMITER => ',' ) ) libs,
+        table( QSYS2.OBJECT_STATISTICS( OBJECT_SCHEMA => 'QSYS', OBJTYPELIST => '*LIB', OBJECT_NAME => libs.ELEMENT ) ) os
       `;
-      results = await this.ibmi.runSQL(statement);
+      const results = await this.ibmi.runSQL(statement);
+
+      objects = results.map(object => ({
+        library: 'QSYS',
+        name: this.ibmi.sysNameInLocal(String(object.NAME)),
+        type: String(object.TYPE),
+        attribute: String(object.ATTRIBUTE),
+        text: String(object.TEXT || ""),
+        sourceFile: Boolean(object.IS_SOURCE),
+        sourceLength: object.SOURCE_LENGTH !== undefined ? Number(object.SOURCE_LENGTH) : undefined,
+        size: Number(object.SIZE),
+        created: new Date(Number(object.CREATED)),
+        changed: new Date(Number(object.CHANGED)),
+        created_by: object.CREATED_BY,
+        owner: object.OWNER,
+        asp: this.ibmi.aspInfo[Number(object.IASP_NUMBER)]
+      } as IBMiObject));
     } else {
-      results = await this.getQTempTable(libraries.map(library => `@DSPOBJD OBJ(QSYS/${library}) OBJTYPE(*LIB) DETAIL(*TEXTATR) OUTPUT(*OUTFILE) OUTFILE(QTEMP/LIBLIST) OUTMBR(*FIRST *ADD)`), "LIBLIST");
+      let results = await this.getQTempTable(libraries.map(library => `@DSPOBJD OBJ(QSYS/${library}) OBJTYPE(*LIB) DETAIL(*TEXTATR) OUTPUT(*OUTFILE) OUTFILE(QTEMP/LIBLIST) OUTMBR(*FIRST *ADD)`), "LIBLIST");
       if (results.length === 1 && !results[0].ODOBNM?.toString().trim()) {
         return [];
       }
       results = results.filter(object => libraries.includes(this.ibmi.sysNameInLocal(String(object.ODOBNM))));
-    };
 
-    const objects = results.map(object => ({
-      library: 'QSYS',
-      type: '*LIB',
-      name: this.ibmi.enableSQL ? object.ODOBNM : this.ibmi.sysNameInLocal(String(object.ODOBNM)),
-      attribute: object.ODOBAT,
-      text: object.ODOBTX
-    } as IBMiObject));
+      objects = results.map(object => ({
+        library: 'QSYS',
+        type: '*LIB',
+        name: this.ibmi.sysNameInLocal(String(object.ODOBNM)),
+        attribute: object.ODOBAT,
+        text: object.ODOBTX
+      } as IBMiObject));
+    };
 
     return libraries.map(library => {
       return objects.find(info => info.name === library) ||
@@ -948,5 +971,54 @@ export default class IBMiContent {
 
   async countFiles(directory: string) {
     return Number((await this.ibmi.sendCommand({ command: `ls | wc -l`, directory })).stdout.trim());
+  }
+
+  objectToToolTip(path: string, object: IBMiObject) {
+    const tooltip = new MarkdownString(Tools.generateTooltipHtmlTable(path, {
+      type: object.type,
+      attribute: object.attribute,
+      text: object.text,
+      size: object.size,
+      created: object.created?.toISOString().slice(0, 19).replace(`T`, ` `),
+      changed: object.changed?.toISOString().slice(0, 19).replace(`T`, ` `),
+      created_by: object.created_by,
+      owner: object.owner,
+      iasp: object.asp
+    }));
+    tooltip.supportHtml = true;
+    return tooltip;
+  }
+
+  async sourcePhysicalFileToToolTip(path: string, object: IBMiObject) {
+    const tooltip = new MarkdownString(Tools.generateTooltipHtmlTable(path, {
+      text: object.text,
+      members: await this.countMembers(object),
+      length: object.sourceLength,
+      CCSID: (await this.getAttributes(object, "CCSID"))?.CCSID || '?',
+      iasp: object.asp
+    }));
+    tooltip.supportHtml = true;
+    return tooltip;
+  }
+
+  memberToToolTip(path: string, member: IBMiMember) {
+    const tooltip = new MarkdownString(Tools.generateTooltipHtmlTable(path, {
+      text: member.text,
+      lines: member.lines,
+      created: member.created?.toISOString().slice(0, 19).replace(`T`, ` `),
+      changed: member.changed?.toISOString().slice(0, 19).replace(`T`, ` `)
+    }));
+    tooltip.supportHtml = true;
+    return tooltip;
+  }
+
+  ifsFileToToolTip(path: string, ifsFile: IFSFile) {
+    const tooltip = new MarkdownString(Tools.generateTooltipHtmlTable(path, {
+      size: ifsFile.size,
+      modified: ifsFile.modified ? new Date(ifsFile.modified.getTime() - ifsFile.modified.getTimezoneOffset() * 60 * 1000).toISOString().slice(0, 19).replace(`T`, ` `) : ``,
+      owner: ifsFile.owner ? ifsFile.owner.toUpperCase() : ``
+    }));
+    tooltip.supportHtml = true;
+    return tooltip;
   }
 }

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -367,7 +367,11 @@ export namespace Tools {
   export function generateTooltipHtmlTable(header: string, rows: Record<string, any>) {
     return `<table>`
       .concat(`${header ? `<thead>${header}</thead>` : ``}`)
-      .concat(`${Object.entries(rows).filter(([key, value]) => value !== undefined).map(([key, value]) => `<tr><td>${t(key)}:</td><td>&nbsp;${value}</td></tr>`).join(``)}`)
+      .concat(`${Object.entries(rows)
+        .filter(([key, value]) => value !== undefined && value !== '')
+        .map(([key, value]) => `<tr><td>${t(key)}:</td><td>&nbsp;${value}</td></tr>`)
+        .join(``)}`
+      )
       .concat(`</table>`);
   }
 

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -101,12 +101,7 @@ class IFSItem extends BrowserItem implements WithPath {
   constructor(readonly file: IFSFile, parameters: BrowserItemParameters) {
     super(file.name, parameters);
     this.path = file.path;
-    this.tooltip = new vscode.MarkdownString(Tools.generateTooltipHtmlTable(this.path, {
-      size: file.size,
-      modified: file.modified ? new Date(file.modified.getTime() - file.modified.getTimezoneOffset() * 60 * 1000).toISOString().slice(0, 19).replace(`T`, ` `) : ``,
-      owner: file.owner ? file.owner.toUpperCase() : ``
-    }));
-    this.tooltip.supportHtml = true;
+    this.tooltip = instance.getContent()?.ifsFileToToolTip(this.path, file);
   }
 
   sortBy(sort: SortOptions) {
@@ -139,11 +134,11 @@ class IFSFileItem extends IFSItem {
     this.iconPath = vscode.ThemeIcon.File;
 
     this.resourceUri = vscode.Uri.parse(this.path).with({ scheme: `streamfile` });
-    
+
     this.command = {
       command: "code-for-ibmi.openWithDefaultMode",
       title: `Open Streamfile`,
-      arguments: [{path: this.path}]
+      arguments: [{ path: this.path }]
     };
   }
 
@@ -823,9 +818,9 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
       await vscode.env.clipboard.writeText(node.path);
     }),
 
-    vscode.commands.registerCommand(`code-for-ibmi.searchIFSBrowser`, async() => {
-        vscode.commands.executeCommand('ifsBrowser.focus');
-        vscode.commands.executeCommand('list.find');
+    vscode.commands.registerCommand(`code-for-ibmi.searchIFSBrowser`, async () => {
+      vscode.commands.executeCommand('ifsBrowser.focus');
+      vscode.commands.executeCommand('list.find');
     })
   )
 }

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -312,18 +312,7 @@ class ObjectBrowserSourcePhysicalFileItem extends ObjectBrowserItem implements O
   }
 
   async getToolTip() {
-    const content = getContent();
-    const tooltip = new vscode.MarkdownString(Tools.generateTooltipHtmlTable(this.path, {
-      text: this.object.text,
-      members: await content.countMembers(this.object),
-      length: this.object.sourceLength,
-      CCSID: (await content.getAttributes(this.object, "CCSID"))?.CCSID || '?',
-      iasp: this.object.asp
-    }));
-
-    tooltip.supportHtml = true;
-
-    return tooltip;
+    return await getContent().sourcePhysicalFileToToolTip(this.path, this.object);
   }
 }
 
@@ -342,18 +331,7 @@ class ObjectBrowserObjectItem extends ObjectBrowserItem implements ObjectItem, W
     this.updateDescription();
 
     this.contextValue = `object.${type.toLowerCase()}${object.attribute ? `.${object.attribute}` : ``}${isLibrary ? '_library' : ''}${this.isProtected() ? `_readonly` : ``}`;
-    this.tooltip = new vscode.MarkdownString(Tools.generateTooltipHtmlTable(this.path, {
-      type: object.type,
-      attribute: object.attribute,
-      text: object.text,
-      size: object.size,
-      created: object.created?.toISOString().slice(0, 19).replace(`T`, ` `),
-      changed: object.changed?.toISOString().slice(0, 19).replace(`T`, ` `),
-      created_by: object.created_by,
-      owner: object.owner,
-      iasp: object.asp
-    }));
-    this.tooltip.supportHtml = true;
+    this.tooltip = getContent().objectToToolTip(this.path, object);
 
     this.resourceUri = vscode.Uri.from({
       scheme: `object`,
@@ -405,13 +383,7 @@ class ObjectBrowserMemberItem extends ObjectBrowserItem implements MemberItem {
 
     this.resourceUri = getMemberUri(member, { readonly });
     this.path = this.resourceUri.path.substring(1);
-    this.tooltip = new vscode.MarkdownString(Tools.generateTooltipHtmlTable(this.path, {
-      text: member.text,
-      lines: member.lines,
-      created: member.created?.toISOString().slice(0, 19).replace(`T`, ` `),
-      changed: member.changed?.toISOString().slice(0, 19).replace(`T`, ` `)
-    }));
-    this.tooltip.supportHtml = true;
+    this.tooltip = getContent().memberToToolTip(this.path, member);
 
     this.sortBy = (sort: SortOptions) => parent.sortBy(sort);
 
@@ -749,7 +721,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
 
       // If the member is currently open in an editor tab, and 
       // the member has unsaved changes, then prevent the renaming operation.
-      if(oldMemberTabs.find(tab => tab.isDirty)){
+      if (oldMemberTabs.find(tab => tab.isDirty)) {
         vscode.window.showErrorMessage(t("objectBrowser.renameMember.errorMessage", t("member.has.unsaved.changes")));
         return;
       }
@@ -1324,9 +1296,9 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
       }
     }),
 
-    vscode.commands.registerCommand(`code-for-ibmi.searchObjectBrowser`, async() => {
-        vscode.commands.executeCommand('objectBrowser.focus');
-        vscode.commands.executeCommand('list.find');
+    vscode.commands.registerCommand(`code-for-ibmi.searchObjectBrowser`, async () => {
+      vscode.commands.executeCommand('objectBrowser.focus');
+      vscode.commands.executeCommand('list.find');
     })
   );
 }


### PR DESCRIPTION
### Changes

- Add tooltips for libraries in the user library list view (just like the object browser)
  ![image](https://github.com/codefori/vscode-ibmi/assets/32170854/7a210c5a-48e6-4162-b7c2-83c748259d78)
- Add tooltip related APIs in `IBMiContent` to be used by Project Explorer:
  - `objectToToolTip`
  - `sourcePhysicalFileToToolTip`
  - `memberToToolTip`
  - `ifsFileToToolTip`

### How to test this PR

Check the following tooltips are rendering correctly

1. User Library List View - Libraries
2. Object Browser - Objects, Source Physical Files, Members
3. IFS Browser - IFS files/directories

### Checklist

* [x] have tested my change