### PR TITLE
Enhance date formatting and improve test coverage

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -993,8 +993,8 @@ export default class IBMiContent {
       "Attribute": object.attribute,
       "Text": object.text,
       "Size": object.size,
-      "Created": object.created?.toISOString().slice(0, 19).replace(`T`, ` `),
-      "Changed": object.changed?.toISOString().slice(0, 19).replace(`T`, ` `),
+      "Created": safeIsoValue(object.created),
+      "Changed": safeIsoValue(object.changed),
       "Created by": object.created_by,
       "Owner": object.owner,
       "IASP": object.asp
@@ -1019,8 +1019,8 @@ export default class IBMiContent {
     const tooltip = new MarkdownString(Tools.generateTooltipHtmlTable(path, {
       "Text": member.text,
       "Lines": member.lines,
-      "Created": member.created?.toISOString().slice(0, 19).replace(`T`, ` `),
-      "Changed": member.changed?.toISOString().slice(0, 19).replace(`T`, ` `)
+      "Created": safeIsoValue(member.created),
+      "Changed": safeIsoValue(member.changed)
     }));
     tooltip.supportHtml = true;
     return tooltip;
@@ -1029,7 +1029,7 @@ export default class IBMiContent {
   ifsFileToToolTip(path: string, ifsFile: IFSFile) {
     const tooltip = new MarkdownString(Tools.generateTooltipHtmlTable(path, {
       "Size": ifsFile.size,
-      "Modified": ifsFile.modified ? new Date(ifsFile.modified.getTime() - ifsFile.modified.getTimezoneOffset() * 60 * 1000).toISOString().slice(0, 19).replace(`T`, ` `) : ``,
+      "Modified": ifsFile.modified ? safeIsoValue(new Date(ifsFile.modified.getTime() - ifsFile.modified.getTimezoneOffset() * 60 * 1000)) : ``,
       "Owner": ifsFile.owner ? ifsFile.owner.toUpperCase() : ``
     }));
     tooltip.supportHtml = true;
@@ -1047,5 +1047,13 @@ export default class IBMiContent {
     if (result.code !== 0) {
       throw new Error(result.stderr);
     }
+  }
+}
+
+function safeIsoValue(date: Date|undefined) {
+  try {
+    return date ? date.toISOString().slice(0, 19).replace(`T`, ` `) : ``;
+  } catch (e) {
+    return `Unknown`;
   }
 }

--- a/src/testing/encoding.ts
+++ b/src/testing/encoding.ts
@@ -250,7 +250,7 @@ export const EncodingSuite: TestSuite = {
 
           commands.push(`CRTSRCPF FILE(${library}/${sourceFile}) RCDLEN(112) CCSID(${ccsid})`);
           for (const member of members) {
-            commands.push(`ADDPFM FILE(${library}/${sourceFile}) MBR(${member}) SRCTYPE(TXT)`);
+            commands.push(`ADDPFM FILE(${library}/${sourceFile}) MBR(${member}) SRCTYPE(TXT) TEXT('Test ${member}')`);
           }
 
           commands.push(`CRTDTAARA DTAARA(${library}/${dataArea}) TYPE(*CHAR) LEN(50) VALUE('hi')`);
@@ -289,7 +289,7 @@ export const EncodingSuite: TestSuite = {
 
           const expectedMembers = await content.getMemberList({ library, sourceFile });
           assert.ok(expectedMembers);
-          assert.ok(expectedMembers.every(member => members.find(m => m === member.name)));
+          assert.ok(expectedMembers.every(member => members.find(m => m === member.name && member.text?.includes(m))));
 
           const sourceFilter = await content.getObjectList({ library, types: ["*SRCPF"], object: `${connection.variantChars.local[0]}*` });
           assert.strictEqual(sourceFilter.length, 1);


### PR DESCRIPTION
Refactor date formatting to utilize the `safeIsoValue` function for better consistency and error handling. Add additional test cases to verify member text functionality. Will solve 'Invalid time value' error.

* The test cases for `getMemberList` are passing
* IFS Browser and Object Browser still functioning.

<img width="498" alt="image" src="https://github.com/user-attachments/assets/c8f05723-a3d8-447d-8327-3d787c43f5a6">