### PR TITLE
Use `vscode.openWith` only when necessary

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -116,7 +116,12 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
       }
 
       try {
-        await vscode.commands.executeCommand(`vscode.openWith`, uri, 'default', { selection: options.position } as vscode.TextDocumentShowOptions);
+        if(options.position){
+          await vscode.commands.executeCommand(`vscode.openWith`, uri, 'default', { selection: options.position } as vscode.TextDocumentShowOptions);
+        }
+        else{
+          await vscode.commands.executeCommand(`vscode.open`, uri);
+        }
 
         // Add file to front of recently opened files list.
         const recentLimit = GlobalConfiguration.get<number>(`recentlyOpenedFilesLimit`);


### PR DESCRIPTION
### Changes

Fixes #2347 

Streamfiles were always opened using `vscode.openWith`, forcing VS Code to use the default text editor regardless of the file's type. Since `vscode.openWith` is used to be able to open the text editor at a given position, if we don't need to open at a position, we use `vscode.open` instead, allowing the editor linked to the file type to be opened, if any.

### How to test this PR
1. Install [vscode-pdf](https://marketplace.visualstudio.com/items?itemName=tomoki1207.pdf)
2. Connect to an IBM i
3. Open a PDF file from the IFS browser
4. The PDF editor must open to display the PDF file

### Checklist
* [x] have tested my change