### PR TITLE
Build workspace watcher only once

### DIFF
--- a/src/api/local/deployment.ts
+++ b/src/api/local/deployment.ts
@@ -42,7 +42,7 @@ export namespace Deployment {
 
     const workspaces = vscode.workspace.workspaceFolders;
     if (workspaces && workspaces.length > 0) {
-      buildWatcher().then(bw => context.subscriptions.push(bw));
+      buildWatcher().then(context.subscriptions.push);
     }
 
     instance.subscribe(
@@ -57,7 +57,6 @@ export namespace Deployment {
 
         if (workspaces && connection && storage && config) {
           if (workspaces.length > 0) {
-            buildWatcher().then(bw => context.subscriptions.push(bw));
             button.show();
           }
 


### PR DESCRIPTION
### Changes
A new workspace watcher (used to track changes to be deployed) was created each time a connection was established.
This Pr makes sure only one watcher is created when the extension starts.

### How to test this PR
1. Open a local workspace
2. Make some changes in the local files
3. Deploy using the `Changed` method and check the correct number of files have been tracked

### Checklist
* [x] have tested my change