### PR TITLE
Added settings to open PASE/5250 terminals in editor area

### DIFF
--- a/package.json
+++ b/package.json
@@ -530,6 +530,16 @@
 					"default": true,
 					"description": "If enabled, will show the 'Date search' button in the status bar when source dates with diff mode is enabled."
 				},
+				"code-for-ibmi.terminals.5250.openInEditorArea": {
+					"type": "boolean",
+					"default": true,
+					"description": "If enabled, 5250 terminals will open in the editor area as tabs instead of panels."
+				},
+				"code-for-ibmi.terminals.pase.openInEditorArea": {
+					"type": "boolean",
+					"default": false,
+					"description": "If enabled, PASE terminals will open in the editor area as tabs instead of panels."
+				},
 				"code-for-ibmi.connections": {
 					"type": "array",
 					"items": {

--- a/src/api/Terminal.ts
+++ b/src/api/Terminal.ts
@@ -1,9 +1,10 @@
 
-import vscode, { commands, window } from 'vscode';
+import path from 'path';
+import vscode, { commands } from 'vscode';
 import { instance } from '../instantiate';
+import { GlobalConfiguration } from './Configuration';
 import IBMi from './IBMi';
 import Instance from './Instance';
-import path from 'path';
 
 function getOrDefaultToUndefined(value: string) {
   if (value && value !== `default`) {
@@ -26,6 +27,7 @@ export namespace Terminal {
 
   interface TerminalSettings {
     type: TerminalType
+    location: vscode.TerminalLocation
     encoding?: string
     terminal?: string
     name?: string
@@ -46,7 +48,7 @@ export namespace Terminal {
       vscode.commands.registerCommand(`code-for-ibmi.launchTerminalPicker`, () => {
         return selectAndOpen(instance);
       }),
-  
+
       vscode.commands.registerCommand(`code-for-ibmi.openTerminalHere`, async (ifsNode) => {
         const content = instance.getContent();
         if (content) {
@@ -77,6 +79,7 @@ export namespace Terminal {
       if (type) {
         const terminalSettings: TerminalSettings = {
           type,
+          location: GlobalConfiguration.get<boolean>(`terminals.${type.toLowerCase()}.openInEditorArea`) ? vscode.TerminalLocation.Editor : vscode.TerminalLocation.Panel,
           connectionString: configuration.connectringStringFor5250
         };
 
@@ -125,7 +128,7 @@ export namespace Terminal {
 
     const emulatorTerminal = vscode.window.createTerminal({
       name: `IBM i ${terminalSettings.type}`,
-      
+      location: terminalSettings.location,
       pty: {
         onDidWrite: writeEmitter.event,
         open: () => { },

--- a/src/api/Terminal.ts
+++ b/src/api/Terminal.ts
@@ -127,7 +127,7 @@ export namespace Terminal {
     });
 
     const emulatorTerminal = vscode.window.createTerminal({
-      name: `IBM i ${terminalSettings.type}`,
+      name: `IBM i ${terminalSettings.type}: ${connection.config?.name}`,
       location: terminalSettings.location,
       pty: {
         onDidWrite: writeEmitter.event,


### PR DESCRIPTION
### Changes
This PR adds two global settings to enable opening PASE and 5250 terminals in the editor area.
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/9bb963b6-7b1e-4229-9059-5e9ffd0df908)

Opening 5250 Terminal in editor area is enabled by default, since it requires more height than PASE.
![image](https://github.com/codefori/vscode-ibmi/assets/11096890/53163315-4842-4fa3-aea5-17e3a32e338b)

The name of the connection for which the terminal is opened has also been added to the terminal title.


### How to test this PR
1. Connect
2. Open a 5250 terminal: it must open in the editor area
3. Open a PASE terminal: it must open in the panel area
4. Change the global settings to change the terminals location
5. Open PASE and 5250 again to see the change in effect

### Checklist
* [x] have tested my change