### PR TITLE
Refactor IBMiComponent for easier export

### DIFF
--- a/src/components/component.ts
+++ b/src/components/component.ts
@@ -34,10 +34,10 @@ export type IBMiComponentType<T extends IBMiComponent> = new (c: IBMi) => T;
  */
 export abstract class IBMiComponent {
   public static readonly InstallDirectory = `$HOME/.vscode/`;
-  private state: ComponentState = `NotChecked`;
-  private cachedInstallDirectory: string | undefined;
+  state: ComponentState = `NotChecked`;
+  cachedInstallDirectory: string | undefined;
 
-  constructor(protected readonly connection: IBMi) {
+  constructor(readonly connection: IBMi) {
 
   }
 
@@ -53,11 +53,11 @@ export abstract class IBMiComponent {
     return this.cachedInstallDirectory;
   }
 
-  getState() {
+  getState(): ComponentState {
     return this.state;
   }
 
-  async check() {
+  async check(): Promise<ComponentState> {
     try {
       this.state = await this.getRemoteState();
       if (this.state !== `Installed`) {
@@ -70,7 +70,7 @@ export abstract class IBMiComponent {
       this.state = `Error`;
     }
 
-    return this;
+    return this.state;
   }
 
   toString() {
@@ -88,7 +88,7 @@ export abstract class IBMiComponent {
   /**
    * @returns the component's {@link ComponentState state} on the IBM i
    */
-  protected abstract getRemoteState(): ComponentState | Promise<ComponentState>;
+  abstract getRemoteState(): ComponentState | Promise<ComponentState>;
 
   /**
    * Called whenever the components needs to be installed or updated, depending on its {@link ComponentState state}.
@@ -97,5 +97,5 @@ export abstract class IBMiComponent {
    * 
    * @returns the component's {@link ComponentState state} after the update is done
    */
-  protected abstract update(): ComponentState | Promise<ComponentState>
+  abstract update(): ComponentState | Promise<ComponentState>
 }

--- a/src/components/copyToImport.ts
+++ b/src/components/copyToImport.ts
@@ -17,11 +17,11 @@ export class CopyToImport extends IBMiComponent {
     return { name: 'CopyToImport', version: 1 };
   }
 
-  protected getRemoteState(): ComponentState {
+  getRemoteState(): ComponentState {
     return `Installed`;
   }
 
-  protected update(): ComponentState | Promise<ComponentState> {
+  update(): ComponentState | Promise<ComponentState> {
     return this.getRemoteState();
   }
 

--- a/src/components/cqsh/index.ts
+++ b/src/components/cqsh/index.ts
@@ -19,7 +19,7 @@ export class cqsh extends IBMiComponent {
     return path.posix.join(installDir, this.getFileName());
   }
 
-  protected async getRemoteState(): Promise<ComponentState> {
+  async getRemoteState(): Promise<ComponentState> {
     const remotePath = await this.getPath();
     const result = await this.connection.content.testStreamFile(remotePath, "x");
 
@@ -36,7 +36,7 @@ export class cqsh extends IBMiComponent {
     return `Installed`;
   }
 
-  protected async update(): Promise<ComponentState> {
+  async update(): Promise<ComponentState> {
     const extensionPath = extensions.getExtension(`halcyontechltd.code-for-ibmi`)!.extensionPath;
     const remotePath = await this.getPath();
 

--- a/src/components/getMemberInfo.ts
+++ b/src/components/getMemberInfo.ts
@@ -12,7 +12,7 @@ export class GetMemberInfo extends IBMiComponent {
     return { name: 'GetMemberInfo', version: this.installedVersion };
   }
 
-  protected async getRemoteState(): Promise<ComponentState> {
+  async getRemoteState(): Promise<ComponentState> {
     const [result] = await this.connection.runSQL(`select LONG_COMMENT from qsys2.sysroutines where routine_schema = '${this.connection.config?.tempLibrary.toUpperCase()}' and routine_name = '${this.procedureName}'`);
     if (result.LONG_COMMENT) {
       const comment = result.LONG_COMMENT as string;
@@ -28,7 +28,7 @@ export class GetMemberInfo extends IBMiComponent {
     return `Installed`;
   }
 
-  protected async update(): Promise<ComponentState> {
+  async update(): Promise<ComponentState> {
     const config = this.connection.config!;
     return this.connection.withTempDirectory(async tempDir => {
       const tempSourcePath = posix.join(tempDir, `getMemberInfo.sql`);

--- a/src/components/getNewLibl.ts
+++ b/src/components/getNewLibl.ts
@@ -7,11 +7,11 @@ export class GetNewLibl extends IBMiComponent {
     return { name: 'GetNewLibl', version: 1 };
   }
 
-  protected async getRemoteState(): Promise<ComponentState> {
+  async getRemoteState(): Promise<ComponentState> {
     return this.connection.remoteFeatures[`GETNEWLIBL.PGM`] ? `Installed` : `NotInstalled`;
   }
 
-  protected update(): Promise<ComponentState> {
+  update(): Promise<ComponentState> {
     const config = this.connection.config!
     const content = instance.getContent();
     return this.connection.withTempDirectory(async (tempDir): Promise<ComponentState> => {

--- a/src/components/manager.ts
+++ b/src/components/manager.ts
@@ -43,7 +43,9 @@ export class ComponentManager {
   public async startup() {
     const components = Array.from(extensionComponentRegistry.getComponents().values()).flatMap(a => a.flat());
     for (const Component of components) {
-      this.registered.set(Component, await new Component(this.connection).check());
+      const comp: IBMiComponent = await new Component(this.connection);
+      await comp.check();
+      this.registered.set(Component, comp);
     }
   }
 


### PR DESCRIPTION
Refactor methods in the IBMiComponent class to improve export functionality. This includes changing access modifiers and return types for better clarity and consistency.

It also enables `IBMiComponent` to be implemented, and not only extended. This is particularly important for other extensions, so they can add their own components.

```ts
  class a implements IBMiComponent {
    state: ComponentState = `NotChecked`;
    cachedInstallDirectory: string | undefined;
    constructor(readonly connection: IBMi) {}
    async getInstallDirectory(): Promise<string> {
      return `BOOP`;
    }
    getState(): ComponentState {
      return `NotInstalled`;
    }
    async check(): Promise<ComponentState> {
      return `NotInstalled`;
    }
    toString(): string {
      throw new Error("Method not implemented.");
    }
    getIdentification(): ComponentIdentification {
      return {name: `test`, version: 1};
    }
    getRemoteState(): ComponentState | Promise<ComponentState> {
      throw new Error("Method not implemented.");
    }
    async update(): Promise<ComponentState> {
      return `Installed`;
    }
  }
  
  extensionComponentRegistry.registerComponent(context, a);
```