### PR TITLE
#2105 Improved error when running an action in readonly mode

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -562,6 +562,10 @@ export namespace CompileTools {
         else {
           return false;
         }
+      } else if (isProtected) {
+        //when a member is protected(read only)
+        vscode.window.showErrorMessage(`Action cannot be applied on a read only member.`);
+        return false;
       } else {
         //No compile commands
         vscode.window.showErrorMessage(`No compile commands found for ${uri.scheme}-${extension}.`);


### PR DESCRIPTION
Changes

Changed the error message to make it more contextual when running an action while browsing a member (read-only mode). 

How to test this PR

Examples:
1. Open a member in browse mode.
2. Run an action using the keyboard shortcut.
3. New error message will be displayed in the VSCode message notification area.

Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)