### PR TITLE
Fix and test case for supporting members with dollar signs

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -149,7 +149,7 @@ export default class IBMiContent {
     member = this.ibmi.upperCaseName(member);
 
     let retry = false;
-    let path = Tools.qualifyPath(library, sourceFile, member, asp);
+    let path = Tools.qualifyPath(library, sourceFile, member, asp, true);
     const tempRmt = this.getTempRemote(path);
     while (true) {
       let copyResult: CommandResult;
@@ -222,7 +222,7 @@ export default class IBMiContent {
     let retry = false;
     try {
       await writeFileAsync(tmpobj, content, `utf8`);
-      let path = Tools.qualifyPath(library, sourceFile, member, asp);
+      let path = Tools.qualifyPath(library, sourceFile, member, asp, true);
       const tempRmt = this.getTempRemote(path);
       await client.putFile(tmpobj, tempRmt);
 
@@ -261,7 +261,6 @@ export default class IBMiContent {
               //The member may be located on SYSBAS
               if (asp) {
                 path = Tools.qualifyPath(library, sourceFile, member);
-                retry = true;
               }
             }
             else {

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -261,6 +261,7 @@ export default class IBMiContent {
               //The member may be located on SYSBAS
               if (asp) {
                 path = Tools.qualifyPath(library, sourceFile, member);
+                retry = false;
               }
             }
             else {

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -261,7 +261,7 @@ export default class IBMiContent {
               //The member may be located on SYSBAS
               if (asp) {
                 path = Tools.qualifyPath(library, sourceFile, member);
-                retry = false;
+                retry = true;
               }
             }
             else {

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -172,13 +172,13 @@ export namespace Tools {
    * @param member Optional
    * @param iasp Optional: an iASP name
    */
-  export function qualifyPath(library: string, object: string, member?: string, iasp?: string, sanitise?: boolean) {
+  export function qualifyPath(library: string, object: string, member?: string, iasp?: string, noEscape?: boolean) {
     const libraryPath = library === `QSYS` ? `QSYS.LIB` : `QSYS.LIB/${Tools.sanitizeLibraryNames([library]).join(``)}.LIB`;
     const filePath = `${object}.FILE`;
     const memberPath = member ? `/${member}.MBR` : '';
     const subPath = `${filePath}${memberPath}`;
 
-    const result = (iasp && iasp.length > 0 ? `/${iasp}` : ``) + `/${libraryPath}/${sanitise ? subPath : Tools.escapePath(subPath)}`;
+    const result = (iasp && iasp.length > 0 ? `/${iasp}` : ``) + `/${libraryPath}/${noEscape ? subPath : Tools.escapePath(subPath)}`;
     return result;
   }
 

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -250,6 +250,35 @@ export const ContentSuite: TestSuite = {
     },
 
     {
+      name: `Test downloadMemberContent with dollar`, test: async () => {
+        const content = instance.getContent();
+        const config = instance.getConfig();
+        const connection = instance.getConnection();
+        const tempLib = config!.tempLibrary,
+          tempSPF = `TESTINGS`,
+          tempMbr = Tools.makeid(2) + `$` + Tools.makeid(2);
+
+        await connection!.runCommand({
+          command: `CRTSRCPF ${tempLib}/${tempSPF} MBR(*NONE)`,
+          environment: `ile`
+        });
+
+        await connection!.runCommand({
+          command: `ADDPFM FILE(${tempLib}/${tempSPF}) MBR(${tempMbr}) `,
+          environment: `ile`
+        });
+
+        const baseContent = `Hello world\r\n`;
+
+        const uploadResult = await content?.uploadMemberContent(undefined, tempLib, tempSPF, tempMbr, baseContent);
+        assert.ok(uploadResult);
+
+        const memberContent = await content?.downloadMemberContent(undefined, tempLib, tempSPF, tempMbr);
+        assert.strictEqual(memberContent, baseContent);
+      },
+    },
+
+    {
       name: `Test runSQL (basic select)`, test: async () => {
         const content = instance.getContent();
 


### PR DESCRIPTION
### Changes

Fixes #2177 by not escaping at the right time.

* A new test case with members with dollar signs in the name has been added
* Renamed `sanitise` to `noEscape` to make more sense based on the existing code logic

### How to test this PR

Examples:

1. Run the test cases
2. Try creating and editing a member with a dollar sign

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)