### PR TITLE
Add additional checks for debug configuration/certificate

### DIFF
--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -191,7 +191,7 @@ export async function setup(connection: IBMi, imported?: ImportedCertificate) {
           debugConfig.set("JAVA_HOME", javaHome);
           debugConfig.set("DEBUG_SERVICE_KEYSTORE_FILE", certificatePath);
           debugConfig.set("DEBUG_SERVICE_KEYSTORE_PASSWORD", encryptResult.stdout);
-          debugConfig.set("CODE4IDEBUG", `$([ -f $DBGSRV_WRK_DIR/${ENCRYPTION_KEY} ] && cp $DBGSRV_WRK_DIR/${ENCRYPTION_KEY} $DBGSRV_WRK_DIR/key.properties)`);
+          debugConfig.setCode4iDebug(`$([ -f $DBGSRV_WRK_DIR/${ENCRYPTION_KEY} ] && cp $DBGSRV_WRK_DIR/${ENCRYPTION_KEY} $DBGSRV_WRK_DIR/key.properties)`);
           debugConfig.save();
         }
         else {
@@ -208,6 +208,10 @@ export async function setup(connection: IBMi, imported?: ImportedCertificate) {
       throw error;
     }
   });
+}
+
+export async function debugKeyFileExists(connection: IBMi, debugConfig: DebugConfiguration) {
+  return await connection.content.testStreamFile(`${debugConfig.getRemoteServiceWorkDir()}/.code4i.debug`, "f");
 }
 
 export async function remoteCertificatesExists(debugConfig?: DebugConfiguration) {

--- a/src/api/debug/config.ts
+++ b/src/api/debug/config.ts
@@ -91,6 +91,14 @@ export class DebugConfiguration {
   getRemoteServiceWorkDir() {
     return this.getOrDefault("DBGSRV_WRK_DIR", "/QIBM/UserData/IBMiDebugService");
   }
+
+  getCode4iDebug() {
+    return this.get("CODE4IDEBUG");
+  }
+
+  setCode4iDebug(value: string) {
+    return this.set("CODE4IDEBUG", value);
+  }
 }
 
 interface DebugServiceDetails {
@@ -145,7 +153,7 @@ export async function getDebugServiceDetails(): Promise<DebugServiceDetails> {
         console.log(e);
       }
     }
-    else{
+    else {
       details = {
         version: `1.0.0`,
         java: `8`,

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -283,8 +283,9 @@ export async function initialize(context: ExtensionContext) {
           const ptfInstalled = server.debugPTFInstalled();
 
           if (ptfInstalled) {
-            const remoteCertsExists = await certificates.remoteCertificatesExists();
-            if (remoteCertsExists) {
+            const debugConfig = await new DebugConfiguration().load()
+            const remoteCertsExists = await certificates.remoteCertificatesExists(debugConfig);
+            if (remoteCertsExists && await certificates.debugKeyFileExists(connection, debugConfig) && debugConfig.getCode4iDebug()) {
               await certificates.downloadClientCert(connection);
               vscode.window.showInformationMessage(`Debug Service Certificate already exist on the server. The client certificate has been downloaded to enable debugging.`);
             }

--- a/src/locale/ids/en.json
+++ b/src/locale/ids/en.json
@@ -360,7 +360,7 @@
   "objectBrowser.uploadAndReplaceMemberAsFile.infoMessage": "Member was uploaded.",
   "offline": "Offline",
   "online": "Online",
-  "open":"Open",
+  "open": "Open",
   "open.service.configuration": "Open configuration",
   "overview": "Overview",
   "overwrite": "Overwrite",
@@ -394,8 +394,8 @@
   "sandbox.noconnection.modal.title": "Oh no! The sandbox is down.",
   "sandbox.noPassword": "Connection to {0} ended as no password was provided.",
   "save": "Save",
-  "searchView.find.message":"{0} file(s) named '{1}'",
-  "searchView.search.message":"{0} file(s) contain(s) '{1}'",
+  "searchView.find.message": "{0} file(s) named '{1}'",
+  "searchView.search.message": "{0} file(s) contain(s) '{1}'",
   "service.certificate.exists": "Remote service certificate exists",
   "shortcut": "shortcut",
   "size": "Size",
@@ -422,5 +422,7 @@
   "type": "Type",
   "USER_DIRECTORY": "User directory",
   "username": "Username",
-  "Yes": "Yes"
+  "Yes": "Yes",
+  "debug.service.config.incomplete": "Incomplete configuration",
+  "debug.service.config.incomplete.detail": "Certificate needs to be regenerated"
 }


### PR DESCRIPTION
### Changes
Since updating the Debug Service erases the service's configuration, two additional checks have been added when doing the Service's healthcheck:
- Check if the `CODE4IDEBUG` variable is found in the configuration file
- Check if the encryption key backup file exists (i.e. `/QIBM/UserData/IBMiDebugService/.code4i.debug`)

If the healthcheck fails on one of these items, the IBM i Debugger view will show this:
![image](https://github.com/user-attachments/assets/edbf4706-3cd1-4f91-8729-1c9cca07d5be)

The `Generate certificate` inline action will be enabled on the Debug Service item so the situation can be addressed (i.e. regenerate everything).

### How to test this PR
1. Delete the `CODE4IDEBUG` in `/QIBM/ProdData/IBMiDebugService/bin/DebugService.env`
2. Refresh the IBM i Debugger view
3. It must show te error above and offer to regenerate the certificate
4. Generate the certificate
5. Delete the `/QIBM/UserData/IBMiDebugService/.code4i.debug` file
6. Refresh the IBM i Debugger view
7. It must show te error above and offer to regenerate the certificate
8. Generate the certificate


### Checklist
* [x] have tested my change