### PR TITLE
Use default open mode in IFS search and find results

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -672,12 +672,12 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       return vscode.commands.executeCommand("code-for-ibmi.openWithDefaultMode", item, "edit" as DefaultOpenMode);
     }),
 
-    vscode.commands.registerCommand("code-for-ibmi.openWithDefaultMode", (item: WithPath, overrideMode?: DefaultOpenMode) => {
+    vscode.commands.registerCommand("code-for-ibmi.openWithDefaultMode", (item: WithPath, overrideMode?: DefaultOpenMode, position?: vscode.Range) => {
       const readonly = (overrideMode || GlobalConfiguration.get<DefaultOpenMode>("defaultOpenMode")) === "browse";
-      vscode.commands.executeCommand(`code-for-ibmi.openEditable`, item.path, { readonly });
+      vscode.commands.executeCommand(`code-for-ibmi.openEditable`, item.path, { readonly, position } as OpenEditableOptions);
     }),
     vscode.commands.registerCommand("code-for-ibmi.updateConnectedBar", updateConnectedBar),
-    
+
     vscode.commands.registerCommand("code-for-ibmi.refreshFile", async (uri?: vscode.Uri) => {
       let doc: vscode.TextDocument | undefined;
       if (uri) {
@@ -690,19 +690,19 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       if (doc?.isDirty) {
         vscode.window
           .showWarningMessage(
-            t(`discard.changes`), 
-            { modal: true }, 
+            t(`discard.changes`),
+            { modal: true },
             t(`Continue`))
           .then(result => {
-              if (result === t(`Continue`)) {
-                vscode.commands.executeCommand(`workbench.action.files.revert`);
-              }
-        });
+            if (result === t(`Continue`)) {
+              vscode.commands.executeCommand(`workbench.action.files.revert`);
+            }
+          });
       } else {
         vscode.commands.executeCommand(`workbench.action.files.revert`);
       }
     }),
-);
+  );
 
   ActionsUI.initialize(context);
   VariablesUI.initialize(context);

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -3,7 +3,7 @@ import path, { dirname, extname } from "path";
 import vscode, { FileType, window } from "vscode";
 
 import { existsSync, mkdirSync, rmdirSync } from "fs";
-import { ConnectionConfiguration, DefaultOpenMode, GlobalConfiguration } from "../api/Configuration";
+import { ConnectionConfiguration, GlobalConfiguration } from "../api/Configuration";
 import { SortOptions } from "../api/IBMiContent";
 import { Search } from "../api/Search";
 import { GlobalStorage } from "../api/Storage";
@@ -967,9 +967,8 @@ async function doFindStreamfiles(findTerm: string, findPath: string) {
 }
 
 function openIFSSearchResults(searchPath: string, searchResults: SearchResults) {
-  const readonly = GlobalConfiguration.get<DefaultOpenMode>("defaultOpenMode") === "browse";
   searchResults.hits =
-    searchResults.hits.map(a => ({ ...a, label: path.posix.relative(searchPath, a.path), readonly: readonly }) as SearchHit)
+    searchResults.hits.map(a => ({ ...a, label: path.posix.relative(searchPath, a.path) }) as SearchHit)
       .sort((a, b) => a.path.localeCompare(b.path));
   vscode.commands.executeCommand(`code-for-ibmi.setSearchResults`, searchResults);
 }

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -3,7 +3,7 @@ import path, { dirname, extname } from "path";
 import vscode, { FileType, window } from "vscode";
 
 import { existsSync, mkdirSync, rmdirSync } from "fs";
-import { ConnectionConfiguration, GlobalConfiguration } from "../api/Configuration";
+import { ConnectionConfiguration, DefaultOpenMode, GlobalConfiguration } from "../api/Configuration";
 import { SortOptions } from "../api/IBMiContent";
 import { Search } from "../api/Search";
 import { GlobalStorage } from "../api/Storage";
@@ -958,8 +958,9 @@ async function doFindStreamfiles(findTerm: string, findPath: string) {
 }
 
 function openIFSSearchResults(searchPath: string, searchResults: SearchResults) {
+  const readonly = GlobalConfiguration.get<DefaultOpenMode>("defaultOpenMode") === "browse";
   searchResults.hits =
-    searchResults.hits.map(a => ({ ...a, label: path.posix.relative(searchPath, a.path) }) as SearchHit)
+    searchResults.hits.map(a => ({ ...a, label: path.posix.relative(searchPath, a.path), readonly: readonly }) as SearchHit)
       .sort((a, b) => a.path.localeCompare(b.path));
   vscode.commands.executeCommand(`code-for-ibmi.setSearchResults`, searchResults);
 }

--- a/src/views/searchView.ts
+++ b/src/views/searchView.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import vscode from "vscode";
 import { DefaultOpenMode } from "../api/Configuration";
 import { t } from '../locale';
-import { OpenEditableOptions, SearchHit, SearchHitLine, SearchResults } from "../typings";
+import { SearchHit, SearchHitLine, SearchResults } from "../typings";
 
 export function initializeSearchView(context: vscode.ExtensionContext) {
   const searchView = new SearchView();
@@ -106,18 +106,18 @@ class LineHit extends vscode.TreeItem {
 
     const upperContent = line.content.trim().toUpperCase();
     const upperTerm = term.toUpperCase();
-    const openOptions: OpenEditableOptions = { readonly };
     let index = 0;
 
     // Calculate the highlights
+    let position;
     if (term.length > 0) {
       const positionLine = line.number - 1;
       while (index >= 0) {
         index = upperContent.indexOf(upperTerm, index);
         if (index >= 0) {
           highlights.push([index, index + term.length]);
-          if (!openOptions.position) {
-            openOptions.position = new vscode.Range(positionLine, index, positionLine, index + term.length)
+          if (!position) {
+            position = new vscode.Range(positionLine, index, positionLine, index + term.length)
           }
           index += term.length;
         }
@@ -135,9 +135,9 @@ class LineHit extends vscode.TreeItem {
     this.description = `line ${line.number}`;
 
     this.command = {
-      command: `code-for-ibmi.openEditable`,
+      command: `code-for-ibmi.openWithDefaultMode`,
       title: `Open`,
-      arguments: [this.path, openOptions]
+      arguments: [this, readonly ? "browse" as DefaultOpenMode : undefined, position]
     };
   }
 }

--- a/src/views/searchView.ts
+++ b/src/views/searchView.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import vscode from "vscode";
+import { DefaultOpenMode } from "../api/Configuration";
 import { t } from '../locale';
 import { OpenEditableOptions, SearchHit, SearchHitLine, SearchResults } from "../typings";
 
@@ -68,7 +69,7 @@ class SearchView implements vscode.TreeDataProvider<vscode.TreeItem> {
 }
 
 class HitSource extends vscode.TreeItem {
-  private readonly _path: string;
+  private readonly path: string;
   private readonly _readonly?: boolean;
 
   constructor(readonly term: string, readonly result: SearchHit) {
@@ -77,7 +78,7 @@ class HitSource extends vscode.TreeItem {
 
     this.contextValue = `hitSource`;
     this.iconPath = vscode.ThemeIcon.File;
-    this._path = result.path;
+    this.path = result.path;
     this._readonly = result.readonly;
     this.tooltip = result.path;
 
@@ -87,15 +88,15 @@ class HitSource extends vscode.TreeItem {
     else {
       this.description = result.path;
       this.command = {
-        command: `code-for-ibmi.openEditable`,
+        command: `code-for-ibmi.openWithDefaultMode`,
         title: `Open`,
-        arguments: [this._path, { readonly: result.readonly } as OpenEditableOptions]
+        arguments: [this, this._readonly ? "browse" as DefaultOpenMode : undefined]
       };
     }
   }
 
   async getChildren(): Promise<LineHit[]> {
-    return this.result.lines.map(line => new LineHit(this.term, this._path, line, this._readonly));
+    return this.result.lines.map(line => new LineHit(this.term, this.path, line, this._readonly));
   }
 }
 


### PR DESCRIPTION
### Changes

This PR will add a `readonly` value to IFS search and find results, to honor the default open mode set in the configurations.
When default open mode is `browse`, clicking on a search/find result will open the file in readonly mode.

### How to test this PR

Examples:

1. Set the default open mode to `browse` in the extension configuration
2. Create a search or find result
3. Click on one of the search/find results
4. Confirm the file is opened on readonly mode
5. Change the default open mode to `edit` in the extension configuration
6. Re-run steps 2 and 3
7. Confirm the file is opened in edit mode

### Checklist

* [x] have tested my change
