### PR TITLE
Add missing refresh action in IFS Browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -2739,6 +2739,11 @@
 					"group": "3_ifsTransfer@3"
 				},
 				{
+					"command": "code-for-ibmi.refreshIFSBrowserItem",
+					"when": "view == ifsBrowser && viewItem =~ /^(directory|shortcut).*$/",
+					"group": "99_ifsBrowserAction@1"
+				},
+				{
 					"command": "code-for-ibmi.changeObjectDesc",
 					"when": "view == objectBrowser && (viewItem =~ /^object/ || viewItem == SPF)",
 					"group": "1_objActions@1"

--- a/package.json
+++ b/package.json
@@ -2600,7 +2600,7 @@
 				},
 				{
 					"command": "code-for-ibmi.refreshObjectBrowserItem",
-					"when": "view == objectBrowser",
+					"when": "view == objectBrowser && viewItem =~ /^(filter|object.*library|SPF).*$/",
 					"group": "99_objectBrowserAction@1"
 				},
 				{
@@ -2740,7 +2740,7 @@
 				},
 				{
 					"command": "code-for-ibmi.refreshIFSBrowserItem",
-					"when": "view == ifsBrowser && viewItem =~ /^(directory|shortcut).*$/",
+					"when": "view == ifsBrowser && viewItem =~ /^(shortcut|directory).*$/",
 					"group": "99_ifsBrowserAction@1"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -1214,13 +1214,6 @@
 				"icon": "$(arrow-circle-right)"
 			},
 			{
-				"command": "code-for-ibmi.refreshMemberBrowser",
-				"enablement": "code-for-ibmi:connected",
-				"title": "Refresh",
-				"category": "IBM i",
-				"icon": "$(refresh)"
-			},
-			{
 				"command": "code-for-ibmi.searchSourceFile",
 				"enablement": "code-for-ibmi:connected",
 				"title": "Search Source File...",
@@ -2171,10 +2164,6 @@
 				},
 				{
 					"command": "code-for-ibmi.refreshLibraryListView",
-					"when": "never"
-				},
-				{
-					"command": "code-for-ibmi.refreshMemberBrowser",
 					"when": "never"
 				},
 				{


### PR DESCRIPTION
### Changes

- Add refresh command for shortcuts and directories in IFS browser (command existed but was not contributed to the tree item)
- Remove unused `code-for-ibmi.refreshMemberBrowser` command
- Fix refresh command for the object browser tree items so only expandable items have the action

### How to test this PR

1. Verify the refresh action appears on expandable items in the IFS Browser and Object Browser.

### Checklist

* [x] have tested my change