### PR TITLE
Feature/download members with correct EOL format based on OS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@NicolasSchindler](https://github.com/NicolasSchindler)
 * [@marcin-ogon](https://github.com/marcin-ogon)
 * [@Detrytus59](https://github.com/Detrytus59)
+* [@preetpalsinghmehra](https://github.com/preetpalsinghmehra)


### PR DESCRIPTION
### Changes

This PR addresses an issue with line endings in the code repository. Currently, when the member is downloaded from the object browser to the local repository on a Windows machine, files are downloaded with LF (Line Feed) endings instead of the expected CRLF (Carriage Return Line Feed) format. As a result, when code is pushed to the remote repository, Git detects changes across all lines due to inconsistent line endings, leading to unnecessary diff outputs and complicating code reviews. As a fix CPYTOSTMF is changed based on the type of Operating System.

### How to test this PR
Download the member from object browser on Windows machine it should be downloaded with CRLF (Carriage Return Line Feed) and on Linux/Mac OS it should be downloaded with LF (Line Feed). It can be verified by checking the format on the bottom right of the VS Code.

![image](https://github.com/user-attachments/assets/8fbe2b6e-a3be-414b-8b32-8a75eac6bd81)

Examples:

1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette

### Checklist

* [x] have tested my change
* [x] have created one or more test cases
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)