### PR TITLE
Implement remove filter command in object browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1474,6 +1474,13 @@
 				"icon": "$(filter)"
 			},
 			{
+				"command": "code-for-ibmi.objectBrowser.removeFilter",
+				"enablement": "code-for-ibmi:connected",
+				"title": "Remove Filter",
+				"category": "IBM i",
+				"icon": "$(remove)"
+			},
+			{
 				"command": "code-for-ibmi.objectBrowser.delete",
 				"enablement": "code-for-ibmi:connected",
 				"title": "Delete...",
@@ -2222,6 +2229,10 @@
 					"when": "never"
 				},
 				{
+					"command": "code-for-ibmi.objectBrowser.removeFilter",
+					"when": "never"
+				},
+				{
 					"command": "code-for-ibmi.objectBrowser.delete",
 					"when": "never"
 				},
@@ -2596,9 +2607,9 @@
 					"group": "4_filters@2"
 				},
 				{
-					"command": "code-for-ibmi.objectBrowser.delete",
+					"command": "code-for-ibmi.objectBrowser.removeFilter",
 					"when": "view == objectBrowser && viewItem =~ /^filter.*$/",
-					"group": "4_filters@3"
+					"group": "4_filters@4"
 				},
 				{
 					"command": "code-for-ibmi.moveFilterUp",

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -1234,6 +1234,15 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         }
       } while (newLibrary && !newLibraryOK)
     }),
+    vscode.commands.registerCommand(`code-for-ibmi.objectBrowser.removeFilter`, async (node?: ObjectBrowserItem) => {
+      if (node && node instanceof ObjectBrowserFilterItem) {
+        const message = t('objectBrowser.delete.confirm', node.toString());
+        if (await vscode.window.showWarningMessage(message, { modal: true }, t(`Yes`))) {
+          await node.delete();
+          vscode.commands.executeCommand(`code-for-ibmi.refreshObjectBrowser`);
+        }
+      }
+    }),
     vscode.commands.registerCommand("code-for-ibmi.objectBrowser.delete", async (node?: ObjectBrowserItem, nodes?: ObjectBrowserItem[]) => {
       const candidates: ObjectBrowserItem[] = [];
       if (nodes) {


### PR DESCRIPTION
This pull request adds a new command, "Remove Filter", to the object browser in the IBM i category. The command allows users to remove a filter from the object browser. The implementation includes changes to the command registration and the initialization of the object browser.

This change was added to seperate the difference between deleting an object vs removing the filter (just like we do in the IFS Browser)