### PR TITLE
Use system names for libraries and source files in SQL

### DIFF
--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -93,11 +93,14 @@ export class ExtendedIBMiContent {
     let recordLength: number = DEFAULT_RECORD_LENGTH;
 
     if (content) {
-      const result = await content.runSQL(`SELECT LENGTH(srcdta) as LENGTH FROM ${aliasPath} limit 1`);
+      const result = await content.runSQL(`select length(SRCDTA) as LENGTH from ${aliasPath} limit 1`);
       if (result.length > 0) {
         recordLength = Number(result[0].LENGTH);
       } else {
-        const result = await content.runSQL(`SELECT row_length-12 as LENGTH FROM QSYS2.SYSTABLES WHERE TABLE_SCHEMA = '${lib}' and TABLE_NAME = '${spf}' limit 1`);
+        const result = await content.runSQL(`select row_length-12 as LENGTH
+                                               from QSYS2.SYSTABLES
+                                              where SYSTEM_TABLE_SCHEMA = '${lib}' and SYSTEM_TABLE_NAME = '${spf}'
+                                              limit 1`);
         if (result.length > 0) {
           recordLength = Number(result[0].LENGTH);
         }

--- a/src/testing/content.ts
+++ b/src/testing/content.ts
@@ -854,6 +854,36 @@ export const ContentSuite: TestSuite = {
           }
         }
       }
+    },
+    {
+      name: `Test long library name`, test: async () => {
+        const connection = instance.getConnection()!;
+        const content = instance.getContent()!;
+        const longName = Tools.makeid(18);
+        const shortName = Tools.makeid(8);
+        const createLib = await connection.runCommand({ command: `RUNSQL 'create schema "${longName}" for ${shortName}' commit(*none)`, noLibList: true });
+        if (createLib.code === 0) {
+          await connection!.runCommand({ command: `CRTSRCPF FILE(${shortName}/SFILE) MBR(MBR) TEXT('Test long library name')` });
+
+          const libraries = await content?.getLibraries({ library: `${shortName}` })
+          assert.strictEqual(libraries?.length, 1);
+
+          const objects = await content?.getObjectList({ library: `${shortName}`, types: [`*SRCPF`], object: `SFILE` });
+          assert.strictEqual(objects?.length, 1);
+          assert.strictEqual(objects[0].type, `*FILE`);
+          assert.strictEqual(objects[0].text, `Test long library name`);
+
+          const memberCount = await content.countMembers({ library: `${shortName}`, name: `SFILE` });
+          assert.strictEqual(memberCount, 1);
+          const members = await content?.getMemberList({ library: `${shortName}`, sourceFile: `SFILE` });
+
+          assert.strictEqual(members?.length, 1);
+
+          await connection.runCommand({ command: `RUNSQL 'drop schema "${longName}"' commit(*none)`, noLibList: true });
+        } else {
+          throw new Error(`Failed to create schema "${longName}"`);
+        }
+      }
     }
   ]
 };


### PR DESCRIPTION
### Changes

This PR will fix issue #2323 (originated from discussion #2316) by changing the SQL for QSYS.LIB objects to use the system name columns instead of the SQL name columns.

### How to test this PR

Examples:

1. Create a library as a DB2 schema with a long SQL name and shorter system name:
  ```sql
create schema  "Testing_a_long_schema_name" for TESTSYSNAM
```
2. Create a source file and member in this library:
```cl
CRTSRCPF FILE(TESTSYSNAM/SFILE) MBR(MBR)
```
3. Create a filter in the Object Browser for this library.
4. Expand the filter - with this change everything shows as expected, including tooltips.

### Checklist

* [x] have tested my change
* [x] have created one or more test cases
