### PR TITLE
Fixed incorrect messages + open members download location

### DIFF
--- a/src/views/ConnectionBrowser.ts
+++ b/src/views/ConnectionBrowser.ts
@@ -150,7 +150,7 @@ export function initializeConnectionBrowser(context: vscode.ExtensionContext) {
       }
 
       if (!connectionBrowser.attemptingConnection && toBeDeleted.length) {
-        const message = toBeDeleted.length === 1 ? vscode.l10n.t(`Are you sure you want to delete the connection "{0}"?`, toBeDeleted[0].name) : vscode.l10n.t(`Are you sure you want to delete the connection "{0}"?`, toBeDeleted[0].name);
+        const message = toBeDeleted.length === 1 ? vscode.l10n.t(`Are you sure you want to delete the connection "{0}"?`, toBeDeleted[0].name) : vscode.l10n.t("Are you sure you want to delete these {0} connections?", toBeDeleted.length);
         const detail = toBeDeleted.length === 1 ? undefined : toBeDeleted.map(server => `- ${server.name}`).join("\n");
         if (await vscode.window.showWarningMessage(message, { modal: true, detail }, vscode.l10n.t(`Yes`))) {
           for (const server of toBeDeleted) {

--- a/src/views/ProfilesView.ts
+++ b/src/views/ProfilesView.ts
@@ -59,7 +59,7 @@ export class ProfilesView {
           const currentProfiles = config.connectionProfiles;
           const chosenProfile = await getOrPickAvailableProfile(currentProfiles, profileNode);
           if (chosenProfile) {
-            vscode.window.showWarningMessage(l10n.t(`Are you sure you want to delete the "{0}" profile?`, chosenProfile.name), l10n.t(`Are you sure you want to delete the "{0}" profile?`, chosenProfile.name), l10n.t(`Are you sure you want to delete the "{0}" profile?`, chosenProfile.name)).then(async result => {
+            vscode.window.showWarningMessage(l10n.t(`Are you sure you want to delete the "{0}" profile?`, chosenProfile.name), l10n.t("Yes")).then(async result => {
               if (result === l10n.t(`Yes`)) {
                 currentProfiles.splice(currentProfiles.findIndex(profile => profile === chosenProfile), 1);
                 config.connectionProfiles = currentProfiles;

--- a/src/views/debugView.ts
+++ b/src/views/debugView.ts
@@ -30,7 +30,7 @@ export function initializeDebugBrowser(context: vscode.ExtensionContext) {
   const updateDebugBrowser = async () => {
     if (instance.getConnection()) {
       debugTreeViewer.title = `${title} ${(await getDebugServiceDetails()).version}`
-      debugTreeViewer.description = await isDebugEngineRunning() ? vscode.l10n.t(`Online`) : vscode.l10n.t(`Online`);
+      debugTreeViewer.description = await isDebugEngineRunning() ? vscode.l10n.t(`Online`) : vscode.l10n.t(`Offline`);
     }
     else {
       debugTreeViewer.title = title;

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -209,7 +209,7 @@ async function downloadLogs() {
             const result = await zip.writeZipPromise(downloadLocation, { overwrite: false });
 
             if (result) {
-              const result = await vscode.window.showInformationMessage(vscode.l10n.t(`Successfully downloaded logs to {0}`, zipFile), vscode.l10n.t(`Successfully downloaded logs to {0}`, zipFile));
+              const result = await vscode.window.showInformationMessage(vscode.l10n.t(`Successfully downloaded logs to {0}`, zipFile), vscode.l10n.t(`Open`));
               if (result && result === vscode.l10n.t(`Open`)) {
                 vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(downloadLocation))
               }

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -552,7 +552,7 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
         if (items && items.length) {
           if (!items.find(n => isProtected(n.path))) {
             let deletionConfirmed = false;
-            const message = items.length === 1 ? l10n.t(`Are you sure you want to delete {0}?`, items[0].path) : l10n.t(`Are you sure you want to delete {0}?`, items[0].path);
+            const message = items.length === 1 ? l10n.t(`Are you sure you want to delete {0}?`, items[0].path) : l10n.t("Are you sure you want to delete the {0} selected files?", items.length);
             const detail = items.length === 1 ? undefined : items.map(i => `- ${i.path}`).join("\n");
             if (await vscode.window.showWarningMessage(message, { modal: true, detail }, l10n.t(`Yes`))) {
               const toBeDeleted: string[] = [];
@@ -733,7 +733,7 @@ Please type "{0}" to confirm deletion.`, dirName);
 
           const quickPick = vscode.window.createQuickPick();
           quickPick.items = items.length ? [...items, ...clearListArray] : [];
-          quickPick.placeholder = items.length ? l10n.t(`Enter search term or select one of the previous search terms.`) : l10n.t(`Enter search term or select one of the previous search terms.`);
+          quickPick.placeholder = items.length ? l10n.t(`Enter search term or select one of the previous search terms.`) : l10n.t("Enter search term.");
           quickPick.title = l10n.t(`Search {0}`, searchPath);
 
           quickPick.onDidChangeValue(() => {
@@ -793,7 +793,7 @@ Please type "{0}" to confirm deletion.`, dirName);
 
           const quickPick = vscode.window.createQuickPick();
           quickPick.items = items.length ? [...items, ...clearListArray] : [];
-          quickPick.placeholder = items.length ? l10n.t(`Enter find term or select one of the previous find terms.`) : l10n.t(`Enter find term or select one of the previous find terms.`);
+          quickPick.placeholder = items.length ? l10n.t(`Enter find term or select one of the previous find terms.`) : l10n.t("Enter find term.");
           quickPick.title = l10n.t(`Find {0}`, findPath);
 
           quickPick.onDidChangeValue(() => {
@@ -890,7 +890,7 @@ Do you want to replace it?`, target))) {
                   await ibmi.downloadFile(downloadLocation!, targetPath);
                 }
               }
-              vscode.window.showInformationMessage(l10n.t(`Download complete`), l10n.t(`Download complete`))
+              vscode.window.showInformationMessage(l10n.t(`Download complete`), l10n.t(`Open`))
                 .then(open => open ? vscode.commands.executeCommand('revealFileInOS', saveIntoDirectory ? vscode.Uri.joinPath(downloadLocationURI, path.basename(items[0].path)) : downloadLocationURI) : undefined);
             }
             catch (e: any) {

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -583,7 +583,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         });
 
         if (error) {
-          if (await vscode.window.showErrorMessage(vscode.l10n.t(`Error creating member {0}: {1}`, fullPath, error), vscode.l10n.t(`Error creating member {0}: {1}`, fullPath, error))) {
+          if (await vscode.window.showErrorMessage(vscode.l10n.t(`Error creating member {0}: {1}`, fullPath, error), vscode.l10n.t("Retry"))) {
             vscode.commands.executeCommand(`code-for-ibmi.createMember`, node, fullName);
           }
         }
@@ -620,7 +620,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
             const newMemberExists = checkResult.code === 0;
 
             if (newMemberExists) {
-              const result = await vscode.window.showInformationMessage(vscode.l10n.t(`Are you sure you want overwrite member {0}?`, memberPath.name), { modal: true }, vscode.l10n.t(`Are you sure you want overwrite member {0}?`, memberPath.name), vscode.l10n.t(`Are you sure you want overwrite member {0}?`, memberPath.name))
+              const result = await vscode.window.showInformationMessage(vscode.l10n.t(`Are you sure you want overwrite member {0}?`, memberPath.name), { modal: true }, vscode.l10n.t("Yes"));
               if (result === vscode.l10n.t(`Yes`)) {
                 await connection.runCommand({
                   command: `RMVM FILE(${memberPath.library}/${memberPath.file}) MBR(${memberPath.name})`,
@@ -669,7 +669,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
         });
 
         if (error) {
-          if (await vscode.window.showErrorMessage(vscode.l10n.t(`Error creating member {0}: {1}`, fullPath, error), vscode.l10n.t(`Error creating member {0}: {1}`, fullPath, error))) {
+          if (await vscode.window.showErrorMessage(vscode.l10n.t(`Error creating member {0}: {1}`, fullPath, error), vscode.l10n.t("Retry"))) {
             vscode.commands.executeCommand(`code-for-ibmi.copyMember`, node, fullPath);
           }
         }
@@ -897,8 +897,8 @@ Do you want to replace it?`, item.name), skipAllLabel, overwriteLabel, overwrite
 
               task.report({ message: vscode.l10n.t(`getting streamfiles`), increment: 33 })
               await connection.downloadDirectory(downloadLocation!, directory);
-              vscode.window.showInformationMessage(vscode.l10n.t(`Members download complete.`), vscode.l10n.t(`Members download complete.`))
-                .then(open => open ? vscode.commands.executeCommand('revealFileInOS', saveIntoDirectory ? vscode.Uri.joinPath(downloadLocationURI, toBeDownloaded[0].name) : downloadLocationURI) : undefined);
+              vscode.window.showInformationMessage(vscode.l10n.t(`Members download complete.`), vscode.l10n.t(`Open`))
+                .then(open => open ? vscode.commands.executeCommand('revealFileInOS', saveIntoDirectory ? vscode.Uri.joinPath(downloadLocationURI, toBeDownloaded[0].name.toLocaleLowerCase()) : downloadLocationURI) : undefined);
             });
           } catch (e: any) {
             vscode.window.showErrorMessage(vscode.l10n.t(`Error downloading member(s)! {0}`, e));
@@ -965,7 +965,7 @@ Do you want to replace it?`, item.name), skipAllLabel, overwriteLabel, overwrite
 
           const quickPick = vscode.window.createQuickPick();
           quickPick.items = list.length > 0 ? listHeader.concat(list.map(term => ({ label: term }))).concat(clearListArray) : [];
-          quickPick.placeholder = list.length > 0 ? vscode.l10n.t(`Enter search term or select one of the previous search terms.`) : vscode.l10n.t(`Enter search term or select one of the previous search terms.`);
+          quickPick.placeholder = list.length > 0 ? vscode.l10n.t(`Enter search term or select one of the previous search terms.`) : vscode.l10n.t(`Enter search term.`);
           quickPick.title = vscode.l10n.t(`Search {0} {1}`, parameters.path, aspText);
 
           quickPick.onDidChangeValue(() => {
@@ -1041,7 +1041,7 @@ Do you want to replace it?`, item.name), skipAllLabel, overwriteLabel, overwrite
         const autoRefresh = objectBrowser.autoRefresh();
 
         // Add to library list ?
-        await vscode.window.showInformationMessage(vscode.l10n.t(`Would you like to add the new library to the library list?`), vscode.l10n.t(`Yes`), vscode.l10n.t(`No`))
+        await vscode.window.showInformationMessage(vscode.l10n.t(`Would you like to add the new library to the library list?`), vscode.l10n.t(`Yes`))
           .then(async result => {
             switch (result) {
               case vscode.l10n.t(`Yes`):
@@ -1249,7 +1249,7 @@ Do you want to replace it?`, item.name), skipAllLabel, overwriteLabel, overwrite
 
       const toBeDeleted = candidates.filter(item => item instanceof ObjectBrowserFilterItem || !item.isProtected());
       if (toBeDeleted.length) {
-        const message = toBeDeleted.length === 1 ? vscode.l10n.t(`Are you sure you want to delete {0}?`, toBeDeleted[0].toString()) : vscode.l10n.t(`Are you sure you want to delete {0}?`, toBeDeleted[0].toString());
+        const message = toBeDeleted.length === 1 ? vscode.l10n.t(`Are you sure you want to delete {0}?`, toBeDeleted[0].toString()) : vscode.l10n.t("Are you sure you want to delete these {0} elements?", toBeDeleted.length);
         const detail = toBeDeleted.length === 1 ? undefined : toBeDeleted.map(item => `- ${item.toString()}`).join("\n");
         if (await vscode.window.showWarningMessage(message, { modal: true, detail }, vscode.l10n.t(`Yes`))) {
           const increment = 100 / toBeDeleted.length;

--- a/src/webviews/actions/index.ts
+++ b/src/webviews/actions/index.ts
@@ -165,7 +165,7 @@ export namespace ActionsUI {
             } as Tab)), getDefaultTabIndex(currentAction.type)
         )
         .addHorizontalRule()
-        .addInput(`extensions`, vscode.l10n.t(`Extensions`), vscode.l10n.t(`Extensions`), { default: currentAction.extensions?.join(`, `) })
+        .addInput(`extensions`, vscode.l10n.t(`Extensions`), vscode.l10n.t(`A comma delimited list of extensions for this action. This can be a member extension, a streamfile extension, an object type or an object attribute`), { default: currentAction.extensions?.join(`, `) })
         .addSelect(`type`, vscode.l10n.t(`Type`), [
           {
             selected: currentAction.type === `member`,
@@ -238,7 +238,7 @@ export namespace ActionsUI {
             text: vscode.l10n.t(`The entire browser is refreshed`)
           }], vscode.l10n.t(`The browser level to refresh after the action is done`)
         )        
-        .addCheckbox("runOnProtected", vscode.l10n.t(`Run on protected/read only`), vscode.l10n.t(`Run on protected/read only`), currentAction.runOnProtected)
+        .addCheckbox("runOnProtected", vscode.l10n.t(`Run on protected/read only`), vscode.l10n.t(`Allows the execution of this Action on protected or read-only targets`), currentAction.runOnProtected)
         .addHorizontalRule()
         .addButtons(
           { id: `saveAction`, label: vscode.l10n.t(`Save`) },
@@ -253,7 +253,7 @@ export namespace ActionsUI {
           switch (data.buttons) {
             case `deleteAction`:
               const yes = vscode.l10n.t(`Yes`);
-              const result = await vscode.window.showInformationMessage(vscode.l10n.t(`Are you sure you want to delete the action "{0}"?`, currentAction.name), { modal: true }, yes, vscode.l10n.t(`Are you sure you want to delete the action "{0}"?`, currentAction.name))
+              const result = await vscode.window.showInformationMessage(vscode.l10n.t(`Are you sure you want to delete the action "{0}"?`, currentAction.name), { modal: true }, yes, vscode.l10n.t("No"))
               if (result === yes) {
                 allActions.splice(id, 1);
                 await saveActions(allActions);

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -32,7 +32,7 @@ export class Login {
       .addParagraph(l10n.t(`Only provide either the password or a private key - not both.`))
       .addPassword(`password`, l10n.t(`Password`))
       .addCheckbox(`savePassword`, l10n.t(`Save Password`))
-      .addFile(`privateKeyPath`, l10n.t(`Private Key`), l10n.t(`Private Key`));
+      .addFile(`privateKeyPath`, l10n.t(`Private Key`), l10n.t(`OpenSSH, RFC4716, or PPK formats are supported.`));
 
     const tempTab = new Section()
       .addInput(`tempLibrary`, `Temporary library`, `Temporary library. Cannot be QTEMP.`, { default: `ILEDITOR`, minlength: 1, maxlength: 10 })


### PR DESCRIPTION
### Changes
Some messages were placed incorrectly, because of mistakes made after the `vscode.l10n` migration.
This PR fixes this.

It also fixes the `Open` action on the notification shown after downloading a physical source file. The action would run on Windows but not on *nix OSes, because of the file system's case sensitivity.

### How to test this PR
**Only on Linux/Mac os**
1. Download a physical source file
2. Click on the `Open` action in the `Download complete` notification
3. The download location must open

### Checklist
* [x] have tested my change