### PR TITLE
Always show "Download client certificate" button

### DIFF
--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -199,10 +199,8 @@ export class SettingsUI {
                 localCertificateIssue = `${String(error)}. Debugging will not function correctly.`;
               }
               debuggerTab.addParagraph(`<b>${localCertificateIssue || "Client certificate for service has been imported and matches remote certificate."}</b>`)
-                .addParagraph(`To debug on IBM i, Visual Studio Code needs to load a client certificate to connect to the Debug Service. Each server has a unique certificate. This client certificate should exist at <code>${certificates.getLocalCertPath(connection)}</code>`);
-              if (!localCertificateIssue) {
-                debuggerTab.addButtons({ id: `import`, label: `Download client certificate` })
-              }
+                .addParagraph(`To debug on IBM i, Visual Studio Code needs to load a client certificate to connect to the Debug Service. Each server has a unique certificate. This client certificate should exist at <code>${certificates.getLocalCertPath(connection)}</code>`)
+                .addButtons({ id: `import`, label: `Download client certificate` });              
             }
             else {
               debuggerTab.addParagraph(`The service certificate doesn't exist or is incomplete; it must be generated before the debug service can be started.`)


### PR DESCRIPTION
### Changes

Fixes #2280 

The test controlling if the Download Client Certificate buttons in the connection settings was wrong: it would hide the button in case if problem (mismatch, not found, ...).

The test has been removed so the button always shows in the settings.

### How to test this PR
1. Remove local client certificate (located in user home directory)
2. Open connection settings
3. Go to the Debugger tab
4. The Download button should be visible
5. Click on the button
6. Re-open the settings
7. The client certificate should have been downloaded and the button should still be displayed

### Checklist
* [x] have tested my change