### PR TITLE
Compile non-IFS sources from local

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -225,7 +225,7 @@ export namespace CompileTools {
               evfeventInfo.object = name.toUpperCase();
               evfeventInfo.extension = ext;
 
-              if (chosenAction.command.includes(`SRCFILE`)) {
+              if (chosenAction.command.includes(`&SRCFILE`)) {
                 variables[`&SRCLIB`] = evfeventInfo.library;
                 variables[`&SRCPF`] = `QTMPSRC`;
                 variables[`&SRCFILE`] =  `${evfeventInfo.library}/QTMPSRC`;
@@ -341,13 +341,12 @@ export namespace CompileTools {
 
                         const createSourceFile = content.toCl(`CRTSRCPF`, {
                           rcdlen: 112, //NICE: this configurable in a VS Code setting?
-                          file: srcpf,
-                          lib,
+                          file: `${lib}/${srcpf}`,
                         });
 
                         const copyFromStreamfile = content.toCl(`CPYFRMSTMF`, {
                           fromstmf: variables[`&FULLPATH`],
-                          tombr: Tools.qualifyPath(lib, srcpf, evfeventInfo.object),
+                          tombr: `'${Tools.qualifyPath(lib, srcpf, evfeventInfo.object)}'`,
                           mbropt: `*REPLACE`,
                           dbfccsid: `*FILE`,
                           stmfccsid: 1208,
@@ -356,6 +355,7 @@ export namespace CompileTools {
                         // We don't care if this fails. Usually it's because the source file already exists.
                         await runCommand(instance, {command: createSourceFile, environment: `ile`, noLibList: true});
 
+                        // Attempt to copy to member
                         const copyResult = await runCommand(instance, {command: copyFromStreamfile, environment: `ile`, noLibList: true});
 
                         if (copyResult.code !== 0) {

--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -225,6 +225,11 @@ export namespace CompileTools {
               evfeventInfo.object = name.toUpperCase();
               evfeventInfo.extension = ext;
 
+              if (chosenAction.command.includes(`SRCFILE`)) {
+                variables[`&SRCLIB`] = evfeventInfo.library;
+                variables[`&SRCPF`] = `QTMPSRC`;
+                variables[`&SRCFILE`] =  `${evfeventInfo.library}/QTMPSRC`;
+              }
 
               switch (chosenAction.type) {
                 case `file`:
@@ -329,6 +334,35 @@ export namespace CompileTools {
 
                     try {
                       writeEmitter.fire(`Running Action: ${chosenAction.name} (${new Date().toLocaleTimeString()})` + NEWLINE);
+
+                      // If &SRCFILE is set, we need to copy the file to a temporary source file from the IFS
+                      if (variables[`&FULLPATH`] && variables[`&SRCFILE`] && evfeventInfo.object) {
+                        const [lib, srcpf] = variables[`&SRCFILE`].split(`/`);
+
+                        const createSourceFile = content.toCl(`CRTSRCPF`, {
+                          rcdlen: 112, //NICE: this configurable in a VS Code setting?
+                          file: srcpf,
+                          lib,
+                        });
+
+                        const copyFromStreamfile = content.toCl(`CPYFRMSTMF`, {
+                          fromstmf: variables[`&FULLPATH`],
+                          tombr: Tools.qualifyPath(lib, srcpf, evfeventInfo.object),
+                          mbropt: `*REPLACE`,
+                          dbfccsid: `*FILE`,
+                          stmfccsid: 1208,
+                        });
+ 
+                        // We don't care if this fails. Usually it's because the source file already exists.
+                        await runCommand(instance, {command: createSourceFile, environment: `ile`, noLibList: true});
+
+                        const copyResult = await runCommand(instance, {command: copyFromStreamfile, environment: `ile`, noLibList: true});
+
+                        if (copyResult.code !== 0) {
+                          writeEmitter.fire(`Failed to copy file to a temporary member.\n\t${copyResult.stderr}\n\n`);
+                          closeEmitter.fire(copyResult.code || 1);
+                        }
+                      }
 
                       const commandResult = await runCommand(instance, {
                         title: chosenAction.name,

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -1046,7 +1046,10 @@ export default class IBMi {
 
     this.appendOutput(JSON.stringify(result, null, 4) + `\n\n`);
 
-    return result;
+    return {
+      ...result,
+      code: result.code || 0,
+    };
   }
 
   private appendOutput(content: string) {

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -310,6 +310,11 @@ export namespace Tools {
     return possibleDoc;
   }
 
+  export function findExistingDocumentByName(nameAndExt: string) {
+    const possibleDoc = vscode.workspace.textDocuments.find(document => document.fileName.toLowerCase().endsWith(nameAndExt.toLowerCase()));
+    return possibleDoc ? possibleDoc.uri : undefined;
+  }
+
   /**
    * We convert member to lowercase as members are case insensitive.
    */

--- a/src/api/errors/diagnostics.ts
+++ b/src/api/errors/diagnostics.ts
@@ -169,6 +169,18 @@ export function handleEvfeventLines(lines: string[], instance: Instance, evfeven
             }
             continue;
           }
+
+          // If we get there, that means that even though we compiled from local, we likely had to use a temp member.
+          // We should try to find the file in the workspace. Since we can use findFile (it's async), then we look for open
+          // tabs like we do below.
+          if (evfeventInfo.extension) {
+            const baseName = file.split(`/`).pop();
+            const openFile = Tools.findExistingDocumentByName(`${baseName}.${evfeventInfo.extension}`);
+            if (openFile) {
+              ileDiagnostics.set(openFile, diagnostics);
+              continue;
+            }
+          }
         }
       }
 

--- a/src/api/local/LocalLanguageActions.ts
+++ b/src/api/local/LocalLanguageActions.ts
@@ -129,6 +129,17 @@ export const LocalLanguageActions: Record<string, Action[]> = {
       environment: `ile`,
     }
   ],
+  DSPF: [
+    {
+      "name": "Create DSPF",
+      "command": "CRTDSPF FILE(&CURLIB/&NAME) SRCFILE(&SRCFILE) RSTDSP(*NO) OPTION(*EVENTF)",
+      "environment": "ile",
+      "deployFirst": true,
+      "extensions": [
+        "dspf"
+      ]
+    }
+  ],
   "Service Programs": [
     {
       "extensions": [

--- a/src/testing/action.ts
+++ b/src/testing/action.ts
@@ -16,7 +16,15 @@ export const helloWorldProject: Folder = {
   name: `DeleteMe_${Tools.makeid()}`,
   files: [
     new File("hello.pgm.rpgle", ['**free', 'dsply \'Hello World\';', 'return;']),
-    new File("thebadone.pgm.rpgle", ['**free', 'dsply Hello world;', 'return;'])
+    new File("thebadone.pgm.rpgle", ['**free', 'dsply Hello world;', 'return;']),
+    new File("ugly.dspf", [
+      `     A                                      INDARA`,
+      `     A                                      CA12(12)`,
+      `     A          R DETAIL                    `,
+      `     A                                  6 10'ID'`,
+      `     A                                      DSPATR(HI)`,
+      `     A                                      DSPATR(UL)`,
+    ])
   ],
 }
 
@@ -70,6 +78,21 @@ export const ActionSuite: TestSuite = {
         action.deployFirst = false;
         const uri = helloWorldProject.files![0].localPath!;
         await testHelloWorldProgram(uri, action, currentLibrary);
+      }
+    },
+    {
+      name: `Create display file (from local, custom action)`, test: async () => {
+        const uri = helloWorldProject.files![2].localPath!;
+        const action: Action = {
+          command: `CRTDSPF FILE(&CURLIB/&NAME) SRCFILE(&SRCFILE) TEXT('DSPF from local')`,
+          environment: `ile`,
+          type: `file`,
+          name: `Create Display File (CRTDSPF)`,
+        };
+
+        const success = await CompileTools.runAction(instance, uri, action, `all`);
+        console.log(success);
+        assert.ok(success);
       }
     },
     {

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -57,7 +57,7 @@ export interface CommandData extends StandardIO {
 }
 
 export interface CommandResult {
-  code: number | null;
+  code: number;
   stdout: string;
   stderr: string;
   command?: string;


### PR DESCRIPTION
### Changes

Enables local actions to compile sources from source members. This enables the ability to use `CRTDSPF`, `CRTPF`, `CRTLF`, etc, on local workspace sources.

### How to test this PR

Examples:

1. Create a valid display file
2. Create an action in `actions.json` for `CRTDSPF`
3. Use the Action runner to use the newly action
4. Put an intential error in the display file
5. Run the action again and expect problems to appear

Also, run the test cases for Actions.

### Nice to have

* New option in the Actions setup quickpick ✅
* Update the documentation on Actions
* Ability to define record length and CCSID of temp source file

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)