### PR TITLE
Fixed object/members listing failing when name contains variant chars

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -656,7 +656,7 @@ export default class IBMiContent {
         asp,
         library,
         file: String(result.SOURCE_FILE),
-        name: String(result.NAME),
+        name: this.ibmi.sysNameInLocal(String(result.NAME)),
         extension: String(result.TYPE),
         recordLength: Number(result.RECORD_LENGTH) - 12,
         text: `${result.TEXT || ``}${sourceFile === `*ALL` ? ` (${result.SOURCE_FILE})` : ``}`.trim(),

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -482,6 +482,7 @@ export default class IBMiContent {
    */
   async getObjectList(filters: { library: string; object?: string; types?: string[]; filterType?: FilterType }, sortOrder?: SortOrder): Promise<IBMiObject[]> {
     const library = this.ibmi.upperCaseName(filters.library);
+    const americanLibrary = this.ibmi.sysNameInAmerican(library);
     if (!await this.checkObject({ library: "QSYS", name: library, type: "*LIB" })) {
       throw new Error(`Library ${library} does not exist.`);
     }
@@ -511,7 +512,7 @@ export default class IBMiContent {
         `  t.ROW_LENGTH        as SOURCE_LENGTH,`,
         `  t.IASP_NUMBER       as IASP_NUMBER`,
         `from QSYS2.SYSTABLES as t`,
-        `where t.table_schema = '${library}' and t.file_type = 'S'${objectNameLike()}`,
+        `where t.table_schema = '${americanLibrary}' and t.file_type = 'S'${objectNameLike()}`,
       ];
     } else if (!withSourceFiles) {
       //DSPOBJD only
@@ -536,14 +537,14 @@ export default class IBMiContent {
       createOBJLIST = [
         `with SRCPF as (`,
         `  select `,
-        `    t.SYSTEM_TABLE_NAME as NAME,`,
+        `    Replace(Replace(Replace(t.SYSTEM_TABLE_NAME, '${this.ibmi.variantChars.american[2]}','${this.ibmi.variantChars.local[2]}'), '${this.ibmi.variantChars.american[1]}', '${this.ibmi.variantChars.local[1]}'), '${this.ibmi.variantChars.american[0]}', '${this.ibmi.variantChars.local[0]}') as NAME,`,
         `    '*FILE'             as TYPE,`,
         `    'PF'                as ATTRIBUTE,`,
         `    t.TABLE_TEXT        as TEXT,`,
         `    1                   as IS_SOURCE,`,
         `    t.ROW_LENGTH        as SOURCE_LENGTH`,
         `  from QSYS2.SYSTABLES as t`,
-        `  where t.table_schema = '${library}' and t.file_type = 'S'${objectNameLike()}`,
+        `  where t.table_schema = '${americanLibrary}' and t.file_type = 'S'${objectNameLike()}`,
         `), OBJD as (`,
         `  select `,
         `    OBJNAME           as NAME,`,
@@ -580,7 +581,7 @@ export default class IBMiContent {
 
     return objects.map(object => ({
       library,
-      name: this.ibmi.sysNameInLocal(String(object.NAME)),
+      name: sourceFilesOnly ? this.ibmi.sysNameInLocal(String(object.NAME)) : String(object.NAME),
       type: String(object.TYPE),
       attribute: String(object.ATTRIBUTE),
       text: String(object.TEXT || ""),
@@ -643,10 +644,10 @@ export default class IBMiContent {
               b.table_name = a.table_name
       )
       Select * From MEMBERS
-      Where LIBRARY = '${library}'
-        ${sourceFile !== `*ALL` ? `And SOURCE_FILE = '${sourceFile}'` : ``}
-        ${singleMember ? `And NAME Like '${singleMember}'` : ''}
-        ${singleMemberExtension ? `And TYPE Like '${singleMemberExtension}'` : ''}
+      Where LIBRARY = '${this.ibmi.sysNameInAmerican(library)}'
+        ${sourceFile !== `*ALL` ? `And SOURCE_FILE = '${this.ibmi.sysNameInAmerican(sourceFile)}'` : ``}
+        ${singleMember ? `And NAME Like '${this.ibmi.sysNameInAmerican(singleMember)}'` : ''}
+        ${singleMemberExtension ? `And TYPE Like '${this.ibmi.sysNameInAmerican(singleMemberExtension)}'` : ''}
       Order By ${sort.order === 'name' ? 'NAME' : 'CHANGED'} ${!sort.ascending ? 'DESC' : 'ASC'}`;
 
     const results = await this.ibmi.runSQL(statement);
@@ -655,9 +656,9 @@ export default class IBMiContent {
       return results.map(result => ({
         asp,
         library,
-        file: String(result.SOURCE_FILE),
+        file: this.ibmi.sysNameInLocal(String(result.SOURCE_FILE)),
         name: this.ibmi.sysNameInLocal(String(result.NAME)),
-        extension: String(result.TYPE),
+        extension: this.ibmi.sysNameInLocal(String(result.TYPE)),
         recordLength: Number(result.RECORD_LENGTH) - 12,
         text: `${result.TEXT || ``}${sourceFile === `*ALL` ? ` (${result.SOURCE_FILE})` : ``}`.trim(),
         lines: Number(result.LINES),

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -490,7 +490,7 @@ export default class IBMiContent {
     const singleEntry = filters.filterType !== 'regex' ? singleGenericName(filters.object) : undefined;
     const nameFilter = parseFilter(filters.object, filters.filterType);
     const objectFilter = filters.object && (nameFilter.noFilter || singleEntry) && filters.object !== `*` ? this.ibmi.upperCaseName(filters.object) : undefined;
-    const objectNameLike = () => objectFilter ? ` and t.SYSTEM_TABLE_NAME ${(objectFilter.includes('*') ? ` like ` : ` = `)} '${objectFilter.replace('*', '%')}'` : '';
+    const objectNameLike = () => objectFilter ? ` and t.SYSTEM_TABLE_NAME ${(objectFilter.includes('*') ? ` like ` : ` = `)} '${this.ibmi.sysNameInAmerican(objectFilter).replace('*', '%')}'` : '';
     const objectName = () => objectFilter ? `, OBJECT_NAME => '${objectFilter}'` : '';
 
     const typeFilter = filters.types && filters.types.length > 1 ? (t: string) => filters.types?.includes(t) : undefined;

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -8,7 +8,7 @@ import { TestSuite } from ".";
 import { Tools } from "../api/Tools";
 import { getMemberUri } from "../filesystems/qsys/QSysFs";
 import { instance } from "../instantiate";
-import { CommandResult } from "../typings";
+import { CommandResult, IBMiObject } from "../typings";
 
 export const ContentSuite: TestSuite = {
   name: `Content API tests`,
@@ -784,6 +784,74 @@ export const ContentSuite: TestSuite = {
         }
         else {
           throw new Error("No temporary library defined in configuration");
+        }
+      }
+    },
+    {
+      name: "Listing objects with variants",
+      test: async () => {
+        const connection = instance.getConnection();
+        const content = instance.getConnection()?.content;
+        if (connection && content && connection.getEncoding().ccsid !== 37) {
+          const ccsid = connection.getEncoding().ccsid;
+          let library = `TESTLIB${connection.variantChars.local}`;
+          let skipLibrary = false;
+          const sourceFile = `TESTFIL${connection.variantChars.local}`;
+          const members: string[] = [];
+          for (let i = 0; i < 5; i++) {
+            members.push(`TSTMBR${connection.variantChars.local}${i}`);
+          }
+          try {
+            const crtLib = await connection.runCommand({ command: `CRTLIB LIB(${library}) TYPE(*PROD)`, noLibList: true });
+            if (Tools.parseMessages(crtLib.stderr).findId("CPD0032")) {
+              //Not authorized: carry on, skip library name test
+              library = connection.config?.tempLibrary!;
+              skipLibrary = true
+            }
+            const crtSrcPF = await connection.runCommand({ command: `CRTSRCPF FILE(${library}/${sourceFile}) RCDLEN(112) CCSID(${ccsid})`, noLibList: true });
+            if ((crtLib.code === 0 || skipLibrary) && crtSrcPF.code === 0) {
+              for (const member of members) {
+                const addPFM = await connection.runCommand({ command: `ADDPFM FILE(${library}/${sourceFile}) MBR(${member}) SRCTYPE(TXT)`, noLibList: true });
+                if (addPFM.code !== 0) {
+                  throw new Error(`Failed to create member ${member}: ${addPFM.stderr}`);
+                }
+              }
+            }
+            else {
+              throw new Error(`Failed to create library and source file: ${crtLib.stderr || crtLib.stderr}`)
+            }
+
+            if (!skipLibrary) {
+              const [expectedLibrary] = await content.getLibraries({ library });
+              assert.ok(expectedLibrary);
+              assert.strictEqual(library, expectedLibrary.name);
+            }
+
+            const checkFile = (expectedObject: IBMiObject) => {
+              assert.ok(expectedObject);
+              assert.ok(expectedObject.sourceFile, `${expectedObject.name} not a source file`);
+              assert.strictEqual(expectedObject.name, sourceFile);
+              assert.strictEqual(expectedObject.library, library);
+            };
+
+            const [expectedObject] = await content.getObjectList({ library, object: sourceFile, types: ["*ALL"] });
+            checkFile(expectedObject);
+
+            const [expectedSourceFile] = await content.getObjectList({ library, object: sourceFile, types: ["*SRCPF"] });
+            checkFile(expectedSourceFile);
+
+            const expectedMembers = await content.getMemberList({ library, sourceFile });
+            assert.ok(expectedMembers);
+            assert.ok(expectedMembers.every(member => members.find(m => m === member.name)));
+          }
+          finally {
+            if (!skipLibrary && await content.checkObject({ library: "QSYS", name: library, type: "*LIB" })) {
+              await connection.runCommand({ command: `DLTLIB LIB(${library})`, noLibList: true })
+            }
+            if (skipLibrary && await content.checkObject({ library, name: sourceFile, type: "*FILE" })) {
+              await connection.runCommand({ command: `DLTF FILE(${library}/${sourceFile})`, noLibList: true })
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
### Changes
Listing objects and/or members with names containing variant characters using a profile with CCSID different from 37 would result in members being displayed with American variant characters and physical source files not being displayed or being displayed as regular PF.

Example, with CCSID 297 variants characters:

Before this PR, when listing members
![image](https://github.com/user-attachments/assets/28700b98-72fc-4bc4-8446-5d4ff60e9939)

After this PR
![image](https://github.com/user-attachments/assets/978e485a-1885-4e04-9135-b5f1d4db79ae)

Before this PR, when listing source physical files:
With Object type = *ALL
![image](https://github.com/user-attachments/assets/cba99ac3-c586-41a7-a483-3b085b587b23)
With Object type = *SRCPF
![image](https://github.com/user-attachments/assets/c3381692-c32d-4389-aaac-994c2e57cb84)

After this PR
![image](https://github.com/user-attachments/assets/a17dd7f1-c204-4ff4-ab18-c4733fb68d49)
![image](https://github.com/user-attachments/assets/8a87b893-273e-43a5-a536-b500dfbe5e28)

Turns out the system tables contains the names in CCSID 37 and the OBJECT_STATISTICS table function does translates the names to the connection's CCSID before returning the results.

### How to test this PR
1. Connect with a profile with CCSID other than 37
2. Create a member with one or more variant characters
3. It must be displayed correctly and can be opened.

### Checklist
* [x] have tested my change