### PR TITLE
Fix `Search Source File` crashing when used with a complex filter

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -86,6 +86,7 @@ export default class IBMi {
 
   commandsExecuted = 0;
 
+  //Maximum admited length for command's argument - any command whose arguments are longer than this won't be executed by the shell
   maximumArgsLength = 0;
 
   dangerousVariants = false;
@@ -913,8 +914,8 @@ export default class IBMi {
           }
 
           if ((!quickConnect || !cachedServerSettings?.maximumArgsLength)) {
-            //Compute the maximum length of arguments. Source: Googling and https://www.in-ulm.de/~mascheck/various/argmax/#effectively_usable
-            this.maximumArgsLength = Number((await this.sendCommand({ command: "expr `getconf ARG_MAX` - `env|wc -c` - `env|wc -l` \\* 4 - 2048" })).stdout);
+            //Compute the maximum admited length of a command's arguments. Source: Googling and https://www.in-ulm.de/~mascheck/various/argmax/#effectively_usable
+            this.maximumArgsLength = Number((await this.sendCommand({ command: "/QOpenSys/usr/bin/expr `/QOpenSys/usr/bin/getconf ARG_MAX` - `env|wc -c` - `env|wc -l` \\* 4 - 2048" })).stdout);
           }
           else{
             this.maximumArgsLength = cachedServerSettings.maximumArgsLength;

--- a/src/api/Search.ts
+++ b/src/api/Search.ts
@@ -136,7 +136,7 @@ export namespace Search {
   function parseGrepOutput(output: string, readonly?: boolean, pathTransformer?: (path: string) => string): SearchHit[] {
     const results: SearchHit[] = [];
     for (const line of output.split('\n')) {
-      if (!line.startsWith(`Binary`)) {
+      if (line && !line.startsWith(`Binary`)) {
         const parts = line.split(`:`); //path:line
         const path = pathTransformer?.(parts[0]) || parts[0];
         let result = results.find(r => r.path === path);

--- a/src/api/Search.ts
+++ b/src/api/Search.ts
@@ -1,18 +1,29 @@
 
-import { SearchHit, SearchResults } from '../typings';
+import { IBMiMember, SearchHit, SearchResults } from '../typings';
 import { GlobalConfiguration } from './Configuration';
 import Instance from './Instance';
 import { Tools } from './Tools';
 
 export namespace Search {
-  const QSYS_PATTERN = /(?:\/\w{1,10}\/QSYS\.LIB\/)|(?:\/QSYS\.LIB\/)|(?:\.LIB)|(?:\.FILE)|(?:\.MBR)/g;
-
-  export async function searchMembers(instance: Instance, library: string, sourceFile: string, memberFilter: string, searchTerm: string, readOnly?: boolean): Promise<SearchResults> {
+  export async function searchMembers(instance: Instance, library: string, sourceFile: string, searchTerm: string, members: IBMiMember[] | string, readOnly?: boolean,): Promise<SearchResults> {
     const connection = instance.getConnection();
     const config = instance.getConfig();
     const content = instance.getContent();
 
     if (connection && config && content) {
+      let memberFilter = connection.sysNameInAmerican(typeof members === 'string' ? `${members}.MBR` : members.map(member => `${member.name}.MBR`).join(" "));
+
+      let postSearchFilter = (hit: SearchHit) => true;
+      if (Array.isArray(members) && memberFilter.length > connection.maximumArgsLength) {
+        //Failsafe: when searching on a complex filter, the member list may exceed the maximum admited arguments length (which is around 4.180.000 characters, roughly 298500 members),
+        //          in this case, we fall back to a global search and manually filter the results afterwards/
+        memberFilter = "*.MBR";
+        postSearchFilter = (hit) => {
+          const memberName = hit.path.split("/").at(-1);
+          return members.find(member => member.name === memberName) !== undefined;
+        }
+      }
+
       let asp = ``;
       if (config.sourceASP) {
         asp = `/${config.sourceASP}`;
@@ -27,14 +38,16 @@ export namespace Search {
       }
 
       const result = await connection.sendQsh({
-        command: `/usr/bin/grep -inHR -F "${sanitizeSearchTerm(searchTerm)}" ${asp}/QSYS.LIB/${connection.sysNameInAmerican(library)}.LIB/${connection.sysNameInAmerican(sourceFile)}.FILE/${memberFilter ? connection.sysNameInAmerican(memberFilter) : `*`}`,
+        command: `/usr/bin/grep -inHR -F "${sanitizeSearchTerm(searchTerm)}" ${memberFilter}`,
+        directory: connection.sysNameInAmerican(`${asp}/QSYS.LIB/${library}.LIB/${sourceFile}.FILE`)
       });
 
       if (!result.stderr) {
         return {
           term: searchTerm,
-          hits: parseGrepOutput(result.stdout || '', readOnly,
-            path => connection.sysNameInLocal(path.replace(QSYS_PATTERN, ''))) //Transform QSYS path to URI 'member:' compatible path
+          hits: (parseGrepOutput(result.stdout || '', readOnly || content.isProtectedPath(library),
+            path => connection.sysNameInLocal(`${library}/${sourceFile}/${path.replace(/\.MBR$/, '')}`)))
+            .filter(postSearchFilter)
         }
       }
       else {

--- a/src/api/Storage.ts
+++ b/src/api/Storage.ts
@@ -63,6 +63,7 @@ export type CachedServerSettings = {
   pathChecked?: boolean
   userDefaultCCSID: number | null
   debugConfigLoaded: boolean
+  maximumArgsLength: number
 } | undefined;
 
 export class GlobalStorage extends Storage {

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -9,6 +9,7 @@ import { DeployToolsSuite } from "./deployTools";
 import { EncodingSuite } from "./encoding";
 import { FilterSuite } from "./filter";
 import { ILEErrorSuite } from "./ileErrors";
+import { SearchSuite } from "./search";
 import { StorageSuite } from "./storage";
 import { TestSuitesTreeProvider } from "./testCasesTree";
 import { ToolsSuite } from "./tools";
@@ -21,6 +22,7 @@ const suites: TestSuite[] = [
   ToolsSuite,
   ILEErrorSuite,
   FilterSuite,
+  SearchSuite,
   StorageSuite,
   EncodingSuite,
   ComponentSuite

--- a/src/testing/search.ts
+++ b/src/testing/search.ts
@@ -1,0 +1,61 @@
+import assert from "assert";
+import { TestSuite } from ".";
+import { parseFilter } from "../api/Filter";
+import { Search } from "../api/Search";
+import { instance } from "../instantiate";
+
+export const SearchSuite: TestSuite = {
+  name: `Search API tests`,
+  tests: [
+    {
+      name: "Single member search", test: async () => {
+        const result = await Search.searchMembers(instance, "QSYSINC", "QRPGLESRC", "IBM", "CMRPG");
+        assert.strictEqual(result.term, "IBM");
+        assert.strictEqual(result.hits.length, 1);
+        const [hit] = result.hits;
+        assert.strictEqual(hit.lines.length, 3);
+
+        const checkLine = (index: number, expectedNumber: number) => {
+          assert.strictEqual(hit.lines[index].number, expectedNumber);
+          assert.ok(hit.lines[index].content.includes(result.term));
+        }
+
+        checkLine(0, 7);
+        checkLine(1, 11);
+        checkLine(2, 13);
+      }
+    },
+    {
+      name: "Generic name search", test: async () => {
+        const memberFilter = "E*";
+        const filter = parseFilter(memberFilter);
+        const result = await Search.searchMembers(instance, "QSYSINC", "QRPGLESRC", "IBM", memberFilter);
+        assert.ok(result.hits.every(hit => filter.test(hit.path.split("/").at(-1)!)));
+      }
+    },
+    {
+      name: "Filtered members list search", test: async () => {
+        const library = "QSYSINC";
+        const sourceFile = "QRPGLESRC";
+        const memberFilter = "S*,T*";
+        const filter = parseFilter(memberFilter);
+        const checkNames = (names: string[]) => names.every(filter.test);
+
+        const members = await getConnection().content.getMemberList({ library, sourceFile, members: memberFilter });
+        checkNames(members.map(member => member.name));
+
+        const result = await Search.searchMembers(instance, "QSYSINC", "QRPGLESRC", "SQL", members);
+        assert.strictEqual(result.hits.length, 6);
+        checkNames(result.hits.map(hit => hit.path.split("/").at(-1)!));
+      }
+    }
+  ]
+}
+
+function getConnection() {
+  const connection = instance.getConnection();
+  if (!connection) {
+    throw Error("Cannot run test: no connection")
+  }
+  return connection;
+}

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -1355,11 +1355,13 @@ async function doSearchInSourceFile(searchTerm: string, path: string, filter?: C
         extensions: filter?.memberType,
         filterType: filter?.filterType
       });
+
       if (members.length > 0) {
+        progress.report({ message: t(`objectBrowser.doSearchInSourceFile.searchMessage1`, searchTerm, path) });
+
         // NOTE: if more messages are added, lower the timeout interval
         const timeoutInternal = 9000;
         const searchMessages = [
-          t(`objectBrowser.doSearchInSourceFile.searchMessage1`, searchTerm, path),
           t(`objectBrowser.doSearchInSourceFile.searchMessage2`, members.length, searchTerm, path),
           t(`objectBrowser.doSearchInSourceFile.searchMessage3`, searchTerm),
           t(`objectBrowser.doSearchInSourceFile.searchMessage4`, searchTerm, path),

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -1393,6 +1393,7 @@ async function doSearchInSourceFile(searchTerm: string, path: string, filter?: C
         }
 
         const results = await Search.searchMembers(instance, library, sourceFile, searchTerm, memberFilter, filter?.protected);
+        clearInterval(messageTimeout)
         if (results.hits.length) {
           const objectNamesLower = GlobalConfiguration.get(`ObjectBrowser.showNamesInLowercase`);
 

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -3,7 +3,7 @@ import os from "os";
 import path, { basename, dirname } from "path";
 import vscode from "vscode";
 import { ConnectionConfiguration, DefaultOpenMode, GlobalConfiguration } from "../api/Configuration";
-import { parseFilter } from "../api/Filter";
+import { parseFilter, singleGenericName } from "../api/Filter";
 import { MemberParts } from "../api/IBMi";
 import { SortOptions, SortOrder } from "../api/IBMiContent";
 import { Search } from "../api/Search";
@@ -1336,9 +1336,9 @@ function storeMemberList(path: string, list: string[]) {
   }
 }
 
-async function doSearchInSourceFile(searchTerm: string, path: string, filter: ConnectionConfiguration.ObjectFilters | undefined) {
+async function doSearchInSourceFile(searchTerm: string, path: string, filter?: ConnectionConfiguration.ObjectFilters) {
   const content = getContent();
-  const pathParts = path.split(`/`);
+  const [library, sourceFile] = path.split(`/`);
   try {
     await vscode.window.withProgress({
       location: vscode.ProgressLocation.Notification,
@@ -1348,7 +1348,13 @@ async function doSearchInSourceFile(searchTerm: string, path: string, filter: Co
         message: t(`objectBrowser.doSearchInSourceFile.progressMessage`, path)
       });
 
-      const members = await content.getMemberList({ library: pathParts[0], sourceFile: pathParts[1], members: filter?.member });
+      const members = await content.getMemberList({
+        library,
+        sourceFile,
+        members: filter?.member,
+        extensions: filter?.memberType,
+        filterType: filter?.filterType
+      });
       if (members.length > 0) {
         // NOTE: if more messages are added, lower the timeout interval
         const timeoutInternal = 9000;
@@ -1376,26 +1382,22 @@ async function doSearchInSourceFile(searchTerm: string, path: string, filter: Co
           }
         }, timeoutInternal);
 
-        const results = await Search.searchMembers(instance, pathParts[0], pathParts[1], `${filter?.member || `*`}.MBR`, searchTerm, filter?.protected || content.isProtectedPath(pathParts[0]));
-        // Filter search result by member type filter.
-        if (results.hits.length && filter?.member) {
-          const patternExt = new RegExp(`^` + filter?.member.replace(/[*]/g, `.*`).replace(/[$]/g, `\\$`) + `$`);
-          results.hits = results.hits.filter(result => {
-            const resultPath = result.path.split(`/`);
-            const resultName = resultPath[resultPath.length - 1];
-            const member = members.find(member => member.name === resultName);
-            return (member && patternExt.test(member.extension));
-          })
+        let memberFilter: string | IBMiMember[] = '*';
+        if (filter?.member && filter?.filterType !== "regex" && singleGenericName(filter.member)) {
+          memberFilter = filter?.member;
+        }
+        else if (!parseFilter(filter?.member, filter?.filterType).noFilter) {
+          memberFilter = members;
         }
 
+        const results = await Search.searchMembers(instance, library, sourceFile, searchTerm, memberFilter, filter?.protected);
         if (results.hits.length) {
           const objectNamesLower = GlobalConfiguration.get(`ObjectBrowser.showNamesInLowercase`);
 
           // Format result to include member type.
           results.hits.forEach(result => {
-            const resultPath = result.path.split(`/`);
-            const resultName = resultPath[resultPath.length - 1];
-            result.path += `.${members.find(member => member.name === resultName)?.extension || ''}`;
+            const memberName = result.path.split("/").at(-1);
+            result.path += `.${members.find(member => member.name === memberName)?.extension || ''}`;
             if (objectNamesLower === true) {
               result.path = result.path.toLowerCase();
             }

--- a/src/views/searchView.ts
+++ b/src/views/searchView.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import vscode from "vscode";
 import { DefaultOpenMode } from "../api/Configuration";
 import { t } from '../locale';
-import { SearchHit, SearchHitLine, SearchResults } from "../typings";
+import { SearchHit, SearchHitLine, SearchResults, WithPath } from "../typings";
 
 export function initializeSearchView(context: vscode.ExtensionContext) {
   const searchView = new SearchView();
@@ -68,9 +68,9 @@ class SearchView implements vscode.TreeDataProvider<vscode.TreeItem> {
   }
 }
 
-class HitSource extends vscode.TreeItem {
-  private readonly path: string;
+class HitSource extends vscode.TreeItem implements WithPath {  
   private readonly _readonly?: boolean;
+  readonly path: string;
 
   constructor(readonly term: string, readonly result: SearchHit) {
     const hits = result.lines.length;

--- a/src/views/searchView.ts
+++ b/src/views/searchView.ts
@@ -68,7 +68,7 @@ class SearchView implements vscode.TreeDataProvider<vscode.TreeItem> {
   }
 }
 
-class HitSource extends vscode.TreeItem implements WithPath {  
+class HitSource extends vscode.TreeItem implements WithPath {
   private readonly _readonly?: boolean;
   readonly path: string;
 
@@ -117,7 +117,8 @@ class LineHit extends vscode.TreeItem {
         if (index >= 0) {
           highlights.push([index, index + term.length]);
           if (!position) {
-            position = new vscode.Range(positionLine, index, positionLine, index + term.length)
+            const offset = index + (line.content.length - line.content.trimStart().length);
+            position = new vscode.Range(positionLine, offset, positionLine, offset + term.length)
           }
           index += term.length;
         }


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/2207

Searching for text in members of a source file would crash if run on a "complex" filter. By complex, I mean a filter whose member filtering term is either a Regex or not a single generic name (`XXX*`).

This PR fixes this issue, making sure the search runs fine in all cases.
It also fixes some minor issues:
- The search progress message was still `Listing members...` even after the listing was done and `grep` was running
- The position used when opening a search hit could be wrong if the line started with one or more whitespaces
- The interval set for displaying different messages during the search was not cleared immediately when the search was over

### How to test this PR
1. Run a search on a simple filter
2. Run a search on a complex filter

In both cases, the results must be as expected and only the members actually listed by the filter must be shown in the search result.

### Checklist
* [x] have tested my change