### PR TITLE
Fix encoding issue when writing files

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -117,7 +117,7 @@ export default class IBMiContent {
       ccsid = await this.getNotUTF8CCSID(features.attr, originalPath);
     }
 
-    await writeFileAsync(tmpobj, content, encoding);
+    await writeFileAsync(tmpobj, content, {encoding: encoding as BufferEncoding});
 
     if (ccsid && features.iconv) {
       // Upload our file to the same temp file, then write convert it back to the original ccsid
@@ -952,7 +952,7 @@ export default class IBMiContent {
   }
 
   async getAttributes(path: string | (QsysPath & { member?: string }), ...operands: AttrOperands[]) {    
-    const target = (path = typeof path === 'string' ? Tools.escapePath(path) : this.ibmi.sysNameInAmerican(Tools.qualifyPath(path.library, path.name, path.member, path.asp)));
+    const target = Tools.escapePath(path = typeof path === 'string' ? path : this.ibmi.sysNameInAmerican(Tools.qualifyPath(path.library, path.name, path.member, path.asp)));
 
     const result = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.attr} -p ${target} ${operands.join(" ")}` });
     if (result.code === 0) {


### PR DESCRIPTION
This pull request includes a simple fix for always escaping the path when writing files. The `getAttributes` function has been updated to properly handle the path parameter for when bad characters, like a dollar sign, are used.

This fix also ensures that the encoding is correctly specified when using the `writeFileAsync` function.

Fixes #2303.