### PR TITLE
Always debug securely

### DIFF
--- a/package.json
+++ b/package.json
@@ -369,11 +369,6 @@
 								"default": "8008",
 								"description": "Port to connect to IBM i Debug Service for SEP."
 							},
-							"debugIsSecure": {
-								"type": "boolean",
-								"default": true,
-								"description": "Used to determine if the client should connect securely or not."
-							},
 							"debugUpdateProductionFiles": {
 								"type": "boolean",
 								"default": false,

--- a/src/api/Configuration.ts
+++ b/src/api/Configuration.ts
@@ -126,7 +126,6 @@ export namespace ConnectionConfiguration {
     showDescInLibList: boolean;
     debugPort: string;
     debugSepPort: string;
-    debugIsSecure: boolean;
     debugUpdateProductionFiles: boolean;
     debugEnableDebugTracing: boolean;
     readOnlyMode: boolean;
@@ -207,7 +206,6 @@ export namespace ConnectionConfiguration {
       showDescInLibList: (parameters.showDescInLibList === true),
       debugPort: (parameters.debugPort || "8005"),
       debugSepPort: (parameters.debugSepPort || "8008"),
-      debugIsSecure: (parameters.debugIsSecure === true),
       debugUpdateProductionFiles: (parameters.debugUpdateProductionFiles === true),
       debugEnableDebugTracing: (parameters.debugEnableDebugTracing === true),
       readOnlyMode: (parameters.readOnlyMode === true),

--- a/src/views/debugView.ts
+++ b/src/views/debugView.ts
@@ -9,7 +9,6 @@ import { BrowserItem } from "../typings";
 
 const title = "IBM i debugger";
 type Certificates = {
-  secureDebug: boolean
   remoteCertificate: boolean
   remoteCertificatePath?: string
   localCertificateIssue?: string
@@ -76,12 +75,11 @@ class DebugBrowser implements vscode.TreeDataProvider<BrowserItem> {
     if (connection) {
       const debugConfig = await new DebugConfiguration().load();
       const certificates: Certificates = {
-        secureDebug: connection.config?.debugIsSecure || false,
         remoteCertificate: await remoteCertificatesExists(debugConfig),
         remoteCertificatePath: debugConfig.getRemoteServiceCertificatePath()
       };
 
-      if (certificates.remoteCertificate && certificates.secureDebug) {
+      if (certificates.remoteCertificate) {
         try {
           await checkClientCertificate(connection, debugConfig);
         }
@@ -158,7 +156,7 @@ class DebugJobItem extends DebugItem {
           detail: t('remote.certificate.not.found.detail', "debug_service.pfx", certificates.remoteCertificatePath)
         }
       }
-      else if (certificates.secureDebug && certificates.localCertificateIssue) {
+      else if (certificates.localCertificateIssue) {
         problem = {
           context: "localissue",
           label: certificates.localCertificateIssue

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -189,19 +189,17 @@ export class SettingsUI {
             .addCheckbox(`debugEnableDebugTracing`, `Debug trace`, `Tells the debug service to send more data to the client. Only useful for debugging issues in the service. Not recommended for general debugging.`, config.debugEnableDebugTracing);
 
           if (!isManaged()) {
-            debuggerTab
-              .addHorizontalRule()
-              .addCheckbox(`debugIsSecure`, `Debug securely`, `Tells the debug service to authenticate by server and client certificates. Ensure that the client certificate is imported when enabled.`, config.debugIsSecure);
+            debuggerTab.addHorizontalRule();
             if (await certificates.remoteCertificatesExists()) {
               let localCertificateIssue;
               try {
                 await certificates.checkClientCertificate(connection);
               }
               catch (error) {
-                localCertificateIssue = `${String(error)}. Debugging securely will not function correctly.`;
+                localCertificateIssue = `${String(error)}. Debugging will not function correctly.`;
               }
               debuggerTab.addParagraph(`<b>${localCertificateIssue || "Client certificate for service has been imported and matches remote certificate."}</b>`)
-                .addParagraph(`To debug securely, Visual Studio Code needs access to a certificate to connect to the Debug Service. Each server can have unique certificates. This client certificate should exist at <code>${certificates.getLocalCertPath(connection)}</code>`);
+                .addParagraph(`To debug on IBM i, Visual Studio Code needs to load a client certificate to connect to the Debug Service. Each server has a unique certificate. This client certificate should exist at <code>${certificates.getLocalCertPath(connection)}</code>`);
               if (!localCertificateIssue) {
                 debuggerTab.addButtons({ id: `import`, label: `Download client certificate` })
               }


### PR DESCRIPTION
### Changes
This PR removes the `debugIsSecure` parameter from the connection settings.
Since the Service Entry Points requires a client certificate, there is no point in keeping the option to turn off secure debugging.

If the client certificate is not found locally or if there is a mismatch, the `IBM i Debugger` view will offer to download and update it locally.

A notification is shown in the status bar when the client certificate is being downloaded.

### How to test this PR
1. Connect
2. Go to the `IBM i Debugger` view
3. Check if the client certificate needs to be downloaded and click on the action to download it
4. Try debugging

### Checklist
* [x] have tested my change