### PR TITLE
Add support for different shell export syntax in sendCommand method

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -1167,7 +1167,12 @@ export default class IBMi {
   async sendCommand(options: CommandData): Promise<CommandResult> {
     let commands: string[] = [];
     if (options.env) {
-      commands.push(...Object.entries(options.env).map(([key, value]) => `export ${key}="${value ? IBMi.escapeForShell(value) : ``}"`));
+      if (this.usingBash()) {
+        commands.push(...Object.entries(options.env).map(([key, value]) => `export ${key}="${value ? IBMi.escapeForShell(value) : ``}"`));
+      } else {
+        // bourne shell doesn't support the same export syntax as bash
+        commands.push(...Object.entries(options.env).map(([key, value]) => `${key}="${value ? IBMi.escapeForShell(value) : ``}" export ${key}`));
+      }
     }
 
     commands.push(options.command);


### PR DESCRIPTION
Introduce support for varying export syntax based on the shell type in the sendCommand method, accommodating both Bash and Bourne shell conventions.

https://unix.stackexchange.com/a/193137

Run this SQL statement to change your shell: `call qsys2.set_pase_shell_info('USERNAME', '/QOpenSys/usr/bin/bsh')`, then restart your connection.

Tests that use `getAttributes` are passing.

Will fix #2370.