### PR TITLE
Support for local and server profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,13 @@
 					".vscode/actions.json"
 				],
 				"url": "./schemas/actions.json"
+			},
+			{
+				"fileMatch": [
+					".vscode/profiles.json",
+					"/.vscode/profiles.json"
+				],
+				"url": "./schemas/profiles.json"
 			}
 		],
 		"configuration": {
@@ -2520,7 +2527,7 @@
 				},
 				{
 					"command": "code-for-ibmi.loadConnectionProfile",
-					"when": "view == profilesView && viewItem == profile",
+					"when": "view == profilesView && (viewItem == profile || viewItem == localProfile)",
 					"group": "inline"
 				},
 				{

--- a/schemas/profiles.json
+++ b/schemas/profiles.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "FilterType": {
+      "type": "string",
+      "enum": ["simple", "regex"]
+    },
+    "ObjectFilters": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "filterType": { "$ref": "#/definitions/FilterType" },
+        "library": { "type": "string" },
+        "object": { "type": "string" },
+        "types": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "member": { "type": "string" },
+        "memberType": { "type": "string" },
+        "protected": { "type": "boolean" }
+      },
+      "required": ["name", "filterType", "library", "object", "types", "member", "memberType", "protected"]
+    },
+    "CustomVariable": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "value": { "type": "string" }
+      },
+      "required": ["name", "value"]
+    },
+    "ConnectionProfile": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "homeDirectory": { "type": "string" },
+        "currentLibrary": { "type": "string" },
+        "libraryList": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "objectFilters": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/ObjectFilters" }
+        },
+        "ifsShortcuts": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "customVariables": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/CustomVariable" }
+        }
+      },
+      "required": ["name"]
+    },
+    "TopLevel": {
+      "type": "object",
+      "properties": {
+        "profiles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "homeDirectory": { "type": "string" },
+              "currentLibrary": { "type": "string" },
+              "libraryList": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "objectFilters": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/ObjectFilters" }
+              },
+              "ifsShortcuts": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "customVariables": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/CustomVariable" }
+              }
+            }
+          }
+        }
+      },
+      "required": ["profiles"]
+    }
+  },
+  "$ref": "#/definitions/TopLevel"
+}

--- a/src/api/local/profiles.ts
+++ b/src/api/local/profiles.ts
@@ -1,0 +1,113 @@
+
+import { workspace, window } from "vscode";
+import { ConnectionConfiguration } from "../../api/Configuration";
+import IBMi from "../IBMi";
+
+type PartialConnectionProfile = Partial<ConnectionConfiguration.ConnectionProfile>;
+type FullConnectionProfile = ConnectionConfiguration.ConnectionProfile;
+
+const PROFILES_PATH = `/.vscode/profiles.json`;
+
+let serverProfiles: FullConnectionProfile[]|undefined;
+
+interface ProfilesFile {
+  profiles: PartialConnectionProfile[]
+}
+
+export async function getProfiles(connection: IBMi) {
+  const profiles: ConnectionConfiguration.ConnectionProfile[] = [];
+
+  if (workspace.workspaceFolders) {
+    const actionsFiles = await workspace.findFiles(`**${PROFILES_PATH}`);
+
+    for (const file of actionsFiles) {
+      const content = await workspace.fs.readFile(file);
+      try {
+        profiles.push(...parseJsonIntoProfilesFile(content.toString()));
+      } catch (e: any) {
+        // ignore
+        window.showErrorMessage(`Error parsing ${file.fsPath}: ${e.message}\n`);
+      }
+    };
+  }
+
+  if (serverProfiles === undefined) {
+    serverProfiles = [];
+    const isAvailable = await connection.content.testStreamFile(PROFILES_PATH, `r`);
+    if (isAvailable) {
+      const content = await connection.content.downloadStreamfileRaw(PROFILES_PATH);
+      try {
+        serverProfiles = parseJsonIntoProfilesFile(content.toString());
+      } catch (e: any) {
+        // ignore
+        window.showErrorMessage(`Error parsing server file ${PROFILES_PATH}: ${e.message}\n`);
+      }
+    }
+  } else if (Array.isArray(serverProfiles)) {
+    profiles.push(...serverProfiles);
+  }
+
+  return profiles;
+}
+
+export function resetServerProfiles() {
+  serverProfiles = undefined;
+}
+
+function parseJsonIntoProfilesFile(json: string) {
+  const profiles: ConnectionConfiguration.ConnectionProfile[] = [];
+  const theJson: ProfilesFile = JSON.parse(json.toString());
+
+  if (theJson.profiles) {
+    const profilesJson = theJson.profiles;
+    // Maybe one day replace this with real schema validation
+    if (Array.isArray(profilesJson)) {
+      profilesJson.forEach((profile, index) => {
+        const validProfile = validateLocalProfile(profile);
+        profiles.push(validProfile);
+      })
+    }
+  }
+
+  return profiles;
+}
+
+function validateLocalProfile(input: PartialConnectionProfile): FullConnectionProfile {
+  if (!input.name) {
+    throw new Error(`Profile name is required.`);
+  }
+
+  if (input.homeDirectory && typeof input.homeDirectory !== `string`) {
+    throw new Error(`Home directory must a string.`);
+  }
+
+  if (input.currentLibrary && typeof input.currentLibrary !== `string`) {
+    throw new Error(`Current library must a string.`);
+  }
+
+  if (input.libraryList && !Array.isArray(input.libraryList)) {
+    throw new Error(`Library list must be an array of strings.`);
+  }
+
+  if (input.ifsShortcuts && !Array.isArray(input.ifsShortcuts)) {
+    throw new Error(`IFS shortcuts must be an array of strings.`);
+  }
+
+  if (input.objectFilters && !Array.isArray(input.objectFilters)) {
+    throw new Error(`Object filters must be an array of objects.`);
+  }
+
+  if (input.customVariables && !Array.isArray(input.customVariables)) {
+    throw new Error(`Custom variables must be an array of objects.`);
+  }
+
+  return {
+    name: input.name,
+    homeDirectory: input.homeDirectory || `.`,
+    currentLibrary: input.currentLibrary || ``,
+    libraryList: input.libraryList || [],
+    objectFilters: input.objectFilters || [],
+    ifsShortcuts: input.ifsShortcuts || [],
+    customVariables: input.customVariables || []
+  }
+}

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -16,6 +16,8 @@ import { SEUColorProvider } from "./languages/general/SEUColorProvider";
 import { Action, BrowserItem, DeploymentMethod, MemberItem, OpenEditableOptions, WithPath } from "./typings";
 import { ActionsUI } from './webviews/actions';
 import { VariablesUI } from "./webviews/variables";
+import { getAllProfiles } from './views/ProfilesView';
+import { resetServerProfiles } from './api/local/profiles';
 
 export let instance: Instance;
 
@@ -817,7 +819,7 @@ async function updateConnectedBar() {
 }
 
 async function onConnected() {
-  const config = instance.getConfig();
+  const connection = instance.getConnection()!;
 
   [
     connectedBarItem,
@@ -827,7 +829,9 @@ async function onConnected() {
   updateConnectedBar();
 
   // Enable the profile view if profiles exist.
-  vscode.commands.executeCommand(`setContext`, `code-for-ibmi:hasProfiles`, (config?.connectionProfiles || []).length > 0);
+  resetServerProfiles();
+  const profiles = await getAllProfiles(connection);
+  vscode.commands.executeCommand(`setContext`, `code-for-ibmi:hasProfiles`, profiles.length > 0);
 }
 
 async function onDisconnected() {


### PR DESCRIPTION
Introduce functionality to manage both local and server profiles, enhancing the user experience by allowing seamless access to connection profiles. Created the JSON schema and updated related commands to accommodate these changes.

### Checklist

* [ ] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)