### PR TITLE
Improvements to member search

### DIFF
--- a/src/api/Search.ts
+++ b/src/api/Search.ts
@@ -1,29 +1,33 @@
-
+import * as path from 'path';
 import { IBMiMember, SearchHit, SearchResults } from '../typings';
 import { GlobalConfiguration } from './Configuration';
 import Instance from './Instance';
 import { Tools } from './Tools';
+import { GetMemberInfo } from '../components/getMemberInfo';
 
 export namespace Search {
-  export async function searchMembers(instance: Instance, library: string, sourceFile: string, searchTerm: string, members: IBMiMember[] | string, readOnly?: boolean,): Promise<SearchResults> {
+  export async function searchMembers(instance: Instance, library: string, sourceFile: string, searchTerm: string, members: string|IBMiMember[], readOnly?: boolean,): Promise<SearchResults> {
     const connection = instance.getConnection();
     const config = instance.getConfig();
     const content = instance.getContent();
 
     if (connection && config && content) {
-      let memberFilter = connection.sysNameInAmerican(typeof members === 'string' ? `${members}.MBR` : members.map(member => `${member.name}.MBR`).join(" "));
+      let detailedMembers: IBMiMember[]|undefined;
+      let memberFilter: string|undefined;
 
-      let postSearchFilter = (hit: SearchHit) => true;
-      if (Array.isArray(members) && memberFilter.length > connection.maximumArgsLength) {
-        //Failsafe: when searching on a complex filter, the member list may exceed the maximum admited arguments length (which is around 4.180.000 characters, roughly 298500 members),
-        //          in this case, we fall back to a global search and manually filter the results afterwards/
-        memberFilter = "*.MBR";
-        postSearchFilter = (hit) => {
-          const memberName = hit.path.split("/").at(-1);
-          return members.find(member => member.name === memberName) !== undefined;
+      if (typeof members === `string`) {
+        memberFilter = connection.sysNameInAmerican(`${members}.MBR`);
+      } else
+      if (Array.isArray(members)) {
+        if (members.length > connection.maximumArgsLength) {
+          detailedMembers = members;
+          memberFilter = "*.MBR";
+        } else {
+          memberFilter = members.map(member => `${member.name}.MBR`).join(` `);
         }
       }
-
+ 
+      // First, let's fetch the ASP info
       let asp = ``;
       if (config.sourceASP) {
         asp = `/${config.sourceASP}`;
@@ -37,17 +41,59 @@ export namespace Search {
         } catch (e) { }
       }
 
+      // Then search the members
       const result = await connection.sendQsh({
         command: `/usr/bin/grep -inHR -F "${sanitizeSearchTerm(searchTerm)}" ${memberFilter}`,
         directory: connection.sysNameInAmerican(`${asp}/QSYS.LIB/${library}.LIB/${sourceFile}.FILE`)
       });
 
       if (!result.stderr) {
+        let hits = parseGrepOutput(
+          result.stdout || '', readOnly || content.isProtectedPath(library),
+          path => connection.sysNameInLocal(`${library}/${sourceFile}/${path.replace(/\.MBR$/, '')}`)
+        );
+
+        if (detailedMembers) {
+          // If the user provided a list of members, we need to filter the results to only include those members
+          hits = hits.filter(hit => {
+            const { name, dir } = path.parse(hit.path);
+            const [lib, spf] = dir.split(`/`);
+            return detailedMembers!.some(member => member.name === name && member.library === lib && member.file === spf);
+          });
+
+        } else {
+          // Else, we need to fetch the member info for each hit so we can display the correct extension
+          const infoComponent = connection?.getComponent<GetMemberInfo>(`GetMemberInfo`);
+          const memberInfos: IBMiMember[] = hits.map(hit => {
+            const { name, dir } = path.parse(hit.path);
+            const [library, file] = dir.split(`/`);
+
+            return {
+              name,
+              library,
+              file,
+              extension: ``
+            };
+          });
+
+          detailedMembers = await infoComponent?.getMultipleMemberInfo(memberInfos);
+        }
+
+        // Then fix the extensions in the hit
+        for (const hit of hits) {
+          const { name, dir } = path.parse(hit.path);
+          const [lib, spf] = dir.split(`/`);
+
+          const foundMember = detailedMembers?.find(member => member.name === name && member.library === lib && member.file === spf);
+
+          if (foundMember) {
+            hit.path = connection.sysNameInLocal(`${lib}/${spf}/${name}.${foundMember.extension}`);
+          }
+        }
+
         return {
           term: searchTerm,
-          hits: (parseGrepOutput(result.stdout || '', readOnly || content.isProtectedPath(library),
-            path => connection.sysNameInLocal(`${library}/${sourceFile}/${path.replace(/\.MBR$/, '')}`)))
-            .filter(postSearchFilter)
+          hits: hits
         }
       }
       else {

--- a/src/testing/search.ts
+++ b/src/testing/search.ts
@@ -31,6 +31,7 @@ export const SearchSuite: TestSuite = {
         const filter = parseFilter(memberFilter);
         const result = await Search.searchMembers(instance, "QSYSINC", "QRPGLESRC", "IBM", memberFilter);
         assert.ok(result.hits.every(hit => filter.test(hit.path.split("/").at(-1)!)));
+        assert.ok(result.hits.every(hit => !hit.path.endsWith(`MBR`)));
       }
     },
     {
@@ -42,11 +43,12 @@ export const SearchSuite: TestSuite = {
         const checkNames = (names: string[]) => names.every(filter.test);
 
         const members = await getConnection().content.getMemberList({ library, sourceFile, members: memberFilter });
-        checkNames(members.map(member => member.name));
+        assert.ok(checkNames(members.map(member => member.name)));
 
         const result = await Search.searchMembers(instance, "QSYSINC", "QRPGLESRC", "SQL", members);
         assert.strictEqual(result.hits.length, 6);
-        checkNames(result.hits.map(hit => hit.path.split("/").at(-1)!));
+        assert.ok(checkNames(result.hits.map(hit => hit.path.split("/").at(-1)!)));
+        assert.ok(result.hits.every(hit => !hit.path.endsWith(`MBR`)));
       }
     }
   ]

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -1349,27 +1349,18 @@ async function doSearchInSourceFile(searchTerm: string, path: string, filter?: C
         message: t(`objectBrowser.doSearchInSourceFile.progressMessage`, path)
       });
 
-      const members = await content.getMemberList({
-        library,
-        sourceFile,
-        members: filter?.member,
-        extensions: filter?.memberType,
-        filterType: filter?.filterType
-      });
-
-      if (members.length > 0) {
         progress.report({ message: t(`objectBrowser.doSearchInSourceFile.searchMessage1`, searchTerm, path) });
 
         // NOTE: if more messages are added, lower the timeout interval
         const timeoutInternal = 9000;
         const searchMessages = [
-          t(`objectBrowser.doSearchInSourceFile.searchMessage2`, members.length, searchTerm, path),
+          // t(`objectBrowser.doSearchInSourceFile.searchMessage2`, members.length, searchTerm, path),
           t(`objectBrowser.doSearchInSourceFile.searchMessage3`, searchTerm),
           t(`objectBrowser.doSearchInSourceFile.searchMessage4`, searchTerm, path),
           t(`objectBrowser.doSearchInSourceFile.searchMessage5`),
           t(`objectBrowser.doSearchInSourceFile.searchMessage6`),
           t(`objectBrowser.doSearchInSourceFile.searchMessage7`),
-          t(`objectBrowser.doSearchInSourceFile.searchMessage8`, members.length),
+          // t(`objectBrowser.doSearchInSourceFile.searchMessage8`, members.length),
           t(`objectBrowser.doSearchInSourceFile.searchMessage9`, searchTerm, path),
         ];
 
@@ -1385,12 +1376,9 @@ async function doSearchInSourceFile(searchTerm: string, path: string, filter?: C
           }
         }, timeoutInternal);
 
-        let memberFilter: string | IBMiMember[] = '*';
+        let memberFilter: string = '*';
         if (filter?.member && filter?.filterType !== "regex" && singleGenericName(filter.member)) {
           memberFilter = filter?.member;
-        }
-        else if (!parseFilter(filter?.member, filter?.filterType).noFilter) {
-          memberFilter = members;
         }
 
         const results = await Search.searchMembers(instance, library, sourceFile, searchTerm, memberFilter, filter?.protected);
@@ -1398,10 +1386,8 @@ async function doSearchInSourceFile(searchTerm: string, path: string, filter?: C
         if (results.hits.length) {
           const objectNamesLower = GlobalConfiguration.get(`ObjectBrowser.showNamesInLowercase`);
 
-          // Format result to include member type.
+          // Format result to be lowercase if the setting is enabled
           results.hits.forEach(result => {
-            const memberName = result.path.split("/").at(-1);
-            result.path += `.${members.find(member => member.name === memberName)?.extension || ''}`;
             if (objectNamesLower === true) {
               result.path = result.path.toLowerCase();
             }
@@ -1415,10 +1401,6 @@ async function doSearchInSourceFile(searchTerm: string, path: string, filter?: C
         } else {
           vscode.window.showInformationMessage(t(`objectBrowser.doSearchInSourceFile.notFound`, searchTerm, path));
         }
-
-      } else {
-        vscode.window.showErrorMessage(t(`objectBrowser.doSearchInSourceFile.noMembers`));
-      }
 
     });
 


### PR DESCRIPTION
### Changes

Improves the member search API by removing the requirement of fetching a member list before initiating a search. Instead, after the search has finished, we use the brand new 'GetMbrInfo' function to get the detail we need for the result.

This PR is going to be the first of two. The second will be worked on when this is approved and merged. The second will add library/filter search.

### How to test this PR

Examples:

1. Run the test cases
2. Ensure the search continues to work from the Object Browser
   * More test cases to cover new situations might be good.

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)