### PR TITLE
Fix stat() returning `Invalid member path` for members located on iasp

### DIFF
--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -94,7 +94,7 @@ export class QSysFS implements vscode.FileSystemProvider {
     async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
         const path = uri.path;
         const pathLength = path.split(`/`).length;
-        if (pathLength > 4 || !path.startsWith('/')) {
+        if (pathLength > 5 || !path.startsWith('/')) {
             throw new vscode.FileSystemError("Invalid member path");
         }
         const type = pathLength > 3 ? vscode.FileType.File : vscode.FileType.Directory;


### PR DESCRIPTION
### Changes
Fixes #2286

The path validity test was not valid for members located on an iasp.
This PR fixes the issue.

### How to test this PR
1. Open a member located on an iasp

### Checklist
* [x] have tested my change