### PR TITLE
Ensure type is a string for translation

### DIFF
--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -75,7 +75,7 @@ export async function registerUriHandler(context: ExtensionContext) {
                   } else {
                     window.showInformationMessage(l10n.t(`Failed to connect`), {
                       modal: true,
-                      detail: l10n.t("Failed to connect to {0} as {1}", server,  user)
+                      detail: l10n.t("Failed to connect to {0} as {1}", server, String(user))
                     });
                   }
 


### PR DESCRIPTION
SImple fix. TS compiler knew it was a string but our strict type generation wanted to be safe.

We don't need a release for this.