### PR TITLE
Fix: Remove hard coded path to attr

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -965,7 +965,7 @@ export default class IBMiContent {
       result = await this.ibmi.sendQsh({ command: `${this.ibmi.remoteFeatures.attr} -p ${target} ${operands.join(" ")}`});
     } else {
       // Take {DOES_THIS_WORK: `YESITDOES`} away, and all of a sudden names with # aren't found.
-      result = await this.ibmi.sendCommand({ command: `/QOpenSys/${this.ibmi.remoteFeatures.attr} -p ${target} ${operands.join(" ")}`, env: {DOES_THIS_WORK: `YESITDOES`}});
+      result = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.attr} -p ${target} ${operands.join(" ")}`, env: {DOES_THIS_WORK: `YESITDOES`}});
     }
 
     if (result.code === 0) {


### PR DESCRIPTION
Noticed in #2370 that the path was hardcoded. This PR removed the hard coded path and uses the default `attr` path found in the connection startup.

Test cases are still passing.

<img width="417" alt="image" src="https://github.com/user-attachments/assets/cd428860-78f3-44b3-b8c4-d64b558de63c">
