### PR TITLE
Allow filters to be deleted even if protected

### DIFF
--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -1246,7 +1246,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         candidates.push(...objectTreeViewer.selection.filter(i => i instanceof ObjectBrowserItem) as ObjectBrowserItem[]);
       }
 
-      const toBeDeleted = candidates.filter(item => !item.isProtected());
+      const toBeDeleted = candidates.filter(item => item instanceof ObjectBrowserFilterItem || !item.isProtected());
       if (toBeDeleted.length) {
         const message = toBeDeleted.length === 1 ? t('objectBrowser.delete.confirm', toBeDeleted[0].toString()) : t('objectBrowser.delete.multiple.confirm', toBeDeleted.length);
         const detail = toBeDeleted.length === 1 ? undefined : toBeDeleted.map(item => `- ${item.toString()}`).join("\n");


### PR DESCRIPTION
### Changes
Fixes https://github.com/codefori/vscode-ibmi/issues/2251
The logic for deleting Object Browser items would prevent filters from being deleted if they were protected.

This PR makes filter item deletable, not mater what.

### How to test this PR
1. Try to delete a protected filter
2. The confirmation dialog must show up
3. If confirmed, the filter must be removed

### Checklist
* [x] have tested my change