### PR TITLE
Upgrade deprecated `actions/upload-artifact@v2` to `v4`

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
         run: npm run package
         
       - name: Upload build
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: code-for-ibmi-pr-build
           path: ./*.vsix


### PR DESCRIPTION
### Changes

Fixes https://github.com/codefori/vscode-ibmi/actions/runs/10813160788/job/29996523037?pr=2038

### How to test this PR

Add the `build` label