### PR TITLE
Change logic for triggering disconnect

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -159,20 +159,24 @@ export default class IBMi {
 
           let tempLibrarySet = false;
 
-          const disconnected = async () => {
-            const choice = await vscode.window.showWarningMessage(`Connection lost`, {
-              modal: true,
-              detail: `Connection to ${this.currentConnectionName} has dropped. Would you like to reconnect?`
-            }, `Yes`);
+          const timeoutHandleer = async () => {
+            if (!cancelToken.isCancellationRequested) {
+              this.disconnect();
 
-            let disconnect = true;
-            if (choice === `Yes`) {
-              disconnect = !(await this.connect(connectionObject, true)).success;
+              const choice = await vscode.window.showWarningMessage(`Connection lost`, {
+                modal: true,
+                detail: `Connection to ${this.currentConnectionName} has dropped. Would you like to reconnect?`
+              }, `Yes`);
+
+              let disconnect = true;
+              if (choice === `Yes`) {
+                disconnect = !(await this.connect(connectionObject, true)).success;
+              }
+
+              if (disconnect) {
+                this.end();
+              };
             }
-
-            if (disconnect) {
-              this.end();
-            };
           };
 
           progress.report({
@@ -217,9 +221,9 @@ export default class IBMi {
           }
 
           // Register handlers after we might have to abort due to bad configuration.
-          this.client.connection!.once(`timeout`, disconnected);
-          this.client.connection!.once(`end`, disconnected);
-          this.client.connection!.once(`error`, disconnected);
+          this.client.connection!.once(`timeout`, timeoutHandleer);
+          this.client.connection!.once(`end`, timeoutHandleer);
+          this.client.connection!.once(`error`, timeoutHandleer);
 
           if (!reconnecting) {
             instance.setConnection(this);
@@ -935,8 +939,9 @@ export default class IBMi {
             for (const operation of delayedOperations) {
               await operation();
             }
-            instance.fire("connected");
           }
+
+          instance.fire(`connected`);
 
           GlobalStorage.get().setServerSettingsCache(this.currentConnectionName, {
             aspInfo: this.aspInfo,
@@ -1104,9 +1109,17 @@ export default class IBMi {
     this.commandsExecuted += 1;
   }
 
-  async end() {
+  private async disconnect() {
     this.client.connection?.removeAllListeners();
     this.client.dispose();
+    this.client.connection = null;
+    instance.fire(`disconnected`);
+  }
+
+  async end() {
+    if (this.client.connection) {
+      this.disconnect();
+    }
 
     if (this.outputChannel) {
       this.outputChannel.hide();
@@ -1124,7 +1137,6 @@ export default class IBMi {
     ]);
 
     instance.setConnection(undefined);
-    instance.fire(`disconnected`);
     await vscode.commands.executeCommand(`setContext`, `code-for-ibmi:connected`, false);
     vscode.window.showInformationMessage(`Disconnected from ${this.currentHost}.`);
   }

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -159,7 +159,7 @@ export default class IBMi {
 
           let tempLibrarySet = false;
 
-          const timeoutHandleer = async () => {
+          const timeoutHandler = async () => {
             if (!cancelToken.isCancellationRequested) {
               this.disconnect();
 
@@ -221,9 +221,9 @@ export default class IBMi {
           }
 
           // Register handlers after we might have to abort due to bad configuration.
-          this.client.connection!.once(`timeout`, timeoutHandleer);
-          this.client.connection!.once(`end`, timeoutHandleer);
-          this.client.connection!.once(`error`, timeoutHandleer);
+          this.client.connection!.once(`timeout`, timeoutHandler);
+          this.client.connection!.once(`end`, timeoutHandler);
+          this.client.connection!.once(`error`, timeoutHandler);
 
           if (!reconnecting) {
             instance.setConnection(this);


### PR DESCRIPTION
### Changes

We were not triggering the disconnect when the connection timed out. This was causing the database extension issues because the jobs tied to the connection were not going away because the extension was not signaled of the disconnect.

Real changes:

* Trigger `disconnect` and cleanup client when timeout happens
* Trigger `connected` no matter if connecting for the first time or if reconnecting.

### How to test this PR

Examples:

#### Example 1

1. Use release version of the extension
2. Connect to server, spin up SQL job with database extension
3. Trigger the timeout somehow (disconnect from VPN in my case)
4. Use the reconnect option in the UI
5. See that the SQL jobs haven't ended, but are instead just handing

#### Example 2

1. Use this branch of the extension
2. Connect to server, spin up SQL job with database extension
3. Trigger the timeout somehow (disconnect from VPN in my case)
4. Use the reconnect option in the UI
5. See the previous jobs are gone, and new ones must be started - no hang ups

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)