### PR TITLE
Fix `countFiles` when directory does not exist

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -947,6 +947,6 @@ export default class IBMiContent {
   }
 
   async countFiles(directory: string) {
-    return Number((await this.ibmi.sendCommand({ command: `ls | wc -l`, directory })).stdout.trim());
+    return Number((await this.ibmi.sendCommand({ command: `cd ${directory} && (ls | wc -l)` })).stdout.trim());
   }
 }

--- a/src/testing/connection.ts
+++ b/src/testing/connection.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import { TestSuite } from ".";
 import { instance } from "../instantiate";
+import { Tools } from "../api/Tools";
 
 export const ConnectionSuite: TestSuite = {
   name: `Connection tests`,
@@ -275,7 +276,7 @@ export const ConnectionSuite: TestSuite = {
       name: `Test withTempDirectory and countFiles`, test: async () => {
         const connection = instance.getConnection()!;
         const content = instance.getContent()!;
-        let temp;        
+        let temp;
 
         await connection.withTempDirectory(async tempDir => {
           temp = tempDir;
@@ -291,6 +292,9 @@ export const ConnectionSuite: TestSuite = {
           }
 
           assert.strictEqual(await content.countFiles(tempDir), toCreate);
+
+          //Directory does not exist
+          assert.strictEqual(await content.countFiles(`${tempDir}/${Tools.makeid(20)}`), 0);
         });
 
         if (temp) {


### PR DESCRIPTION
### Changes

The `countFiles` function ends up counting the number of files in the home directory when the directory that it is given does not exist. Although I have not noticed any issue in Code4i because of this, it causes an issue in Project Explorer (as it calls `getDeployCompareFiles`) where it shows that it is going to delete the contents of my home directory:

![image](https://github.com/codefori/vscode-ibmi/assets/32170854/0b9c5204-2aec-45a2-994d-4bd73603f390)

Without this fix, the issue can also be observed in the updated test where the `countFiles` result ends up counting the number of files in my home directory rather than the directory provided:

![image](https://github.com/codefori/vscode-ibmi/assets/32170854/c9ab9dd0-402c-4fc0-a467-0fd5d6e035e0)

### How to test this PR

1. Use the test case provided
2. Use Project Explorer:
  - Deploy your workspace
  - Delete the deploy location using the IFS browser
  - Refresh the source in the Project Explorer and observe the contents of the home directory is not visible unlike the first image above

### Checklist

* [x] have tested my change
* [x] have created one or more test cases