### PR TITLE
Fix error when dragging to IFS directory with special characters

### DIFF
--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -250,11 +250,11 @@ class IFSBrowserDragAndDrop implements vscode.TreeDragAndDropController<IFSItem>
         let result;
         switch (action) {
           case "copy":
-            result = await connection.sendCommand({ command: `cp -r ${ifsBrowserItems.map(item => item.path).join(" ")} ${toDirectory.path}` });
+            result = await connection.sendCommand({ command: `cp -r ${ifsBrowserItems.map(item => Tools.escapePath(item.path)).join(" ")} ${Tools.escapePath(toDirectory.path)}` });
             break;
 
           case "move":
-            result = await connection.sendCommand({ command: `mv ${ifsBrowserItems.map(item => item.path).join(" ")} ${toDirectory.path}` });
+            result = await connection.sendCommand({ command: `mv ${ifsBrowserItems.map(item => Tools.escapePath(item.path)).join(" ")} ${Tools.escapePath(toDirectory.path)}` });
             ifsBrowserItems.map(item => item.parent)
               .filter(Tools.distinct)
               .forEach(folder => folder?.refresh?.());


### PR DESCRIPTION
### Changes

When dragging files or folders to a directory with special character(s) in the name of the source(s) or target, the copy or move fail the operation because of the special character(s) in the name(s).

This PR fixes the problem first reported in issue #2237.

### How to test this PR

Examples:

1. Switch to the master branch.
2. Drag and drop a file to a directory having a name with blank(s). The copy or move fails.
3. Drag and drop a file having a name with blank(s) to a directory. The copy or move fails.
4. Switch to this branch.
2. Drag and drop a file to a directory having a name with blank(s). The copy or move completes as expected.
3. Drag and drop a file having a name with blank(s) to a directory. The copy or move completes as expected.

### Checklist

* [x] have tested my change
