### PR TITLE
Minor fixes and enhancements to debugger support

### DIFF
--- a/package.json
+++ b/package.json
@@ -939,6 +939,13 @@
 				"icon": "$(file-binary)"
 			},
 			{
+				"command": "code-for-ibmi.debug.redo.setup",
+				"title": "Regenerate Service Certificate",
+				"category": "IBM i Debug",
+				"enablement": "code-for-ibmi:connected && !code-for-ibmi:debugManaged && !code-for-ibmi:debugWorking",
+				"icon": "$(file-binary)"
+			},
+			{
 				"command": "code-for-ibmi.debug.setup.local",
 				"title": "Import Client Certificate",
 				"category": "IBM i Debug",
@@ -2184,6 +2191,10 @@
 					"when": "never"
 				},
 				{
+					"command": "code-for-ibmi.debug.redo.setup",
+					"when": "never"
+				},
+				{
 					"command": "code-for-ibmi.debug.setup.local",
 					"when": "never"
 				},
@@ -2808,14 +2819,19 @@
 					"group": "inline"
 				},
 				{
-					"command": "code-for-ibmi.debug.open.service.config",
-					"when": "!code-for-ibmi:debugManaged && view == ibmiDebugBrowser && viewItem =~ /^debugJob_service.*$/",
-					"group": "inline"
-				},
-				{
 					"command": "code-for-ibmi.debug.setup.remote",
 					"when": "!code-for-ibmi:debugManaged && view == ibmiDebugBrowser && viewItem === certificateIssue_noremote",
 					"group": "inline"
+				},
+				{
+					"command": "code-for-ibmi.debug.open.service.config",
+					"when": "!code-for-ibmi:debugManaged && view == ibmiDebugBrowser && viewItem =~ /^debugJob_service.*$/",
+					"group": "01_debugServiceJob01"
+				},
+				{
+					"command": "code-for-ibmi.debug.redo.setup",
+					"when": "!code-for-ibmi:debugManaged && view == ibmiDebugBrowser && viewItem =~ /^debugJob_service_.*$/",
+					"group": "02_debugServiceJob01"
 				},
 				{
 					"command": "code-for-ibmi.debug.setup.local",

--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -288,7 +288,7 @@ export async function sanityCheck(connection: IBMi, content: IBMiContent) {
       })
     }
   }
-  else {
+  else if ((await connection.checkUserSpecialAuthorities(["*ALLOBJ"])).valid) {
     try {
       if (legacyCertExists && !remoteCertExists) {
         //import legacy

--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -105,6 +105,7 @@ export async function setup(connection: IBMi, imported?: ImportedCertificate) {
     }
 
     let password;
+    const openssl = "/QOpenSys/usr/bin/openssl";
     if (imported) {
       password = imported.password;
       if (imported.localFile) {
@@ -120,8 +121,9 @@ export async function setup(connection: IBMi, imported?: ImportedCertificate) {
       }
 
       setProgress("generating client certificate");
+
       const clientCertificate = await connection.sendCommand({
-        command: `openssl pkcs12 -in ${debugConfig.getRemoteServiceCertificatePath()} -passin pass:${password} -info -nokeys -clcerts 2>/dev/null | openssl x509 -outform PEM`,
+        command: `${openssl} pkcs12 -in ${debugConfig.getRemoteServiceCertificatePath()} -passin pass:${password} -info -nokeys -clcerts 2>/dev/null | openssl x509 -outform PEM`,
       });
       try {
         if (!clientCertificate.code) {
@@ -143,10 +145,10 @@ export async function setup(connection: IBMi, imported?: ImportedCertificate) {
       const extFileContent = await getExtFileContent(hostInfo);
       //This will generate everything at once and keep only the .pfx (keystore) and .crt (client certificate) files.
       const commands = [
-        `openssl genrsa -out debug_service.key 2048`,
-        `openssl req -new -key debug_service.key -out debug_service.csr -subj '/CN=${hostInfo.hostNames[0]}'`,
-        `openssl x509 -req -in debug_service.csr -signkey debug_service.key -out ${CLIENT_CERTIFICATE} -days 1095 -sha256 -req -extfile <(printf "${extFileContent}")`,
-        `openssl pkcs12 -export -out ${SERVICE_CERTIFICATE} -inkey debug_service.key -in ${CLIENT_CERTIFICATE} -password pass:${password}`,
+        `${openssl} genrsa -out debug_service.key 2048`,
+        `${openssl} req -new -key debug_service.key -out debug_service.csr -subj '/CN=${hostInfo.hostNames[0]}'`,
+        `${openssl} x509 -req -in debug_service.csr -signkey debug_service.key -out ${CLIENT_CERTIFICATE} -days 1095 -sha256 -req -extfile <(printf "${extFileContent}")`,
+        `${openssl} pkcs12 -export -out ${SERVICE_CERTIFICATE} -inkey debug_service.key -in ${CLIENT_CERTIFICATE} -password pass:${password}`,
         `rm debug_service.key debug_service.csr`
       ];
 

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -376,7 +376,6 @@ export async function initialize(context: ExtensionContext) {
   // Run during startup:
   instance.onEvent("connected", async () => {
     activateDebugExtension();
-    resetDebugServiceDetails();
     const connection = instance.getConnection();
     const content = instance.getContent();
     if (connection && content && server.debugPTFInstalled()) {
@@ -403,6 +402,7 @@ export async function initialize(context: ExtensionContext) {
   });
 
   instance.onEvent("disconnected", () => {
+    resetDebugServiceDetails();
     vscode.commands.executeCommand(`setContext`, debugContext, false);
     vscode.commands.executeCommand(`setContext`, debugSEPContext, false);
   });

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -487,7 +487,7 @@ export async function startDebug(instance: Instance, options: DebugOptions) {
         "startBatchJobCommand": `SBMJOB CMD(${currentCommand}) INLLIBL(${options.libraries.libraryList.join(` `)}) CURLIB(${options.libraries.currentLibrary}) JOBQ(QSYSNOMAX) MSGQ(*USRPRF) CPYENVVAR(*YES)`,
         "updateProductionFiles": updateProductionFiles,
         "trace": enableDebugTracing,
-      };
+      } as vscode.DebugConfiguration;
 
       const debugResult = await vscode.debug.startDebugging(undefined, debugConfig, undefined);
 

--- a/src/api/debug/server.ts
+++ b/src/api/debug/server.ts
@@ -158,7 +158,7 @@ export function endJobs(jobIds: string[], connection: IBMi) {
 }
 
 export async function isDebugEngineRunning() {
-  return Boolean(await getDebugServerJob()) && Boolean(await getDebugServiceJob());
+  return (await Promise.all([getDebugServerJob(), getDebugServiceJob()])).every(Boolean);
 }
 
 export async function startServer() {

--- a/src/locale/ids/en.json
+++ b/src/locale/ids/en.json
@@ -238,7 +238,7 @@
   "loading.debugger.info": "Loading debugger information...",
   "local.certificate": "Local certificate",
   "local.certificate.not.found": "Local certificate not found",
-  "local.dont.match.remote": "Local certificate doesn\"t match remote",
+  "local.dont.match.remote": "Local certificate doesn't match remote",
   "login.authDecision": "Only provide either the password or a private key - not both.",
   "login.authRemoved": "Authentication methods removed for \"{0}\".",
   "login.host": "Host or IP Address",


### PR DESCRIPTION
### Changes
- Do not perform Sanity Check (i.e. migration of certificate generated prior to v2.9) if current user doesn't have `*ALLOBJ` authority
- Added a `regenerate certificate` action in debug service's right click menu
- Moved `open configuration` action to debug service's right click menu
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/49cdca3b-62b4-4a0b-af34-19e2375001a1)
- Changed the logic of the method checking the debug service job status when it starts. It did not perform well on slow CPU and/or bad connection
- Debug service details cache is now cleared when disconnecting instead of connecting. That clearing could happen after the `IBM i Debugger` view title was loaded when connecting, leading to the wring version being displayed when switching between connections.
- IBM i debugger view loads slightly faster thanks to `Promise.all`
- Added an `Open output` action on the error notification showed when the debug service fails to start. Clicking on it will load the job's QPRINT spooled file that contains the output from the service startup script.
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/d0828f93-d4eb-4395-ab60-1284cadee6d0)
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/f3e69a0a-96a5-41d0-a149-bb36efb4b18d)
- Force usage of `/QOpenSys/usr/bin/openssl` to generate certificates

### How to test this PR
- Connect to an IBM i with debug PTF installed
- Try to regenerate the service certificate
- Try to stop and start the service; the success notification should show up only once
- Restart the debug server and service to ensure the view still loads fine

### Checklist
* [x] have tested my change