### PR TITLE
Fixed IFS commands/methods crashing with paths with blanks

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -58,7 +58,7 @@ export default class IBMiContent {
   }
 
   private async convertToUTF8(iconv: string, from: string, to: string, ccsid: string) {
-    const result = await this.ibmi.sendCommand({ command: `${iconv} -f IBM-${ccsid} -t UTF-8 "${from}" > ${to}` });
+    const result = await this.ibmi.sendCommand({ command: `${iconv} -f IBM-${ccsid} -t UTF-8 ${Tools.escapePath(from)} > ${Tools.escapePath(to)}` });
     if (result.code === 0) {
       return result.stdout;
     }
@@ -890,7 +890,7 @@ export default class IBMiContent {
    */
   async isDirectory(remotePath: string) {
     return (await this.ibmi.sendCommand({
-      command: `cd ${remotePath}`
+      command: `cd ${Tools.escapePath(remotePath)}`
     })).code === 0;
   }
 
@@ -952,7 +952,7 @@ export default class IBMiContent {
   }
 
   async getAttributes(path: string | (QsysPath & { member?: string }), ...operands: AttrOperands[]) {
-    const target = (path = typeof path === 'string' ? path : Tools.qualifyPath(path.library, path.name, path.member, path.asp));
+    const target = (path = typeof path === 'string' ? Tools.escapePath(path) : Tools.qualifyPath(path.library, path.name, path.member, path.asp));
     const result = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.attr} -p ${target} ${operands.join(" ")}` });
     if (result.code === 0) {
       return result.stdout
@@ -970,7 +970,7 @@ export default class IBMiContent {
   }
 
   async countFiles(directory: string) {
-    return Number((await this.ibmi.sendCommand({ command: `cd ${directory} && (ls | wc -l)` })).stdout.trim());
+    return Number((await this.ibmi.sendCommand({ command: `cd "${directory}" && (ls | wc -l)` })).stdout.trim());
   }
 
   objectToToolTip(path: string, object: IBMiObject) {

--- a/src/api/Terminal.ts
+++ b/src/api/Terminal.ts
@@ -5,6 +5,7 @@ import { instance } from '../instantiate';
 import { GlobalConfiguration } from './Configuration';
 import IBMi from './IBMi';
 import Instance from './Instance';
+import { Tools } from './Tools';
 
 function getOrDefaultToUndefined(value: string) {
   if (value && value !== `default`) {
@@ -56,7 +57,7 @@ export namespace Terminal {
         if (content) {
           const ifsPath = (await content.isDirectory(ifsNode.path)) ? ifsNode.path : path.dirname(ifsNode.path);
           const terminal = await selectAndOpen(context, instance, TerminalType.PASE);
-          terminal?.sendText(`cd ${ifsPath}`);
+          terminal?.sendText(`cd ${Tools.escapePath(ifsPath)}`);
         }
       }),
 


### PR DESCRIPTION
### Changes
Some commands/methods were not working if the IFS path they received contained blanks, namely:
- Saving an IFS file whose CCSID was not Unicode (fixed `iconv` call)
- Opening a terminal
- Adding a new IFS shortcut

### How to test this PR
1. Create a folder with blanks in its name
2. Add its path to the IFS browser
3. Right-click and open a Terminal on it
4. Create a file in it with CCSID 850
5. Edit the file, make some changes, save it
6. Reload VSCode (the file may be in memory)
7. Open the file; changes must be kept

### Checklist
* [x] have tested my change