### PR TITLE
Support workspace folder parameter on `runAction`

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -79,15 +79,17 @@ export namespace CompileTools {
     }
   }
 
-  export async function runAction(instance: Instance, uri: vscode.Uri, customAction?: Action, method?: DeploymentMethod, browserItem?: BrowserItem): Promise<boolean> {
+  export async function runAction(instance: Instance, uri: vscode.Uri, customAction?: Action, method?: DeploymentMethod, browserItem?: BrowserItem, workspaceFolder?: WorkspaceFolder): Promise<boolean> {
     const connection = instance.getConnection();
     const config = instance.getConfig();
     const content = instance.getContent();
 
     const uriOptions = parseFSOptions(uri);
     const isProtected = uriOptions.readonly || config?.readOnlyMode;
-        
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+    
+    if(!workspaceFolder) {
+      workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+    }
     let remoteCwd = config?.homeDirectory || `.`;
 
     if (connection && config && content) {

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -528,7 +528,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       quickPick.show();
 
     }),
-    vscode.commands.registerCommand(`code-for-ibmi.runAction`, async (target: vscode.TreeItem | BrowserItem | vscode.Uri, group?: any, action?: Action, method?: DeploymentMethod) => {
+    vscode.commands.registerCommand(`code-for-ibmi.runAction`, async (target: vscode.TreeItem | BrowserItem | vscode.Uri, group?: any, action?: Action, method?: DeploymentMethod, workspaceFolder?: vscode.WorkspaceFolder) => {
       const editor = vscode.window.activeTextEditor;
       let uri;
       let browserItem;
@@ -574,7 +574,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
           }
 
           if (canRun && [`member`, `streamfile`, `file`, 'object'].includes(uri.scheme)) {
-            return await CompileTools.runAction(instance, uri, action, method, browserItem);
+            return await CompileTools.runAction(instance, uri, action, method, browserItem, workspaceFolder);
           }
         }
         else {


### PR DESCRIPTION
### Changes

This PR simply adds the `workspaceFolder` as an optional parameter on `runAction`. The purpose of this change is so that when `runAction` is used on an object or member in Project Explorer, the local project's `LIBL` and `CURLIB` variables are used.

Associated change in PE: https://github.com/IBM/vscode-ibmi-projectexplorer/pull/575

### How to test this PR

1. Actions unrelated to PE should work as before.
2. Actions from PE should use the project's `LIBL` and `CURLIB`.

### Checklist

* [x] have tested my change