### PR TITLE
Add Save password button on password prompt

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -121,7 +121,7 @@ export default class IBMi {
   /**
    * @returns {Promise<{success: boolean, error?: any}>} Was succesful at connecting or not.
    */
-  async connect(connectionObject: ConnectionData, reconnecting?: boolean, reloadServerSettings: boolean = false): Promise<{ success: boolean, error?: any }> {
+  async connect(connectionObject: ConnectionData, reconnecting?: boolean, reloadServerSettings: boolean = false, onConnectedOperations : Function[] = []): Promise<{ success: boolean, error?: any }> {
     return await Tools.withContext("code-for-ibmi:connecting", async () => {
       try {
         connectionObject.keepaliveInterval = 35000;
@@ -135,7 +135,7 @@ export default class IBMi {
           progress.report({
             message: `Connecting via SSH.`
           });
-          const delayedOperations: Function[] = [];
+          const delayedOperations: Function[] = [...onConnectedOperations];
 
           await this.client.connect(connectionObject as node_ssh.Config);
 

--- a/src/locale/ids/fr.json
+++ b/src/locale/ids/fr.json
@@ -246,7 +246,7 @@
   "login.authDecision": "Renseignez soit le mot de passe, soit la clé privée - pas les deux.",
   "login.authRemoved": "Authentification supprimée pour \"{0}\".",
   "login.host": "Nom d'Hôte ou Adresse IP",
-  "login.password.label": "Rensignez un mot de passe seulement si vous souhaitez le changer.",
+  "login.password.label": "Renseignez un mot de passe seulement si vous souhaitez le changer.",
   "login.password.updated": "Mot de passe mis à jour et utilisé pour se connecter à \"{0}\".",
   "login.port": "Port (SSH)",
   "login.privateKey.label": "Sélectionnez une clé privée seulement si vous souhaitez en changer.",

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -89,33 +89,38 @@ export class Login {
               break;
             case `connect`:
               vscode.window.showInformationMessage(`Connecting to ${data.host}.`);
-              const connection = new IBMi();
+              const toDoOnConnected: Function[] = [];
+              if (!data.password && !data.privateKeyPath && await promptPassword(context, data)) {
+                toDoOnConnected.push(() => ConnectionManager.setStoredPassword(context, data.name, data.password!));
+              }
 
-              try {
-                const connected = await connection.connect(data);
-                if (connected.success) {
-                  if (newConnection) {
-                    vscode.window.showInformationMessage(`Connected to ${data.host}! Would you like to configure this connection?`, `Open configuration`).then(async (selectionA) => {
-                      if (selectionA === `Open configuration`) {
-                        vscode.commands.executeCommand(`code-for-ibmi.showAdditionalSettings`);
+              if (data.password || data.privateKeyPath) {
+                try {
+                  const connected = await new IBMi().connect(data, false, false, toDoOnConnected);
+                  if (connected.success) {
+                    if (newConnection) {
+                      vscode.window.showInformationMessage(`Connected to ${data.host}! Would you like to configure this connection?`, `Open configuration`).then(async (selectionA) => {
+                        if (selectionA === `Open configuration`) {
+                          vscode.commands.executeCommand(`code-for-ibmi.showAdditionalSettings`);
 
-                      } else {
-                        vscode.window.showInformationMessage(`Source dates are disabled by default. Enable them in the connection settings.`, `Open configuration`).then(async (selectionB) => {
-                          if (selectionB === `Open configuration`) {
-                            vscode.commands.executeCommand(`code-for-ibmi.showAdditionalSettings`, undefined, `Source Code`);
-                          }
-                        });
-                      }
-                    });
+                        } else {
+                          vscode.window.showInformationMessage(`Source dates are disabled by default. Enable them in the connection settings.`, `Open configuration`).then(async (selectionB) => {
+                            if (selectionB === `Open configuration`) {
+                              vscode.commands.executeCommand(`code-for-ibmi.showAdditionalSettings`, undefined, `Source Code`);
+                            }
+                          });
+                        }
+                      });
+                    } else {
+                      vscode.window.showInformationMessage(`Connected to ${data.host}!`);
+                    }
+
                   } else {
-                    vscode.window.showInformationMessage(`Connected to ${data.host}!`);
+                    vscode.window.showErrorMessage(`Not connected to ${data.host}! ${connected.error.message || connected.error}`);
                   }
-
-                } else {
-                  vscode.window.showErrorMessage(`Not connected to ${data.host}! ${connected.error.message || connected.error}`);
+                } catch (e) {
+                  vscode.window.showErrorMessage(`Error connecting to ${data.host}! ${e}`);
                 }
-              } catch (e) {
-                vscode.window.showErrorMessage(`Error connecting to ${data.host}! ${e}`);
               }
               break;
           }
@@ -156,27 +161,9 @@ export class Login {
         // Assume connection with a password, but prompt if we don't have one        
         connectionConfig.password = await ConnectionManager.getStoredPassword(context, connectionConfig.name);
         if (!connectionConfig.password) {
-          const savePasswordLabel = "Save password and connect"
-          const passwordBox = vscode.window.createInputBox();
-          passwordBox.prompt = `Password for ${connectionConfig.name}`;
-          passwordBox.password = true;
-          passwordBox.buttons = [{
-            iconPath: new ThemeIcon("save"),
-            tooltip: savePasswordLabel
-          }];        
-
-          const onClose = (button?: vscode.QuickInputButton | void) => {
-            if (button?.tooltip === savePasswordLabel) {
-              toDoOnConnected.push(() => ConnectionManager.setStoredPassword(context, connectionConfig.name, connectionConfig.password!));
-            }
-            connectionConfig.password = passwordBox.value;
-            passwordBox.dispose();
-          };
-          passwordBox.onDidTriggerButton(onClose);
-          passwordBox.onDidAccept(onClose);
-          
-          passwordBox.show();
-          await new Promise(resolve => passwordBox.onDidHide(resolve));
+          if (await promptPassword(context, connectionConfig)) {
+            toDoOnConnected.push(() => ConnectionManager.setStoredPassword(context, connectionConfig.name, connectionConfig.password!));
+          }
         }
 
         if (!connectionConfig.password) {
@@ -201,4 +188,30 @@ export class Login {
     return false;
   }
 
+}
+
+async function promptPassword(context: vscode.ExtensionContext, connection: ConnectionData) {
+  let savePassword = false;
+  const savePasswordLabel = "Save password and connect"
+  const passwordBox = vscode.window.createInputBox();
+  passwordBox.prompt = `Password for ${connection.name}`;
+  passwordBox.password = true;
+  passwordBox.buttons = [{
+    iconPath: new ThemeIcon("save"),
+    tooltip: savePasswordLabel
+  }];
+
+  const onClose = (button?: vscode.QuickInputButton | void) => {
+    if (button?.tooltip === savePasswordLabel) {
+      savePassword = true;
+    }
+    connection.password = passwordBox.value;
+    passwordBox.dispose();
+  };
+  passwordBox.onDidTriggerButton(onClose);
+  passwordBox.onDidAccept(onClose);
+
+  passwordBox.show();
+  await new Promise(resolve => passwordBox.onDidHide(resolve));
+  return savePassword;
 }


### PR DESCRIPTION
### Changes
This PR adds a `Save password and connect` button on the password prompt shown when connecting to a system whose password is not stored.
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/5f6cbc39-d246-4154-9a7a-e6d54e367aed)

When clicked, the password will be stored only if the connection is successful.

### How to test this PR
1. Connect to a system whose password is not stored
2. Enter the password, press enter to connect
3. Disconnect
4. Connect again: the password prompt must show up again
5. Press `ESC`
6. Connect again: the password prompt must show up again
7. Enter the password and click on `Save password and connect`
8. Disconnect
9. Connect again: the password prompt must not show up

### Checklist
* [x] have tested my change