### PR TITLE
Add Auto Reconnect setting

### DIFF
--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -103,7 +103,7 @@
   "directory": "Répertoire",
   "Directory of the file on the remote system": "Répertoire du fichier sur le système distant",
   "Do you want to copy or move the selection to {0}?": "Voulez-vous déplacer ou copier la sélection vers {0}?",
-  "Do you want to reconnect and open {0}?": "Voulez-vous vous reconnecter et ouvrir {0}?",
+  "Do you want to reconnect to {0} and open {1}?": "Voulez-vous vous reconnecter et ouvrir {0}?",
   "Download certificate": "Télécharger le certificat",
   "Download complete": "Téléchargement terminé",
   "Download Logs": "Télécharger les logs",

--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -103,6 +103,7 @@
   "directory": "Répertoire",
   "Directory of the file on the remote system": "Répertoire du fichier sur le système distant",
   "Do you want to copy or move the selection to {0}?": "Voulez-vous déplacer ou copier la sélection vers {0}?",
+  "Do you want to reconnect and open {0}?": "Voulez-vous vous reconnecter et ouvrir {0}?",
   "Download certificate": "Télécharger le certificat",
   "Download complete": "Téléchargement terminé",
   "Download Logs": "Télécharger les logs",

--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -311,6 +311,7 @@
   "Private key updated and will be used for \"{0}\".": "Clé privée mise à jour et utilisée pour se connecter à \"{0}\".",
   "QShell": "QShell",
   "Recently used": "Utilisé récemment",
+  "Reconnect": "Se reconnecter",
   "Refresh": "Rafraîchissement",
   "Relative path of the streamfile from the working directory or workspace": "Chemin relatif du fichier de flux à partir du répertoire de travail ou de l'espace de travail",
   "Remote certificate not found": "Le certificat du service n\"existe pas",

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -311,6 +311,7 @@
   "Private key updated and will be used for \"{0}\".": "Private key updated and will be used for \"{0}\".",
   "QShell": "QShell",
   "Recently used": "Recently used",
+  "Reconnect": "Reconnect",
   "Refresh": "Refresh",
   "Relative path of the streamfile from the working directory or workspace": "Relative path of the streamfile from the working directory or workspace",
   "Remote certificate not found": "Remote certificate not found",

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -103,7 +103,7 @@
   "directory": "directory",
   "Directory of the file on the remote system": "Directory of the file on the remote system",
   "Do you want to copy or move the selection to {0}?": "Do you want to copy or move the selection to {0}?",
-  "Do you want to reconnect and open {0}?": "Do you want to reconnect and open {0}?",
+  "Do you want to reconnect to {0} and open {1}?": "Do you want to reconnect to {0} and open {1}?",
   "Download certificate": "Download certificate",
   "Download complete": "Download complete",
   "Download Logs": "Download Logs",

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -103,6 +103,7 @@
   "directory": "directory",
   "Directory of the file on the remote system": "Directory of the file on the remote system",
   "Do you want to copy or move the selection to {0}?": "Do you want to copy or move the selection to {0}?",
+  "Do you want to reconnect and open {0}?": "Do you want to reconnect and open {0}?",
   "Download certificate": "Download certificate",
   "Download complete": "Download complete",
   "Download Logs": "Download Logs",

--- a/package.json
+++ b/package.json
@@ -531,7 +531,7 @@
 						"Always reconnect",
 						"Never reconnect"
 					],
-					"description": "The action to take when a source member is left opened when VS Code is closed and re-opened."
+					"description": "The action to take when a source member/streamfile is left opened when VS Code is closed and re-opened."
 				},
 				"code-for-ibmi.connections": {
 					"type": "array",

--- a/package.json
+++ b/package.json
@@ -518,6 +518,21 @@
 					"default": false,
 					"description": "If enabled, PASE terminals will open in the editor area as tabs instead of panels."
 				},
+				"code-for-ibmi.autoReconnect": {
+					"type": "string",
+					"default": "always",
+					"enum": [
+						"ask",
+						"always",
+						"never"
+					],
+					"enumDescriptions": [
+						"Show a choice notification",
+						"Always reconnect",
+						"Never reconnect"
+					],
+					"description": "The action to take when a source member is left opened when VS Code is closed and re-opened."
+				},
 				"code-for-ibmi.connections": {
 					"type": "array",
 					"items": {

--- a/package.json
+++ b/package.json
@@ -520,7 +520,7 @@
 				},
 				"code-for-ibmi.autoReconnect": {
 					"type": "string",
-					"default": "always",
+					"default": "ask",
 					"enum": [
 						"ask",
 						"always",

--- a/src/api/Configuration.ts
+++ b/src/api/Configuration.ts
@@ -5,6 +5,7 @@ import { FilterType } from './Filter';
 
 export type SourceDateMode = "edit" | "diff";
 export type DefaultOpenMode = "browse" | "edit";
+export type ReconnectMode = "always" | "never" | "ask";
 
 const getConfiguration = (): vscode.WorkspaceConfiguration => {
   return vscode.workspace.getConfiguration(`code-for-ibmi`);
@@ -26,7 +27,7 @@ export namespace GlobalConfiguration {
 
   export function set(key: string, value: any) {
     return getConfiguration().update(key, value, vscode.ConfigurationTarget.Global);
-  }  
+  }
 }
 
 export interface StoredConnection {
@@ -34,7 +35,7 @@ export interface StoredConnection {
   data: ConnectionData
 };
 
-const getPasswordKey = (connectionName:string) => `${connectionName}_password`;  
+const getPasswordKey = (connectionName: string) => `${connectionName}_password`;
 
 export namespace ConnectionManager {
   export function getByName(name: string): StoredConnection | undefined {
@@ -133,14 +134,14 @@ export namespace ConnectionConfiguration {
     defaultDeploymentMethod: DeploymentMethod | '';
     protectedPaths: string[];
     showHiddenFiles: boolean;
-    lastDownloadLocation:string;
+    lastDownloadLocation: string;
     [name: string]: any;
-  }  
+  }
 
   export interface ObjectFilters {
     name: string
     filterType: FilterType
-    library: string    
+    library: string
     object: string
     types: string[]
     member: string
@@ -222,7 +223,7 @@ export namespace ConnectionConfiguration {
   }
 
   export async function update(parameters: Parameters) {
-    if(parameters?.name) {
+    if (parameters?.name) {
       const connections = getConnectionSettings();
       connections.filter(conn => conn.name === parameters.name).forEach(conn => Object.assign(conn, parameters));
       await updateAll(connections);

--- a/src/filesystems/ifsFs.ts
+++ b/src/filesystems/ifsFs.ts
@@ -24,8 +24,12 @@ export class IFSFS implements vscode.FileSystemProvider {
         throw new FileSystemError("Not connected to IBM i");
       }
       else {
-        await reconnectFS(uri);
-        return this.readFile(uri, true);
+        if (await reconnectFS(uri)) {
+          return this.readFile(uri, true);
+        }
+        else {
+          return Buffer.alloc(0);
+        }
       }
     }
   }

--- a/src/filesystems/ifsFs.ts
+++ b/src/filesystems/ifsFs.ts
@@ -1,6 +1,7 @@
 import vscode, { FileSystemError, FileType } from "vscode";
 import { Tools } from "../api/Tools";
 import { instance } from "../instantiate";
+import { reconnectFS } from "./qsys/FSUtils";
 import { getFilePermission } from "./qsys/QSysFs";
 
 export class IFSFS implements vscode.FileSystemProvider {
@@ -23,7 +24,7 @@ export class IFSFS implements vscode.FileSystemProvider {
         throw new FileSystemError("Not connected to IBM i");
       }
       else {
-        await vscode.commands.executeCommand(`code-for-ibmi.connectToPrevious`);
+        await reconnectFS(uri);
         return this.readFile(uri, true);
       }
     }

--- a/src/filesystems/qsys/FSUtils.ts
+++ b/src/filesystems/qsys/FSUtils.ts
@@ -10,7 +10,7 @@ import { Tools } from "../../api/Tools";
  * @returns `true` if the user choses to reconnect, `false` otherwise.
  */
 export async function reconnectFS(uri: vscode.Uri) {
-  const reconnect = GlobalConfiguration.get<ReconnectMode>("autoReconnect");
+  const reconnect = GlobalConfiguration.get<ReconnectMode>("autoReconnect") || "ask";
   let doReconnect = false;
   switch (reconnect) {
     case "always":

--- a/src/filesystems/qsys/FSUtils.ts
+++ b/src/filesystems/qsys/FSUtils.ts
@@ -1,11 +1,13 @@
-import vscode, { FileSystemError, l10n } from "vscode";
+import vscode, { l10n } from "vscode";
 import { GlobalConfiguration, ReconnectMode } from "../../api/Configuration";
+import { Tools } from "../../api/Tools";
 
 /**
  * Called when a member/streamfile is left open when VS Code is closed and re-opened to reconnect (or not) to the previous IBM i, based on the `autoReconnect` global configuration value.
+ * If the user choses not to reconnect, the editor tab will be closed.
  * 
  * @param uri the uri of the file triggerring the reconnection attempt
- * @throws `FileSystemError` if not reconnected
+ * @returns `true` if the user choses to reconnect, `false` otherwise.
  */
 export async function reconnectFS(uri: vscode.Uri) {
   const reconnect = GlobalConfiguration.get<ReconnectMode>("autoReconnect");
@@ -26,8 +28,12 @@ export async function reconnectFS(uri: vscode.Uri) {
 
   if (doReconnect) {
     await vscode.commands.executeCommand(`code-for-ibmi.connectToPrevious`);    
+    return true;
   }
   else {
-    throw new FileSystemError("Not connected to IBM i");
+    for(const tab of Tools.findUriTabs(uri)){
+      await vscode.window.tabGroups.close(tab);
+    }
+    return false;
   }
 }

--- a/src/filesystems/qsys/FSUtils.ts
+++ b/src/filesystems/qsys/FSUtils.ts
@@ -1,0 +1,33 @@
+import vscode, { FileSystemError, l10n } from "vscode";
+import { GlobalConfiguration, ReconnectMode } from "../../api/Configuration";
+
+/**
+ * Called when a member/streamfile is left open when VS Code is closed and re-opened to reconnect (or not) to the previous IBM i, based on the `autoReconnect` global configuration value.
+ * 
+ * @param uri the uri of the file triggerring the reconnection attempt
+ * @throws `FileSystemError` if not reconnected
+ */
+export async function reconnectFS(uri: vscode.Uri) {
+  const reconnect = GlobalConfiguration.get<ReconnectMode>("autoReconnect");
+  let doReconnect = false;
+  switch (reconnect) {
+    case "always":
+      doReconnect = true;
+      break;
+
+    case "ask":
+      if (await vscode.window.showInformationMessage(l10n.t("Do you want to reconnect and open {0}?", uri.path.split('/').reverse()?.[0]), l10n.t("Reconnect"))) {
+        doReconnect = true;
+      }
+      break;
+
+    default:
+  }
+
+  if (doReconnect) {
+    await vscode.commands.executeCommand(`code-for-ibmi.connectToPrevious`);    
+  }
+  else {
+    throw new FileSystemError("Not connected to IBM i");
+  }
+}

--- a/src/filesystems/qsys/FSUtils.ts
+++ b/src/filesystems/qsys/FSUtils.ts
@@ -1,5 +1,7 @@
+import path from "path";
 import vscode, { l10n } from "vscode";
 import { GlobalConfiguration, ReconnectMode } from "../../api/Configuration";
+import { GlobalStorage } from "../../api/Storage";
 import { Tools } from "../../api/Tools";
 
 /**
@@ -18,8 +20,11 @@ export async function reconnectFS(uri: vscode.Uri) {
       break;
 
     case "ask":
-      if (await vscode.window.showInformationMessage(l10n.t("Do you want to reconnect and open {0}?", uri.path.split('/').reverse()?.[0]), l10n.t("Reconnect"))) {
-        doReconnect = true;
+      const lastConnection = GlobalStorage.get().getLastConnections()?.at(0)?.name;
+      if (lastConnection) {
+        if (await vscode.window.showInformationMessage(l10n.t("Do you want to reconnect to {0} and open {1}?", lastConnection, path.basename(uri.path)), l10n.t("Reconnect"))) {
+          doReconnect = true;
+        }
       }
       break;
 
@@ -27,11 +32,11 @@ export async function reconnectFS(uri: vscode.Uri) {
   }
 
   if (doReconnect) {
-    await vscode.commands.executeCommand(`code-for-ibmi.connectToPrevious`);    
+    await vscode.commands.executeCommand(`code-for-ibmi.connectToPrevious`);
     return true;
   }
   else {
-    for(const tab of Tools.findUriTabs(uri)){
+    for (const tab of Tools.findUriTabs(uri)) {
       await vscode.window.tabGroups.close(tab);
     }
     return false;

--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -197,8 +197,12 @@ export class QSysFS implements vscode.FileSystemProvider {
                 throw new FileSystemError("Not connected to IBM i");
             }
             else {
-                await reconnectFS(uri);
-                return this.readFile(uri, true);
+                if (await reconnectFS(uri)) {
+                    return this.readFile(uri, true);
+                }
+                else {
+                    return Buffer.alloc(0);
+                }
             }
         }
     }

--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -1,5 +1,5 @@
 import { parse as parsePath } from "path";
-import { ParsedUrlQueryInput, parse, stringify } from "querystring";
+import { parse, ParsedUrlQueryInput, stringify } from "querystring";
 import vscode, { FilePermission, FileSystemError } from "vscode";
 import { onCodeForIBMiConfigurationChange } from "../../api/Configuration";
 import IBMi from "../../api/IBMi";
@@ -7,6 +7,7 @@ import { Tools } from "../../api/Tools";
 import { instance } from "../../instantiate";
 import { IBMiMember, QsysFsOptions, QsysPath } from "../../typings";
 import { ExtendedIBMiContent } from "./extendedContent";
+import { reconnectFS } from "./FSUtils";
 import { SourceDateHandler } from "./sourceDateHandler";
 
 export function getMemberUri(member: IBMiMember, options?: QsysFsOptions) {
@@ -196,7 +197,7 @@ export class QSysFS implements vscode.FileSystemProvider {
                 throw new FileSystemError("Not connected to IBM i");
             }
             else {
-                await vscode.commands.executeCommand(`code-for-ibmi.connectToPrevious`);
+                await reconnectFS(uri);
                 return this.readFile(uri, true);
             }
         }


### PR DESCRIPTION
### Changes
Resolves #2300 

Based on @p-behr suggestion, this PR adds a new global settings that sets the action taken out by Code for i when a member/streamfile is left open when VS Code is closed and re-opened.

![image](https://github.com/user-attachments/assets/874186a6-9b07-44c5-a546-e01852568c0b)

Supported values are:
* `ask`: opens a notification asking whether or not the user wants to reconnect
![image](https://github.com/user-attachments/assets/491a1cf5-68bb-4fb4-a460-a25add190f34)
* `always`: always reconnect
* `never`: never reconnect

If the user choose to reconnect, the member/streamfile is reloaded. Otherwise, the editor that was left open is closed.

### How to test this PR
1. Open a member/streamfile
2. Leave it open and close VS Code
3. Re-open VS Code
4. Based on the reconnect setting, code for i will reconnect, close the editor or ask the user if they want to reconnect

### Checklist
* [x] have tested my change