### PR TITLE
Made Java installation as connection features

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -113,6 +113,10 @@ export default class IBMi {
       tar: undefined,
       ls: undefined,
       find: undefined,
+      jdk80: undefined,
+      jdk11: undefined,
+      jdk17: undefined,
+      openjdk11: undefined
     };
 
     this.variantChars = {
@@ -587,6 +591,16 @@ export default class IBMi {
                 console.log(e);
               }
             }
+
+            //Specific Java installations check
+            progress.report({
+              message: `Checking installed components on host IBM i: Java`
+            });
+            const javaCheck = async (root: string) => await this.content.testStreamFile(`${root}/bin/java`, 'x') ? `${root}` : undefined;
+            this.remoteFeatures.jdk80 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit`);
+            this.remoteFeatures.jdk11 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk11/64bit`);
+            this.remoteFeatures.openjdk11 = await javaCheck(`/QOpensys/pkgs/lib/jvm/openjdk-11`);
+            this.remoteFeatures.jdk17 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk17/64bit`);
           }
 
           if (this.sqlRunnerAvailable()) {

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -596,7 +596,7 @@ export default class IBMi {
             progress.report({
               message: `Checking installed components on host IBM i: Java`
             });
-            const javaCheck = async (root: string) => await this.content.testStreamFile(`${root}/bin/java`, 'x') ? `${root}` : undefined;
+            const javaCheck = async (root: string) => await this.content.testStreamFile(`${root}/bin/java`, 'x') ? root : undefined;
             this.remoteFeatures.jdk80 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit`);
             this.remoteFeatures.jdk11 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk11/64bit`);
             this.remoteFeatures.openjdk11 = await javaCheck(`/QOpensys/pkgs/lib/jvm/openjdk-11`);

--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -170,7 +170,7 @@ export async function setup(connection: IBMi, imported?: ImportedCertificate) {
         debugConfig.delete("DEBUG_SERVICE_KEYSTORE_PASSWORD");
         await debugConfig.save();
       }
-      const javaHome = getJavaHome((await getDebugServiceDetails()).java);
+      const javaHome = getJavaHome(connection, (await getDebugServiceDetails()).java);
       const encryptResult = await connection.sendCommand({
         command: `${path.posix.join(debugConfig.getRemoteServiceBin(), `encryptKeystorePassword.sh`)} | /usr/bin/tail -n 1`,
         env: {
@@ -268,7 +268,7 @@ export async function sanityCheck(connection: IBMi, content: IBMiContent) {
 
   //Check if java home needs to be updated if the service got updated (e.g: v1 uses Java 8 and v2 uses Java 11)
   const javaHome = debugConfig.get("JAVA_HOME");
-  const expectedJavaHome = getJavaHome((await getDebugServiceDetails()).java);
+  const expectedJavaHome = getJavaHome(connection, (await getDebugServiceDetails()).java);
   if (javaHome && javaHome !== expectedJavaHome) {
     if (await content.testStreamFile(DEBUG_CONFIG_FILE, "w")) {
       //Automatically make the change if possible

--- a/src/api/debug/config.ts
+++ b/src/api/debug/config.ts
@@ -2,6 +2,7 @@ import path from "path";
 import vscode from "vscode";
 import { instance } from "../../instantiate";
 import { t } from "../../locale";
+import IBMi from "../IBMi";
 import { SERVICE_CERTIFICATE } from "./certificates";
 
 type ConfigLine = {
@@ -170,9 +171,12 @@ export async function getDebugServiceDetails(): Promise<DebugServiceDetails> {
   return debugServiceDetails;
 }
 
-export function getJavaHome(version: string) {
-  switch (version) {
-    case "11": return `/QOpenSys/QIBM/ProdData/JavaVM/jdk11/64bit`;
-    default: return `/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit`;
+export function getJavaHome(connection: IBMi, version: string) {
+  version = version.padEnd(2, '0');
+  const javaHome = connection.remoteFeatures[`jdk${version}`];
+  if (!javaHome) {
+    throw new Error(t('java.not.found', version));
   }
+
+  return javaHome;
 }

--- a/src/locale/ids/da.json
+++ b/src/locale/ids/da.json
@@ -224,6 +224,7 @@
   "ifsBrowser.uploadStreamfile.select.type.title": "Hvad ønsker du at uploade?",
   "ifsBrowser.uploadStreamfile.uploadedFiles": "Upload er udført.",
   "JAVA_HOME": "Java Home",
+  "java.not.found":"Java version {0} is not installed.",
   "job": "Job",
   "JOB_NAME_SHORT": "Job navn",
   "JOB_NUMBER": "Job nummer",

--- a/src/locale/ids/de.json
+++ b/src/locale/ids/de.json
@@ -224,6 +224,7 @@
   "ifsBrowser.uploadStreamfile.select.type.title": "Was möchten Sie hochladen?",
   "ifsBrowser.uploadStreamfile.uploadedFiles": "Hochladen abgeschlossen.",
   "JAVA_HOME": "Java-Home Pfad",
+  "java.not.found":"Java version {0} is not installed.",
   "job": "Job",
   "JOB_NAME_SHORT": "Job Name",
   "JOB_NUMBER": "Job Nummer",

--- a/src/locale/ids/en.json
+++ b/src/locale/ids/en.json
@@ -224,6 +224,7 @@
   "ifsBrowser.uploadStreamfile.select.type.title": "What do you want to upload?",
   "ifsBrowser.uploadStreamfile.uploadedFiles": "Upload completed.",
   "JAVA_HOME": "Java Home",
+  "java.not.found":"Java version {0} is not installed.",
   "job": "Job",
   "JOB_NAME_SHORT": "Job name",
   "JOB_NUMBER": "Job number",

--- a/src/locale/ids/fr.json
+++ b/src/locale/ids/fr.json
@@ -224,6 +224,7 @@
   "ifsBrowser.uploadStreamfile.select.type.title": "Que souhaitez-vous envoyer?",
   "ifsBrowser.uploadStreamfile.uploadedFiles": "Envoi terminée.",
   "JAVA_HOME": "Java Home",
+  "java.not.found":"Java version {0} n'est pas installé.",
   "job": "Job",
   "JOB_NAME_SHORT": "Nom du job",
   "JOB_NUMBER": "Numéro du job",

--- a/src/locale/ids/no.json
+++ b/src/locale/ids/no.json
@@ -224,6 +224,7 @@
     "ifsBrowser.uploadStreamfile.select.type.title": "Hva ønsker du å uploade?",
     "ifsBrowser.uploadStreamfile.uploadedFiles": "Upload er utført.",
     "JAVA_HOME": "Java Home",
+    "java.not.found":"Java version {0} is not installed.",
     "job": "Jobb",
     "JOB_NAME_SHORT": "Jobb navn",
     "JOB_NUMBER": "Jobb nummer",

--- a/src/locale/ids/pl.json
+++ b/src/locale/ids/pl.json
@@ -224,6 +224,7 @@
     "ifsBrowser.uploadStreamfile.select.type.title": "Co chcesz przesłać?",
     "ifsBrowser.uploadStreamfile.uploadedFiles": "Przesyłanie zakończone.",
     "JAVA_HOME": "Java Home",
+    "java.not.found":"Java version {0} is not installed.",
     "job": "Zadanie",
     "JOB_NAME_SHORT": "Nazwa zadania`",
     "JOB_NUMBER": "Numer zadania",

--- a/src/testing/debug.ts
+++ b/src/testing/debug.ts
@@ -1,0 +1,31 @@
+import assert from "assert";
+import { TestSuite } from ".";
+import { getJavaHome } from "../api/debug/config";
+import { instance } from "../instantiate";
+
+export const DebugSuite: TestSuite = {
+  name: `Debug engine tests`,
+  tests: [
+    {
+      name: "Check Java versions", test: async () => {
+        const connection = instance.getConnection()!;
+        if(connection.remoteFeatures.jdk80){
+          const jdk8 = getJavaHome(connection, '8');
+          assert.strictEqual(jdk8, connection.remoteFeatures.jdk80);
+        }
+
+        if(connection.remoteFeatures.jdk11){
+          const jdk11 = getJavaHome(connection, '11');
+          assert.strictEqual(jdk11, connection.remoteFeatures.jdk11);
+        }
+
+        if(connection.remoteFeatures.jdk17){
+          const jdk11 = getJavaHome(connection, '17');
+          assert.strictEqual(jdk11, connection.remoteFeatures.jdk11);
+        }
+
+        assert.throws(() => getJavaHome(connection, '666'));
+      }
+    }
+  ]
+}

--- a/src/testing/debug.ts
+++ b/src/testing/debug.ts
@@ -21,7 +21,7 @@ export const DebugSuite: TestSuite = {
 
         if(connection.remoteFeatures.jdk17){
           const jdk11 = getJavaHome(connection, '17');
-          assert.strictEqual(jdk11, connection.remoteFeatures.jdk11);
+          assert.strictEqual(jdk11, connection.remoteFeatures.jdk17);
         }
 
         assert.throws(() => getJavaHome(connection, '666'));

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -5,6 +5,7 @@ import { ActionSuite } from "./action";
 import { ComponentSuite } from "./components";
 import { ConnectionSuite } from "./connection";
 import { ContentSuite } from "./content";
+import { DebugSuite } from "./debug";
 import { DeployToolsSuite } from "./deployTools";
 import { EncodingSuite } from "./encoding";
 import { FilterSuite } from "./filter";
@@ -18,6 +19,7 @@ const suites: TestSuite[] = [
   ActionSuite,
   ConnectionSuite,
   ContentSuite,
+  DebugSuite,
   DeployToolsSuite,
   ToolsSuite,
   ILEErrorSuite,


### PR DESCRIPTION
### Changes
This PR takes the Java discovery part of https://github.com/codefori/vscode-ibmi/pull/2195.
The different possible Java installation locations are made into connection features.

These features are now used to get Java Home path when configuring the debug service.

### How to test this PR
1. Run the Debug test case
2. Generate a Debug Service certificate
3. Check Java Home in the Debug Service configuration file

### Checklist
* [x] have tested my change