### PR TITLE
Deprecate legacy APIs and update references

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -1240,6 +1240,8 @@ export default class IBMi {
       this.client.connection?.removeAllListeners();
       this.client.dispose();
       this.client.connection = null;
+
+      instance.fire(`disconnected`);
     }
   }
 
@@ -1254,8 +1256,6 @@ export default class IBMi {
     if (this.outputChannelContent !== undefined) {
       this.outputChannelContent = undefined;
     }
-
-    instance.fire(`disconnected`);
   }
 
   /**

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -23,9 +23,10 @@ export interface MemberParts extends IBMiMember {
   basename: string
 }
 
-const CCSID_NOCONVERSION = 65535;
-const CCSID_SYSVAL = -2;
-const bashShellPath = '/QOpenSys/pkgs/bin/bash';
+export interface ConnectionResult {
+  success: boolean,
+  error?: string
+}
 
 const remoteApps = [ // All names MUST also be defined as key in 'remoteFeatures' below!!
   {
@@ -52,24 +53,37 @@ const remoteApps = [ // All names MUST also be defined as key in 'remoteFeatures
 ];
 
 export default class IBMi {
+  static readonly CCSID_NOCONVERSION = 65535;
+  static readonly CCSID_SYSVAL = -2;
+  static readonly bashShellPath = '/QOpenSys/pkgs/bin/bash';
+
   private systemVersion: number = 0;
-  private qccsid: number = CCSID_NOCONVERSION;
-  private userJobCcsid: number = CCSID_SYSVAL;
+  private qccsid: number = IBMi.CCSID_NOCONVERSION;
+  private userJobCcsid: number = IBMi.CCSID_SYSVAL;
   /** User default CCSID is job default CCSID */
   private userDefaultCCSID: number = 0;
   private sshdCcsid: number | undefined;
 
   private componentManager = new ComponentManager(this);
 
+  /**
+   * @deprecated Will become private in v3.0.0 - use {@link IBMi.getConfig} instead.
+   */
+  config?: ConnectionConfiguration.Parameters;
+  /**
+   * @deprecated Will become private in v3.0.0 - use {@link IBMi.getContent} instead.
+   */
+  content = new IBMiContent(this);
+
   client: node_ssh.NodeSSH;
   currentHost: string = ``;
   currentPort: number = 22;
   currentUser: string = ``;
   currentConnectionName: string = ``;
-  tempRemoteFiles: { [name: string]: string } = {};
+  private tempRemoteFiles: { [name: string]: string } = {};
   defaultUserLibraries: string[] = [];
-  outputChannel?: vscode.OutputChannel;
-  outputChannelContent?: string;
+  private outputChannel?: vscode.OutputChannel;
+  private outputChannelContent?: string;
   /**
    * Used to store ASP numbers and their names
    * Their names usually maps up to a directory in
@@ -84,16 +98,9 @@ export default class IBMi {
     qsysNameRegex?: RegExp
   };
 
-  /** 
-   * Strictly for storing errors from sendCommand.
-   * Used when creating issues on GitHub.
-   * */
-  lastErrors: object[] = [];
-  config?: ConnectionConfiguration.Parameters;
-  content = new IBMiContent(this);
   shell?: string;
 
-  commandsExecuted = 0;
+  private commandsExecuted = 0;
 
   //Maximum admited length for command's argument - any command whose arguments are longer than this won't be executed by the shell
   maximumArgsLength = 0;
@@ -106,7 +113,7 @@ export default class IBMi {
    * Primarily used for running SQL statements.
    */
   get userCcsidInvalid() {
-    return this.userJobCcsid === CCSID_NOCONVERSION;
+    return this.userJobCcsid === IBMi.CCSID_NOCONVERSION;
   }
 
   /**
@@ -125,6 +132,30 @@ export default class IBMi {
   get dangerousVariants() {
     return this.variantChars.local !== this.variantChars.local.toLocaleUpperCase();
   };
+
+  get connected(): boolean {
+    return this.client ? this.client.isConnected() : false;
+  }
+
+  getContent() {
+    return this.content;
+  }
+
+  getConfig() {
+    if (this.connected && this.config) {
+      return this.config!;
+    } else {
+      throw new Error(`Not connected to IBM i.`);
+    }
+  }
+
+  setConfig(newConfig: ConnectionConfiguration.Parameters) {
+    this.config = newConfig;
+  }
+
+  getOutputChannelContent() {
+    return this.outputChannelContent;
+  }
 
   constructor() {
     this.client = new node_ssh.NodeSSH;
@@ -164,951 +195,929 @@ export default class IBMi {
   /**
    * @returns {Promise<{success: boolean, error?: any}>} Was succesful at connecting or not.
    */
-  async connect(connectionObject: ConnectionData, reconnecting?: boolean, reloadServerSettings: boolean = false, onConnectedOperations: Function[] = []): Promise<{ success: boolean, error?: any }> {
+  async connect(connectionObject: ConnectionData, reconnecting?: boolean, reloadServerSettings: boolean = false, onConnectedOperations: Function[] = [], timeoutCallback?: () => Promise<void>): Promise<ConnectionResult> {
     const currentExtensionVersion = process.env.VSCODEIBMI_VERSION;
-    return await Tools.withContext("code-for-ibmi:connecting", async () => {
-      try {
-        connectionObject.keepaliveInterval = 35000;
+    try {
+      connectionObject.keepaliveInterval = 35000;
 
-        configVars.replaceAll(connectionObject);
+      configVars.replaceAll(connectionObject);
 
-        return await vscode.window.withProgress({
-          location: vscode.ProgressLocation.Notification,
-          title: `Connecting`,
-          cancellable: true
-        }, async (progress, cancelToken) => {
-          progress.report({
-            message: `Connecting via SSH.`
-          });
-          const delayedOperations: Function[] = [...onConnectedOperations];
+      return await vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: `Connecting`,
+        cancellable: true
+      }, async (progress, cancelToken) => {
+        progress.report({
+          message: `Connecting via SSH.`
+        });
+        const delayedOperations: Function[] = [...onConnectedOperations];
 
-          await this.client.connect(connectionObject as node_ssh.Config);
+        await this.client.connect(connectionObject as node_ssh.Config);
 
-          cancelToken.onCancellationRequested(() => {
-            this.end();
-          });
+        cancelToken.onCancellationRequested(() => {
+          this.dispose();
+        });
 
-          this.currentConnectionName = connectionObject.name;
-          this.currentHost = connectionObject.host;
-          this.currentPort = connectionObject.port;
-          this.currentUser = connectionObject.username;
+        this.currentConnectionName = connectionObject.name;
+        this.currentHost = connectionObject.host;
+        this.currentPort = connectionObject.port;
+        this.currentUser = connectionObject.username;
 
-          if (!reconnecting) {
-            this.outputChannel = vscode.window.createOutputChannel(`Code for IBM i: ${this.currentConnectionName}`);
-            this.outputChannelContent = '';
-            this.appendOutput(`Code for IBM i, version ${currentExtensionVersion}\n\n`);
+        if (!reconnecting) {
+          this.outputChannel = vscode.window.createOutputChannel(`Code for IBM i: ${this.currentConnectionName}`);
+          this.outputChannelContent = '';
+          this.appendOutput(`Code for IBM i, version ${currentExtensionVersion}\n\n`);
+        }
+
+        let tempLibrarySet = false;
+
+        progress.report({
+          message: `Loading configuration.`
+        });
+
+        //Load existing config
+        this.config = await ConnectionConfiguration.load(this.currentConnectionName);
+
+        // Load cached server settings.
+        const cachedServerSettings: CachedServerSettings = GlobalStorage.get().getServerSettingsCache(this.currentConnectionName);
+
+        // Reload server settings?
+        const quickConnect = () => {
+          return (this.config!.quickConnect === true && reloadServerSettings === false);
+        }
+
+        // Check shell output for additional user text - this will confuse Code...
+        progress.report({
+          message: `Checking shell output.`
+        });
+
+        const checkShellText = `This should be the only text!`;
+        const checkShellResult = await this.sendCommand({
+          command: `echo "${checkShellText}"`,
+          directory: `.`
+        });
+        if (checkShellResult.stdout.split(`\n`)[0] !== checkShellText) {
+          const chosen = await vscode.window.showErrorMessage(`Error in shell configuration!`, {
+            detail: [
+              `This extension can not work with the shell configured on ${this.currentConnectionName},`,
+              `since the output from shell commands have additional content.`,
+              `This can be caused by running commands like "echo" or other`,
+              `commands creating output in your shell start script.`, ``,
+              `The connection to ${this.currentConnectionName} will be aborted.`
+            ].join(`\n`),
+            modal: true
+          }, `Read more`);
+
+          if (chosen === `Read more`) {
+            vscode.commands.executeCommand(`vscode.open`, `https://codefori.github.io/docs/#/pages/tips/setup`);
           }
 
-          let tempLibrarySet = false;
+          throw (`Shell config error, connection aborted.`);
+        }
 
-          const timeoutHandler = async () => {
+        if (timeoutCallback) {
+          const timeoutCallbackWrapper = () => {
+            // Don't call the callback function if it was based on a user cancellation request.
             if (!cancelToken.isCancellationRequested) {
-              this.disconnect();
-
-              const choice = await vscode.window.showWarningMessage(`Connection lost`, {
-                modal: true,
-                detail: `Connection to ${this.currentConnectionName} has dropped. Would you like to reconnect?`
-              }, `Yes`);
-
-              let disconnect = true;
-              if (choice === `Yes`) {
-                disconnect = !(await this.connect(connectionObject, true)).success;
-              }
-
-              if (disconnect) {
-                this.end();
-              };
+              timeoutCallback();
             }
-          };
-
-          progress.report({
-            message: `Loading configuration.`
-          });
-
-          //Load existing config
-          this.config = await ConnectionConfiguration.load(this.currentConnectionName);
-
-          // Load cached server settings.
-          const cachedServerSettings: CachedServerSettings = GlobalStorage.get().getServerSettingsCache(this.currentConnectionName);
-
-          // Reload server settings?
-          const quickConnect = () => {
-            return (this.config!.quickConnect === true && reloadServerSettings === false);
-          }
-
-          // Check shell output for additional user text - this will confuse Code...
-          progress.report({
-            message: `Checking shell output.`
-          });
-
-          const checkShellText = `This should be the only text!`;
-          const checkShellResult = await this.sendCommand({
-            command: `echo "${checkShellText}"`,
-            directory: `.`
-          });
-          if (checkShellResult.stdout.split(`\n`)[0] !== checkShellText) {
-            const chosen = await vscode.window.showErrorMessage(`Error in shell configuration!`, {
-              detail: [
-                `This extension can not work with the shell configured on ${this.currentConnectionName},`,
-                `since the output from shell commands have additional content.`,
-                `This can be caused by running commands like "echo" or other`,
-                `commands creating output in your shell start script.`, ``,
-                `The connection to ${this.currentConnectionName} will be aborted.`
-              ].join(`\n`),
-              modal: true
-            }, `Read more`);
-
-            if (chosen === `Read more`) {
-              vscode.commands.executeCommand(`vscode.open`, `https://codefori.github.io/docs/#/pages/tips/setup`);
-            }
-
-            throw (`Shell config error, connection aborted.`);
           }
 
           // Register handlers after we might have to abort due to bad configuration.
-          this.client.connection!.once(`timeout`, timeoutHandler);
-          this.client.connection!.once(`end`, timeoutHandler);
-          this.client.connection!.once(`error`, timeoutHandler);
+          this.client.connection!.once(`timeout`, timeoutCallbackWrapper);
+          this.client.connection!.once(`end`, timeoutCallbackWrapper);
+          this.client.connection!.once(`error`, timeoutCallbackWrapper);
+        }
 
-          if (!reconnecting) {
-            instance.setConnection(this);
-          }
+        progress.report({
+          message: `Checking home directory.`
+        });
 
-          progress.report({
-            message: `Checking home directory.`
-          });
+        let defaultHomeDir;
 
-          let defaultHomeDir;
+        const echoHomeResult = await this.sendCommand({
+          command: `echo $HOME && cd && test -w $HOME`,
+          directory: `.`
+        });
+        // Note: if the home directory does not exist, the behavior of the echo/cd/test command combo is as follows:
+        //   - stderr contains 'Could not chdir to home directory /home/________: No such file or directory'
+        //       (The output contains 'chdir' regardless of locale and shell, so maybe we could use that
+        //        if we iterate on this code again in the future)
+        //   - stdout contains the name of the home directory (even if it does not exist)
+        //   - The 'cd' command causes an error if the home directory does not exist or otherwise can't be cd'ed into
+        //   - The 'test' command causes an error if the home directory is not writable (one can cd into a non-writable directory)
+        let isHomeUsable = (0 == echoHomeResult.code);
+        if (isHomeUsable) {
+          defaultHomeDir = echoHomeResult.stdout.trim();
+        } else {
+          // Let's try to provide more valuable information to the user about why their home directory
+          // is bad and maybe even provide the opportunity to create the home directory
 
-          const echoHomeResult = await this.sendCommand({
-            command: `echo $HOME && cd && test -w $HOME`,
-            directory: `.`
-          });
-          // Note: if the home directory does not exist, the behavior of the echo/cd/test command combo is as follows:
-          //   - stderr contains 'Could not chdir to home directory /home/________: No such file or directory'
-          //       (The output contains 'chdir' regardless of locale and shell, so maybe we could use that
-          //        if we iterate on this code again in the future)
-          //   - stdout contains the name of the home directory (even if it does not exist)
-          //   - The 'cd' command causes an error if the home directory does not exist or otherwise can't be cd'ed into
-          //   - The 'test' command causes an error if the home directory is not writable (one can cd into a non-writable directory)
-          let isHomeUsable = (0 == echoHomeResult.code);
-          if (isHomeUsable) {
-            defaultHomeDir = echoHomeResult.stdout.trim();
-          } else {
-            // Let's try to provide more valuable information to the user about why their home directory
-            // is bad and maybe even provide the opportunity to create the home directory
+          let actualHomeDir = echoHomeResult.stdout.trim();
 
-            let actualHomeDir = echoHomeResult.stdout.trim();
-
-            // we _could_ just assume the home directory doesn't exist but maybe there's something more going on, namely mucked-up permissions
-            let doesHomeExist = (0 === (await this.sendCommand({ command: `test -e ${actualHomeDir}` })).code);
-            if (doesHomeExist) {
-              // Note: this logic might look backward because we fall into this (failure) leg on what looks like success (home dir exists).
-              //       But, remember, but we only got here if 'cd $HOME' failed.
-              //       Let's try to figure out why....
-              if (0 !== (await this.sendCommand({ command: `test -d ${actualHomeDir}` })).code) {
-                await vscode.window.showWarningMessage(`Your home directory (${actualHomeDir}) is not a directory! Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: !reconnecting });
-              }
-              else if (0 !== (await this.sendCommand({ command: `test -w ${actualHomeDir}` })).code) {
-                await vscode.window.showWarningMessage(`Your home directory (${actualHomeDir}) is not writable! Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: !reconnecting });
-              }
-              else if (0 !== (await this.sendCommand({ command: `test -x ${actualHomeDir}` })).code) {
-                await vscode.window.showWarningMessage(`Your home directory (${actualHomeDir}) is not usable due to permissions! Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: !reconnecting });
-              }
-              else {
-                // not sure, but get your sys admin involved
-                await vscode.window.showWarningMessage(`Your home directory (${actualHomeDir}) exists but is unusable. Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: !reconnecting });
-              }
+          // we _could_ just assume the home directory doesn't exist but maybe there's something more going on, namely mucked-up permissions
+          let doesHomeExist = (0 === (await this.sendCommand({ command: `test -e ${actualHomeDir}` })).code);
+          if (doesHomeExist) {
+            // Note: this logic might look backward because we fall into this (failure) leg on what looks like success (home dir exists).
+            //       But, remember, but we only got here if 'cd $HOME' failed.
+            //       Let's try to figure out why....
+            if (0 !== (await this.sendCommand({ command: `test -d ${actualHomeDir}` })).code) {
+              await vscode.window.showWarningMessage(`Your home directory (${actualHomeDir}) is not a directory! Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: !reconnecting });
             }
-            else if (reconnecting) {
-              vscode.window.showWarningMessage(`Your home directory (${actualHomeDir}) does not exist. Code for IBM i may not function correctly.`, { modal: false });
+            else if (0 !== (await this.sendCommand({ command: `test -w ${actualHomeDir}` })).code) {
+              await vscode.window.showWarningMessage(`Your home directory (${actualHomeDir}) is not writable! Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: !reconnecting });
             }
-            else if (await vscode.window.showWarningMessage(`Home directory does not exist`, {
-              modal: true,
-              detail: `Your home directory (${actualHomeDir}) does not exist, so Code for IBM i may not function correctly. Would you like to create this directory now?`,
-            }, `Yes`)) {
-              this.appendOutput(`creating home directory ${actualHomeDir}`);
-              let mkHomeCmd = `mkdir -p ${actualHomeDir} && chown ${connectionObject.username.toLowerCase()} ${actualHomeDir} && chmod 0755 ${actualHomeDir}`;
-              let mkHomeResult = await this.sendCommand({ command: mkHomeCmd, directory: `.` });
-              if (0 === mkHomeResult.code) {
-                defaultHomeDir = actualHomeDir;
-              } else {
-                let mkHomeErrs = mkHomeResult.stderr;
-                // We still get 'Could not chdir to home directory' in stderr so we need to hackily gut that out, as well as the bashisms that are a side effect of our API
-                mkHomeErrs = mkHomeErrs.substring(1 + mkHomeErrs.indexOf(`\n`)).replace(`bash: line 1: `, ``);
-                await vscode.window.showWarningMessage(`Error creating home directory (${actualHomeDir}):\n${mkHomeErrs}.\n\n Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: true });
-              }
+            else if (0 !== (await this.sendCommand({ command: `test -x ${actualHomeDir}` })).code) {
+              await vscode.window.showWarningMessage(`Your home directory (${actualHomeDir}) is not usable due to permissions! Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: !reconnecting });
+            }
+            else {
+              // not sure, but get your sys admin involved
+              await vscode.window.showWarningMessage(`Your home directory (${actualHomeDir}) exists but is unusable. Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: !reconnecting });
             }
           }
+          else if (reconnecting) {
+            vscode.window.showWarningMessage(`Your home directory (${actualHomeDir}) does not exist. Code for IBM i may not function correctly.`, { modal: false });
+          }
+          else if (await vscode.window.showWarningMessage(`Home directory does not exist`, {
+            modal: true,
+            detail: `Your home directory (${actualHomeDir}) does not exist, so Code for IBM i may not function correctly. Would you like to create this directory now?`,
+          }, `Yes`)) {
+            this.appendOutput(`creating home directory ${actualHomeDir}`);
+            let mkHomeCmd = `mkdir -p ${actualHomeDir} && chown ${connectionObject.username.toLowerCase()} ${actualHomeDir} && chmod 0755 ${actualHomeDir}`;
+            let mkHomeResult = await this.sendCommand({ command: mkHomeCmd, directory: `.` });
+            if (0 === mkHomeResult.code) {
+              defaultHomeDir = actualHomeDir;
+            } else {
+              let mkHomeErrs = mkHomeResult.stderr;
+              // We still get 'Could not chdir to home directory' in stderr so we need to hackily gut that out, as well as the bashisms that are a side effect of our API
+              mkHomeErrs = mkHomeErrs.substring(1 + mkHomeErrs.indexOf(`\n`)).replace(`bash: line 1: `, ``);
+              await vscode.window.showWarningMessage(`Error creating home directory (${actualHomeDir}):\n${mkHomeErrs}.\n\n Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: true });
+            }
+          }
+        }
 
-          // Check to see if we need to store a new value for the home directory
+        // Check to see if we need to store a new value for the home directory
+        if (defaultHomeDir) {
+          if (this.config.homeDirectory !== defaultHomeDir) {
+            this.config.homeDirectory = defaultHomeDir;
+            vscode.window.showInformationMessage(`Configured home directory reset to ${defaultHomeDir}.`);
+          }
+        } else {
+          // New connections always have `.` as the initial value.
+          // If we can't find a usable home directory, just reset it to
+          // the initial default.
+          this.config.homeDirectory = `.`;
+        }
+
+        //Set a default IFS listing
+        if (this.config.ifsShortcuts.length === 0) {
           if (defaultHomeDir) {
-            if (this.config.homeDirectory !== defaultHomeDir) {
-              this.config.homeDirectory = defaultHomeDir;
-              vscode.window.showInformationMessage(`Configured home directory reset to ${defaultHomeDir}.`);
-            }
+            this.config.ifsShortcuts = [this.config.homeDirectory];
           } else {
-            // New connections always have `.` as the initial value.
-            // If we can't find a usable home directory, just reset it to
-            // the initial default.
-            this.config.homeDirectory = `.`;
+            this.config.ifsShortcuts = [`/`];
           }
+        }
 
-          //Set a default IFS listing
-          if (this.config.ifsShortcuts.length === 0) {
-            if (defaultHomeDir) {
-              this.config.ifsShortcuts = [this.config.homeDirectory];
-            } else {
-              this.config.ifsShortcuts = [`/`];
-            }
-          }
+        // If the version has changed (by update for example), then fetch everything again
+        if (cachedServerSettings?.lastCheckedOnVersion !== currentExtensionVersion) {
+          reloadServerSettings = true;
+        }
 
-          // If the version has changed (by update for example), then fetch everything again
-          if (cachedServerSettings?.lastCheckedOnVersion !== currentExtensionVersion) {
-            reloadServerSettings = true;
-          }
-
-          // Check for installed components?
-          // For Quick Connect to work here, 'remoteFeatures' MUST have all features defined and no new properties may be added!
-          if (quickConnect() && cachedServerSettings?.remoteFeaturesKeys && cachedServerSettings.remoteFeaturesKeys === Object.keys(this.remoteFeatures).sort().toString()) {
-            Object.assign(this.remoteFeatures, cachedServerSettings.remoteFeatures);
-          } else {
-            progress.report({
-              message: `Checking installed components on host IBM i.`
-            });
-
-            // We need to check if our remote programs are installed.
-            remoteApps.push(
-              {
-                path: `/QSYS.lib/${this.upperCaseName(this.config.tempLibrary)}.lib/`,
-                names: [`GETNEWLIBL.PGM`],
-                specific: `GE*.PGM`
-              }
-            );
-
-            //Next, we see what pase features are available (installed via yum)
-            //This may enable certain features in the future.
-            for (const feature of remoteApps) {
-              try {
-                progress.report({
-                  message: `Checking installed components on host IBM i: ${feature.path}`
-                });
-
-                const call = await this.sendCommand({ command: `ls -p ${feature.path}${feature.specific || ``}` });
-                if (call.stdout) {
-                  const files = call.stdout.split(`\n`);
-
-                  if (feature.specific) {
-                    for (const name of feature.names)
-                      this.remoteFeatures[name] = files.find(file => file.includes(name));
-                  } else {
-                    for (const name of feature.names)
-                      if (files.includes(name))
-                        this.remoteFeatures[name] = feature.path + name;
-                  }
-                }
-              } catch (e) {
-                console.log(e);
-              }
-            }
-
-            //Specific Java installations check
-            progress.report({
-              message: `Checking installed components on host IBM i: Java`
-            });
-            const javaCheck = async (root: string) => await this.content.testStreamFile(`${root}/bin/java`, 'x') ? root : undefined;
-            this.remoteFeatures.jdk80 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit`);
-            this.remoteFeatures.jdk11 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk11/64bit`);
-            this.remoteFeatures.openjdk11 = await javaCheck(`/QOpensys/pkgs/lib/jvm/openjdk-11`);
-            this.remoteFeatures.jdk17 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk17/64bit`);
-          }
-
-          if (this.remoteFeatures.uname) {
-            progress.report({
-              message: `Checking OS version.`
-            });
-            const systemVersionResult = await this.sendCommand({ command: `${this.remoteFeatures.uname} -rv` });
-
-            if (systemVersionResult.code === 0) {
-              const version = systemVersionResult.stdout.trim().split(` `);
-              this.systemVersion = Number(`${version[1]}.${version[0]}`);
-            }
-          }
-
-          if (!this.systemVersion) {
-            vscode.window.showWarningMessage(`Unable to determine system version. Code for IBM i only supports 7.3 and above. Some features may not work correctly.`);
-          } else if (this.systemVersion < 7.3) {
-            vscode.window.showWarningMessage(`IBM i ${this.systemVersion} is not supported. Code for IBM i only supports 7.3 and above. Some features may not work correctly.`);
-          }
-
-          progress.report({ message: `Checking Code for IBM i components.` });
-          await this.componentManager.startup();
-
-          const componentStates = this.componentManager.getState();
-          this.appendOutput(`\nCode for IBM i components:\n`);
-          Array.from(componentStates.entries()).forEach(([name, state]) => {
-            this.appendOutput(`\t${name} (${state.id.version}): ${state.state}\n`);
-          });
-          this.appendOutput(`\n`);
-
+        // Check for installed components?
+        // For Quick Connect to work here, 'remoteFeatures' MUST have all features defined and no new properties may be added!
+        if (quickConnect() && cachedServerSettings?.remoteFeaturesKeys && cachedServerSettings.remoteFeaturesKeys === Object.keys(this.remoteFeatures).sort().toString()) {
+          Object.assign(this.remoteFeatures, cachedServerSettings.remoteFeatures);
+        } else {
           progress.report({
-            message: `Checking library list configuration.`
+            message: `Checking installed components on host IBM i.`
           });
 
-          //Since the compiles are stateless, then we have to set the library list each time we use the `SYSTEM` command
-          //We setup the defaultUserLibraries here so we can remove them later on so the user can setup their own library list
-          let currentLibrary = `QGPL`;
-          this.defaultUserLibraries = [];
-
-          const liblResult = await this.sendQsh({
-            command: `liblist`
-          });
-          if (liblResult.code === 0) {
-            const libraryListString = liblResult.stdout;
-            if (libraryListString !== ``) {
-              const libraryList = libraryListString.split(`\n`);
-
-              let lib, type;
-              for (const line of libraryList) {
-                lib = line.substring(0, 10).trim();
-                type = line.substring(12);
-
-                switch (type) {
-                  case `USR`:
-                    this.defaultUserLibraries.push(lib);
-                    break;
-
-                  case `CUR`:
-                    currentLibrary = lib;
-                    break;
-                }
-              }
-
-              //If this is the first time the config is made, then these arrays will be empty
-              if (this.config.currentLibrary.length === 0) {
-                this.config.currentLibrary = currentLibrary;
-              }
-              if (this.config.libraryList.length === 0) {
-                this.config.libraryList = this.defaultUserLibraries;
-              }
+          // We need to check if our remote programs are installed.
+          remoteApps.push(
+            {
+              path: `/QSYS.lib/${this.upperCaseName(this.config.tempLibrary)}.lib/`,
+              names: [`GETNEWLIBL.PGM`],
+              specific: `GE*.PGM`
             }
-          }
+          );
 
-          progress.report({
-            message: `Checking temporary library configuration.`
-          });
-
-          //Next, we need to check the temp lib (where temp outfile data lives) exists
-          const createdTempLib = await this.runCommand({
-            command: `CRTLIB LIB(${this.config.tempLibrary}) TEXT('Code for i temporary objects. May be cleared.')`,
-            noLibList: true
-          });
-
-          if (createdTempLib.code === 0) {
-            tempLibrarySet = true;
-          } else {
-            const messages = Tools.parseMessages(createdTempLib.stderr);
-            if (messages.findId(`CPF2158`) || messages.findId(`CPF2111`)) { //Already exists, hopefully ok :)
-              tempLibrarySet = true;
-            }
-            else if (messages.findId(`CPD0032`)) { //Can't use CRTLIB
-              const tempLibExists = await this.runCommand({
-                command: `CHKOBJ OBJ(QSYS/${this.config.tempLibrary}) OBJTYPE(*LIB)`,
-                noLibList: true
-              });
-
-              if (tempLibExists.code === 0) {
-                //We're all good if no errors
-                tempLibrarySet = true;
-              } else if (currentLibrary && !currentLibrary.startsWith(`Q`)) {
-                //Using ${currentLibrary} as the temporary library for temporary data.
-                this.config.tempLibrary = currentLibrary;
-                tempLibrarySet = true;
-              }
-            }
-          }
-
-          progress.report({
-            message: `Checking temporary directory configuration.`
-          });
-
-          let tempDirSet = false;
-          // Next, we need to check if the temp directory exists
-          let result = await this.sendCommand({
-            command: `[ -d "${this.config.tempDir}" ]`
-          });
-
-          if (result.code === 0) {
-            // Directory exists
-            tempDirSet = true;
-          } else {
-            // Directory does not exist, try to create it
-            let result = await this.sendCommand({
-              command: `mkdir -p ${this.config.tempDir}`
-            });
-            if (result.code === 0) {
-              // Directory created
-              tempDirSet = true;
-            } else {
-              // Directory not created
-            }
-          }
-
-          if (!tempDirSet) {
-            this.config.tempDir = `/tmp`;
-          }
-
-          if (tempLibrarySet && this.config.autoClearTempData) {
-            progress.report({
-              message: `Clearing temporary data.`
-            });
-
-            this.runCommand({
-              command: `DLTOBJ OBJ(${this.config.tempLibrary}/O_*) OBJTYPE(*FILE)`,
-              noLibList: true,
-            })
-              .then(result => {
-                // All good!
-                if (result && result.stderr) {
-                  const messages = Tools.parseMessages(result.stderr);
-                  if (!messages.findId(`CPF2125`)) {
-                    // @ts-ignore We know the config exists.
-                    vscode.window.showErrorMessage(`Temporary data not cleared from ${this.config.tempLibrary}.`, `View log`).then(async choice => {
-                      if (choice === `View log`) {
-                        this.outputChannel!.show();
-                      }
-                    });
-                  }
-                }
-              })
-
-            this.sendCommand({
-              command: `rm -rf ${path.posix.join(this.config.tempDir, `vscodetemp*`)}`
-            })
-              .then(result => {
-                // All good!
-              })
-              .catch(e => {
-                // CPF2125: No objects deleted.
-                // @ts-ignore We know the config exists.
-                vscode.window.showErrorMessage(`Temporary data not cleared from ${this.config.tempDir}.`, `View log`).then(async choice => {
-                  if (choice === `View log`) {
-                    this.outputChannel!.show();
-                  }
-                });
-              });
-          }
-
-          const commandShellResult = await this.sendCommand({
-            command: `echo $SHELL`
-          });
-
-          if (commandShellResult.code === 0) {
-            this.shell = commandShellResult.stdout.trim();
-          }
-
-          // Check for bad data areas?
-          if (quickConnect() && cachedServerSettings?.badDataAreasChecked === true) {
-            // Do nothing, bad data areas are already checked.
-          } else {
-            progress.report({
-              message: `Checking for bad data areas.`
-            });
-
-            const QCPTOIMPF = await this.runCommand({
-              command: `CHKOBJ OBJ(QSYS/QCPTOIMPF) OBJTYPE(*DTAARA)`,
-              noLibList: true
-            });
-
-            if (QCPTOIMPF?.code === 0) {
-              vscode.window.showWarningMessage(`The data area QSYS/QCPTOIMPF exists on this system and may impact Code for IBM i functionality.`, {
-                detail: `For V5R3, the code for the command CPYTOIMPF had a major design change to increase functionality and performance. The QSYS/QCPTOIMPF data area lets developers keep the pre-V5R2 version of CPYTOIMPF. Code for IBM i cannot function correctly while this data area exists.`,
-                modal: true,
-              }, `Delete`, `Read more`).then(choice => {
-                switch (choice) {
-                  case `Delete`:
-                    this.runCommand({
-                      command: `DLTOBJ OBJ(QSYS/QCPTOIMPF) OBJTYPE(*DTAARA)`,
-                      noLibList: true
-                    })
-                      .then((result) => {
-                        if (result?.code === 0) {
-                          vscode.window.showInformationMessage(`The data area QSYS/QCPTOIMPF has been deleted.`);
-                        } else {
-                          vscode.window.showInformationMessage(`Failed to delete the data area QSYS/QCPTOIMPF. Code for IBM i may not work as intended.`);
-                        }
-                      })
-                    break;
-                  case `Read more`:
-                    vscode.env.openExternal(vscode.Uri.parse(`https://github.com/codefori/vscode-ibmi/issues/476#issuecomment-1018908018`));
-                    break;
-                }
-              });
-            }
-
-            const QCPFRMIMPF = await this.runCommand({
-              command: `CHKOBJ OBJ(QSYS/QCPFRMIMPF) OBJTYPE(*DTAARA)`,
-              noLibList: true
-            });
-
-            if (QCPFRMIMPF?.code === 0) {
-              vscode.window.showWarningMessage(`The data area QSYS/QCPFRMIMPF exists on this system and may impact Code for IBM i functionality.`, {
-                modal: false,
-              }, `Delete`, `Read more`).then(choice => {
-                switch (choice) {
-                  case `Delete`:
-                    this.runCommand({
-                      command: `DLTOBJ OBJ(QSYS/QCPFRMIMPF) OBJTYPE(*DTAARA)`,
-                      noLibList: true
-                    })
-                      .then((result) => {
-                        if (result?.code === 0) {
-                          vscode.window.showInformationMessage(`The data area QSYS/QCPFRMIMPF has been deleted.`);
-                        } else {
-                          vscode.window.showInformationMessage(`Failed to delete the data area QSYS/QCPFRMIMPF. Code for IBM i may not work as intended.`);
-                        }
-                      })
-                    break;
-                  case `Read more`:
-                    vscode.env.openExternal(vscode.Uri.parse(`https://github.com/codefori/vscode-ibmi/issues/476#issuecomment-1018908018`));
-                    break;
-                }
-              });
-            }
-          }
-
-          // give user option to set bash as default shell.
-          if (this.remoteFeatures[`bash`]) {
+          //Next, we see what pase features are available (installed via yum)
+          //This may enable certain features in the future.
+          for (const feature of remoteApps) {
             try {
-              //check users default shell
+              progress.report({
+                message: `Checking installed components on host IBM i: ${feature.path}`
+              });
 
-              if (!commandShellResult.stderr) {
-                let usesBash = this.shell === bashShellPath;
-                if (!usesBash) {
-                  // make sure chsh is installed
-                  if (this.remoteFeatures[`chsh`]) {
-                    vscode.window.showInformationMessage(`IBM recommends using bash as your default shell.`, `Set shell to bash`, `Read More`,).then(async choice => {
-                      switch (choice) {
-                        case `Set shell to bash`:
-                          const commandSetBashResult = await this.sendCommand({
-                            command: `/QOpenSys/pkgs/bin/chsh -s /QOpenSys/pkgs/bin/bash`
-                          });
+              const call = await this.sendCommand({ command: `ls -p ${feature.path}${feature.specific || ``}` });
+              if (call.stdout) {
+                const files = call.stdout.split(`\n`);
 
-                          if (!commandSetBashResult.stderr) {
-                            vscode.window.showInformationMessage(`Shell is now bash! Reconnect for change to take effect.`);
-                            usesBash = true;
-                          } else {
-                            vscode.window.showInformationMessage(`Default shell WAS NOT changed to bash.`);
-                          }
-                          break;
-
-                        case `Read More`:
-                          vscode.env.openExternal(vscode.Uri.parse(`https://ibmi-oss-docs.readthedocs.io/en/latest/user_setup/README.html#step-4-change-your-default-shell-to-bash`));
-                          break;
-                      }
-                    });
-                  }
-                }
-
-                if (usesBash) {
-                  //Ensure /QOpenSys/pkgs/bin is found in $PATH
-                  progress.report({
-                    message: `Checking /QOpenSys/pkgs/bin in $PATH.`
-                  });
-
-                  if ((!quickConnect || !cachedServerSettings?.pathChecked)) {
-                    const currentPaths = (await this.sendCommand({ command: "echo $PATH" })).stdout.split(":");
-                    const bashrcFile = `${defaultHomeDir}/.bashrc`;
-                    let bashrcExists = (await this.sendCommand({ command: `test -e ${bashrcFile}` })).code === 0;
-                    let reason;
-                    const requiredPaths = ["/QOpenSys/pkgs/bin", "/usr/bin", "/QOpenSys/usr/bin"]
-                    let missingPath;
-                    for (const requiredPath of requiredPaths) {
-                      if (!currentPaths.includes(requiredPath)) {
-                        reason = `Your $PATH shell environment variable does not include ${requiredPath}`;
-                        missingPath = requiredPath
-                        break;
-                      }
-                    }
-                    // If reason is still undefined, then we know the user has all the required paths. Then we don't 
-                    // need to check for their existence before checking the order of the required paths.
-                    if (!reason &&
-                      (currentPaths.indexOf("/QOpenSys/pkgs/bin") > currentPaths.indexOf("/usr/bin")
-                        || (currentPaths.indexOf("/QOpenSys/pkgs/bin") > currentPaths.indexOf("/QOpenSys/usr/bin")))) {
-                      reason = "/QOpenSys/pkgs/bin is not in the right position in your $PATH shell environment variable";
-                      missingPath = "/QOpenSys/pkgs/bin"
-                    }
-                    if (reason && await vscode.window.showWarningMessage(`${missingPath} not found in $PATH`, {
-                      modal: true,
-                      detail: `${reason}, so Code for IBM i may not function correctly. Would you like to ${bashrcExists ? "update" : "create"} ${bashrcFile} to fix this now?`,
-                    }, `Yes`)) {
-                      delayedOperations.push(async () => {
-                        this.appendOutput(`${bashrcExists ? "update" : "create"} ${bashrcFile}`);
-                        if (!bashrcExists) {
-                          // Add "/usr/bin" and "/QOpenSys/usr/bin" to the end of the path. This way we know that the user has 
-                          // all the required paths, but we don't overwrite the priority of other items on their path.
-                          const createBashrc = await this.sendCommand({ command: `echo "# Generated by Code for IBM i\nexport PATH=/QOpenSys/pkgs/bin:\\$PATH:/QOpenSys/usr/bin:/usr/bin" >> ${bashrcFile} && chown ${connectionObject.username.toLowerCase()} ${bashrcFile} && chmod 755 ${bashrcFile}` });
-                          if (createBashrc.code !== 0) {
-                            vscode.window.showWarningMessage(`Error creating ${bashrcFile}):\n${createBashrc.stderr}.\n\n Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: true });
-                          }
-                        }
-                        else {
-                          try {
-                            const content = this.content;
-                            if (content) {
-                              const bashrcContent = (await content.downloadStreamfile(bashrcFile)).split("\n");
-                              let replaced = false;
-                              bashrcContent.forEach((line, index) => {
-                                if (!replaced) {
-                                  const pathRegex = /^((?:export )?PATH=)(.*)(?:)$/.exec(line);
-                                  if (pathRegex) {
-                                    bashrcContent[index] = `${pathRegex[1]}/QOpenSys/pkgs/bin:${pathRegex[2]
-                                      .replace("/QOpenSys/pkgs/bin", "") //Removes /QOpenSys/pkgs/bin wherever it is
-                                      .replace("::", ":")}:/QOpenSys/usr/bin:/usr/bin`; //Removes double : in case /QOpenSys/pkgs/bin wasn't at the end
-                                    replaced = true;
-                                  }
-                                }
-                              });
-
-                              if (!replaced) {
-                                bashrcContent.push(
-                                  "",
-                                  "# Generated by Code for IBM i",
-                                  "export PATH=/QOpenSys/pkgs/bin:$PATH:/QOpenSys/usr/bin:/usr/bin"
-                                );
-                              }
-
-                              await content.writeStreamfile(bashrcFile, bashrcContent.join("\n"));
-                            }
-                          }
-                          catch (error) {
-                            vscode.window.showWarningMessage(`Error modifying PATH in ${bashrcFile}):\n${error}.\n\n Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: true });
-                          }
-                        }
-                      });
-                    }
-                  }
+                if (feature.specific) {
+                  for (const name of feature.names)
+                    this.remoteFeatures[name] = files.find(file => file.includes(name));
+                } else {
+                  for (const name of feature.names)
+                    if (files.includes(name))
+                      this.remoteFeatures[name] = feature.path + name;
                 }
               }
             } catch (e) {
-              // Oh well...trying to set default shell is not worth stopping for.
               console.log(e);
             }
           }
 
-          if (this.config.autoConvertIFSccsid) {
-            if (this.remoteFeatures.attr === undefined || this.remoteFeatures.iconv === undefined) {
-              this.config.autoConvertIFSccsid = false;
-              vscode.window.showWarningMessage(`EBCDIC streamfiles will not be rendered correctly since \`attr\` or \`iconv\` is not installed on the host. They should both exist in \`\\usr\\bin\`.`);
-            }
-          }
-
-          if (defaultHomeDir) {
-            if (!tempLibrarySet) {
-              vscode.window.showWarningMessage(`Code for IBM i will not function correctly until the temporary library has been corrected in the settings.`, `Open Settings`)
-                .then(result => {
-                  switch (result) {
-                    case `Open Settings`:
-                      vscode.commands.executeCommand(`code-for-ibmi.showAdditionalSettings`);
-                      break;
-                  }
-                });
-            }
-          } else {
-            vscode.window.showWarningMessage(`Code for IBM i may not function correctly until your user has a home directory.`);
-          }
-
-          // Validate configured library list.
-          if (quickConnect() && cachedServerSettings?.libraryListValidated === true) {
-            // Do nothing, library list is already checked.
-          } else {
-            if (this.config.libraryList) {
-              progress.report({
-                message: `Validate configured library list`
-              });
-              let validLibs: string[] = [];
-              let badLibs: string[] = [];
-
-              const result = await this.sendQsh({
-                command: [
-                  `liblist -d ` + IBMi.escapeForShell(this.defaultUserLibraries.join(` `)),
-                  ...this.config.libraryList.map(lib => `liblist -a ` + IBMi.escapeForShell(lib))
-                ].join(`; `)
-              });
-
-              if (result.stderr) {
-                const lines = result.stderr.split(`\n`);
-
-                lines.forEach(line => {
-                  const badLib = this.config?.libraryList.find(lib => line.includes(`ibrary ${lib} `));
-
-                  // If there is an error about the library, store it
-                  if (badLib) badLibs.push(badLib);
-                });
-              }
-
-              if (result && badLibs.length > 0) {
-                validLibs = this.config.libraryList.filter(lib => !badLibs.includes(lib));
-                const chosen = await vscode.window.showWarningMessage(`The following ${badLibs.length > 1 ? `libraries` : `library`} does not exist: ${badLibs.join(`,`)}. Remove ${badLibs.length > 1 ? `them` : `it`} from the library list?`, `Yes`, `No`);
-                if (chosen === `Yes`) {
-                  this.config!.libraryList = validLibs;
-                } else {
-                  vscode.window.showWarningMessage(`The following libraries does not exist: ${badLibs.join(`,`)}.`);
-                }
-              }
-            }
-          }
-
-          let debugConfigLoaded = false
-          if ((!quickConnect || !cachedServerSettings?.debugConfigLoaded)) {
-            if (debugPTFInstalled()) {
-              try {
-                const debugServiceConfig = await new DebugConfiguration().load();
-                delete this.config.debugCertDirectory;
-                this.config.debugPort = debugServiceConfig.getOrDefault("DBGSRV_SECURED_PORT", "8005");
-                this.config.debugSepPort = debugServiceConfig.getOrDefault("DBGSRV_SEP_DAEMON_PORT", "8008");
-                debugConfigLoaded = true;
-              }
-              catch (error) {
-                vscode.window.showWarningMessage(`Could not load debug service configuration: ${error}`);
-              }
-            }
-          }
-
-          if ((!quickConnect || !cachedServerSettings?.maximumArgsLength)) {
-            //Compute the maximum admited length of a command's arguments. Source: Googling and https://www.in-ulm.de/~mascheck/various/argmax/#effectively_usable
-            this.maximumArgsLength = Number((await this.sendCommand({ command: "/QOpenSys/usr/bin/expr `/QOpenSys/usr/bin/getconf ARG_MAX` - `env|wc -c` - `env|wc -l` \\* 4 - 2048" })).stdout);
-          }
-          else {
-            this.maximumArgsLength = cachedServerSettings.maximumArgsLength;
-          }
-
-          if (this.sqlRunnerAvailable()) {
-            // Check for ASP information?
-            if (quickConnect() && cachedServerSettings?.aspInfo) {
-              this.aspInfo = cachedServerSettings.aspInfo;
-            } else {
-              progress.report({
-                message: `Checking for ASP information.`
-              });
-
-              //This is mostly a nice to have. We grab the ASP info so user's do
-              //not have to provide the ASP in the settings.
-              try {
-                const resultSet = await this.runSQL(`SELECT * FROM QSYS2.ASP_INFO`);
-                resultSet.forEach(row => {
-                  if (row.DEVICE_DESCRIPTION_NAME && row.DEVICE_DESCRIPTION_NAME && row.DEVICE_DESCRIPTION_NAME !== `null`) {
-                    this.aspInfo[Number(row.ASP_NUMBER)] = String(row.DEVICE_DESCRIPTION_NAME);
-                  }
-                });
-              } catch (e) {
-                //Oh well
-                progress.report({
-                  message: `Failed to get ASP information.`
-                });
-              }
-            }
-
-            // Fetch conversion values?
-            if (quickConnect() && cachedServerSettings?.jobCcsid !== null && cachedServerSettings?.userDefaultCCSID && cachedServerSettings?.qccsid) {
-              this.qccsid = cachedServerSettings.qccsid;
-              this.userJobCcsid = cachedServerSettings.jobCcsid;
-              this.userDefaultCCSID = cachedServerSettings.userDefaultCCSID;
-            } else {
-              progress.report({
-                message: `Fetching conversion values.`
-              });
-
-              // Next, we're going to see if we can get the CCSID from the user or the system.
-              // Some things don't work without it!!!
-              try {
-
-                // we need to grab the system CCSID (QCCSID)
-                const [systemCCSID] = await this.runSQL(`select SYSTEM_VALUE_NAME, CURRENT_NUMERIC_VALUE from QSYS2.SYSTEM_VALUE_INFO where SYSTEM_VALUE_NAME = 'QCCSID'`);
-                if (typeof systemCCSID.CURRENT_NUMERIC_VALUE === 'number') {
-                  this.qccsid = systemCCSID.CURRENT_NUMERIC_VALUE;
-                }
-
-                // we grab the users default CCSID
-                const [userInfo] = await this.runSQL(`select CHARACTER_CODE_SET_ID from table( QSYS2.QSYUSRINFO( USERNAME => upper('${this.currentUser}') ) )`);
-                if (userInfo.CHARACTER_CODE_SET_ID !== `null` && typeof userInfo.CHARACTER_CODE_SET_ID === 'number') {
-                  this.userJobCcsid = userInfo.CHARACTER_CODE_SET_ID;
-                }
-
-                // if the job ccsid is *SYSVAL, then assign it to sysval
-                if (this.userJobCcsid === CCSID_SYSVAL) {
-                  this.userJobCcsid = this.qccsid;
-                }
-
-                // Let's also get the user's default CCSID
-                try {
-                  const [activeJob] = await this.runSQL(`Select DEFAULT_CCSID From Table(QSYS2.ACTIVE_JOB_INFO( JOB_NAME_FILTER => '*', DETAILED_INFO => 'ALL' ))`);
-                  this.userDefaultCCSID = Number(activeJob.DEFAULT_CCSID);
-                }
-                catch (error) {
-                  const [defaultCCSID] = (await this.runCommand({ command: "DSPJOB OPTION(*DFNA)" }))
-                    .stdout
-                    .split("\n")
-                    .filter(line => line.includes("DFTCCSID"));
-
-                  const defaultCCSCID = Number(defaultCCSID.split("DFTCCSID").at(1)?.trim());
-                  if (defaultCCSCID && !isNaN(defaultCCSCID)) {
-                    this.userDefaultCCSID = defaultCCSCID;
-                  }
-                }
-
-              } catch (e) {
-                // Oh well!
-                console.log(e);
-              }
-            }
-
-            let userCcsidNeedsFixing = false;
-            let sshdCcsidMismatch = false;
-
-            const showCcsidWarning = (message: string) => {
-              vscode.window.showWarningMessage(message, `Show documentation`).then(choice => {
-                if (choice === `Show documentation`) {
-                  vscode.commands.executeCommand(`vscode.open`, `https://codefori.github.io/docs/tips/ccsid/`);
-                }
-              });
-            }
-
-            if (this.canUseCqsh) {
-              // If cqsh is available, but the user profile CCSID is bad, then cqsh won't work
-              if (this.getCcsid() === CCSID_NOCONVERSION) {
-                userCcsidNeedsFixing = true;
-              }
-            }
-
-            else {
-              // If cqsh is not available, then we need to check the SSHD CCSID
-              this.sshdCcsid = await this.getSshCcsid();
-              if (this.sshdCcsid === this.getCcsid()) {
-                // If the SSHD CCSID matches the job CCSID (not the user profile!), then we're good.
-                // This means we can use regular qsh without worrying about translation because the SSHD and job CCSID match.
-                userCcsidNeedsFixing = false;
-              } else {
-                // If the SSHD CCSID does not match the job CCSID, then we need to warn the user
-                sshdCcsidMismatch = true;
-              }
-            }
-
-            if (userCcsidNeedsFixing) {
-              showCcsidWarning(`The job CCSID is set to ${CCSID_NOCONVERSION}. This may cause issues with objects with variant characters. Please use CHGUSRPRF USER(${this.currentUser.toUpperCase()}) CCSID(${this.userDefaultCCSID}) to set your profile to the current default CCSID.`);
-            } else if (sshdCcsidMismatch) {
-              showCcsidWarning(`The CCSID of the SSH connection (${this.sshdCcsid}) does not match the job CCSID (${this.getCcsid()}). This may cause issues with objects with variant characters.`);
-            }
-
-            this.appendOutput(`\nCCSID information:\n`);
-            this.appendOutput(`\tQCCSID: ${this.qccsid}\n`);
-            this.appendOutput(`\tUser Job CCSID: ${this.userJobCcsid}\n`);
-            this.appendOutput(`\tUser Default CCSID: ${this.userDefaultCCSID}\n`);
-            if (this.sshdCcsid) {
-              this.appendOutput(`\tSSHD CCSID: ${this.sshdCcsid}\n`);
-            }
-
-            // We only do this check if we're on 7.3 or below.
-            if (this.systemVersion && this.systemVersion <= 7.3) {
-              progress.report({
-                message: `Checking PASE locale environment variables.`
-              });
-
-              const systemEnvVars = await this.getSysEnvVars();
-
-              const paseLang = systemEnvVars.PASE_LANG;
-              const paseCcsid = systemEnvVars.QIBM_PASE_CCSID;
-
-              if (paseLang === undefined || paseCcsid === undefined) {
-                showCcsidWarning(`The PASE environment variables PASE_LANG and QIBM_PASE_CCSID are not set correctly and is required for this OS version (${this.systemVersion}). This may cause issues with objects with variant characters.`);
-              } else if (paseCcsid !== `1208`) {
-                showCcsidWarning(`The PASE environment variable QIBM_PASE_CCSID is not set to 1208 and is required for this OS version (${this.systemVersion}). This may cause issues with objects with variant characters.`);
-              }
-            }
-
-            // We always need to fetch the local variants because 
-            // now we pickup CCSID changes faster due to cqsh
-            progress.report({
-              message: `Fetching local encoding values.`
-            });
-
-            const [variants] = await this.runSQL(`With VARIANTS ( HASH, AT, DOLLARSIGN ) as (`
-              + `  values ( cast( x'7B' as varchar(1) )`
-              + `         , cast( x'7C' as varchar(1) )`
-              + `         , cast( x'5B' as varchar(1) ) )`
-              + `)`
-              + `Select HASH concat AT concat DOLLARSIGN as LOCAL from VARIANTS`);
-
-            if (typeof variants.LOCAL === 'string' && variants.LOCAL !== `null`) {
-              this.variantChars.local = variants.LOCAL;
-            }
-          } else {
-            vscode.window.showWarningMessage(`The SQL runner is not available. This could mean that VS Code will not work for this connection. See our documentation for more information.`)
-          }
-
-          if (!reconnecting) {
-            vscode.workspace.getConfiguration().update(`workbench.editor.enablePreview`, false, true);
-            await vscode.commands.executeCommand(`setContext`, `code-for-ibmi:connected`, true);
-            for (const operation of delayedOperations) {
-              await operation();
-            }
-          }
-
-          instance.fire(`connected`);
-
-          GlobalStorage.get().setServerSettingsCache(this.currentConnectionName, {
-            lastCheckedOnVersion: currentExtensionVersion,
-            aspInfo: this.aspInfo,
-            qccsid: this.qccsid,
-            jobCcsid: this.userJobCcsid,
-            remoteFeatures: this.remoteFeatures,
-            remoteFeaturesKeys: Object.keys(this.remoteFeatures).sort().toString(),
-            badDataAreasChecked: true,
-            libraryListValidated: true,
-            pathChecked: true,
-            userDefaultCCSID: this.userDefaultCCSID,
-            debugConfigLoaded,
-            maximumArgsLength: this.maximumArgsLength
+          //Specific Java installations check
+          progress.report({
+            message: `Checking installed components on host IBM i: Java`
           });
+          const javaCheck = async (root: string) => await this.content.testStreamFile(`${root}/bin/java`, 'x') ? root : undefined;
+          this.remoteFeatures.jdk80 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit`);
+          this.remoteFeatures.jdk11 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk11/64bit`);
+          this.remoteFeatures.openjdk11 = await javaCheck(`/QOpensys/pkgs/lib/jvm/openjdk-11`);
+          this.remoteFeatures.jdk17 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk17/64bit`);
+        }
 
-          return {
-            success: true
-          };
+        if (this.remoteFeatures.uname) {
+          progress.report({
+            message: `Checking OS version.`
+          });
+          const systemVersionResult = await this.sendCommand({ command: `${this.remoteFeatures.uname} -rv` });
+
+          if (systemVersionResult.code === 0) {
+            const version = systemVersionResult.stdout.trim().split(` `);
+            this.systemVersion = Number(`${version[1]}.${version[0]}`);
+          }
+        }
+
+        if (!this.systemVersion) {
+          vscode.window.showWarningMessage(`Unable to determine system version. Code for IBM i only supports 7.3 and above. Some features may not work correctly.`);
+        } else if (this.systemVersion < 7.3) {
+          vscode.window.showWarningMessage(`IBM i ${this.systemVersion} is not supported. Code for IBM i only supports 7.3 and above. Some features may not work correctly.`);
+        }
+
+        progress.report({ message: `Checking Code for IBM i components.` });
+        await this.componentManager.startup();
+
+        const componentStates = await this.componentManager.getState();
+        this.appendOutput(`\nCode for IBM i components:\n`);
+        for (const state of componentStates) {
+          this.appendOutput(`\t${state.id.name} (${state.id.version}): ${state.state}\n`);
+        }
+        this.appendOutput(`\n`);
+
+        progress.report({
+          message: `Checking library list configuration.`
         });
 
-      } catch (e: any) {
+        //Since the compiles are stateless, then we have to set the library list each time we use the `SYSTEM` command
+        //We setup the defaultUserLibraries here so we can remove them later on so the user can setup their own library list
+        let currentLibrary = `QGPL`;
+        this.defaultUserLibraries = [];
 
-        if (this.client.isConnected()) {
-          this.client.dispose();
+        const liblResult = await this.sendQsh({
+          command: `liblist`
+        });
+        if (liblResult.code === 0) {
+          const libraryListString = liblResult.stdout;
+          if (libraryListString !== ``) {
+            const libraryList = libraryListString.split(`\n`);
+
+            let lib, type;
+            for (const line of libraryList) {
+              lib = line.substring(0, 10).trim();
+              type = line.substring(12);
+
+              switch (type) {
+                case `USR`:
+                  this.defaultUserLibraries.push(lib);
+                  break;
+
+                case `CUR`:
+                  currentLibrary = lib;
+                  break;
+              }
+            }
+
+            //If this is the first time the config is made, then these arrays will be empty
+            if (this.config.currentLibrary.length === 0) {
+              this.config.currentLibrary = currentLibrary;
+            }
+            if (this.config.libraryList.length === 0) {
+              this.config.libraryList = this.defaultUserLibraries;
+            }
+          }
         }
 
-        if (reconnecting && await vscode.window.showWarningMessage(`Could not reconnect`, {
-          modal: true,
-          detail: `Reconnection to ${this.currentConnectionName} has failed. Would you like to try again?\n\n${e}`
-        }, `Yes`)) {
-          return this.connect(connectionObject, true);
+        progress.report({
+          message: `Checking temporary library configuration.`
+        });
+
+        //Next, we need to check the temp lib (where temp outfile data lives) exists
+        const createdTempLib = await this.runCommand({
+          command: `CRTLIB LIB(${this.config.tempLibrary}) TEXT('Code for i temporary objects. May be cleared.')`,
+          noLibList: true
+        });
+
+        if (createdTempLib.code === 0) {
+          tempLibrarySet = true;
+        } else {
+          const messages = Tools.parseMessages(createdTempLib.stderr);
+          if (messages.findId(`CPF2158`) || messages.findId(`CPF2111`)) { //Already exists, hopefully ok :)
+            tempLibrarySet = true;
+          }
+          else if (messages.findId(`CPD0032`)) { //Can't use CRTLIB
+            const tempLibExists = await this.runCommand({
+              command: `CHKOBJ OBJ(QSYS/${this.config.tempLibrary}) OBJTYPE(*LIB)`,
+              noLibList: true
+            });
+
+            if (tempLibExists.code === 0) {
+              //We're all good if no errors
+              tempLibrarySet = true;
+            } else if (currentLibrary && !currentLibrary.startsWith(`Q`)) {
+              //Using ${currentLibrary} as the temporary library for temporary data.
+              this.config.tempLibrary = currentLibrary;
+              tempLibrarySet = true;
+            }
+          }
         }
 
-        let error = e;
-        if (e.code === "ENOTFOUND") {
-          error = `Host is unreachable. Check the connection's hostname/IP address.`;
+        progress.report({
+          message: `Checking temporary directory configuration.`
+        });
+
+        let tempDirSet = false;
+        // Next, we need to check if the temp directory exists
+        let result = await this.sendCommand({
+          command: `[ -d "${this.config.tempDir}" ]`
+        });
+
+        if (result.code === 0) {
+          // Directory exists
+          tempDirSet = true;
+        } else {
+          // Directory does not exist, try to create it
+          let result = await this.sendCommand({
+            command: `mkdir -p ${this.config.tempDir}`
+          });
+          if (result.code === 0) {
+            // Directory created
+            tempDirSet = true;
+          } else {
+            // Directory not created
+          }
         }
-        else if (e.code === "ECONNREFUSED") {
-          error = `Port ${connectionObject.port} is unreachable. Check the connection's port number or run command STRTCPSVR SERVER(*SSHD) on the host.`
+
+        if (!tempDirSet) {
+          this.config.tempDir = `/tmp`;
         }
-        else if (e.level === "client-authentication") {
-          error = `Check your credentials${e.message ? ` (${e.message})` : ''}.`;
+
+        if (tempLibrarySet && this.config.autoClearTempData) {
+          progress.report({
+            message: `Clearing temporary data.`
+          });
+
+          this.runCommand({
+            command: `DLTOBJ OBJ(${this.config.tempLibrary}/O_*) OBJTYPE(*FILE)`,
+            noLibList: true,
+          })
+            .then(result => {
+              // All good!
+              if (result && result.stderr) {
+                const messages = Tools.parseMessages(result.stderr);
+                if (!messages.findId(`CPF2125`)) {
+                  // @ts-ignore We know the config exists.
+                  vscode.window.showErrorMessage(`Temporary data not cleared from ${this.config.tempLibrary}.`, `View log`).then(async choice => {
+                    if (choice === `View log`) {
+                      this.outputChannel!.show();
+                    }
+                  });
+                }
+              }
+            })
+
+          this.sendCommand({
+            command: `rm -rf ${path.posix.join(this.config.tempDir, `vscodetemp*`)}`
+          })
+            .then(result => {
+              // All good!
+            })
+            .catch(e => {
+              // CPF2125: No objects deleted.
+              // @ts-ignore We know the config exists.
+              vscode.window.showErrorMessage(`Temporary data not cleared from ${this.config.tempDir}.`, `View log`).then(async choice => {
+                if (choice === `View log`) {
+                  this.outputChannel!.show();
+                }
+              });
+            });
         }
+
+        const commandShellResult = await this.sendCommand({
+          command: `echo $SHELL`
+        });
+
+        if (commandShellResult.code === 0) {
+          this.shell = commandShellResult.stdout.trim();
+        }
+
+        // Check for bad data areas?
+        if (quickConnect() && cachedServerSettings?.badDataAreasChecked === true) {
+          // Do nothing, bad data areas are already checked.
+        } else {
+          progress.report({
+            message: `Checking for bad data areas.`
+          });
+
+          const QCPTOIMPF = await this.runCommand({
+            command: `CHKOBJ OBJ(QSYS/QCPTOIMPF) OBJTYPE(*DTAARA)`,
+            noLibList: true
+          });
+
+          if (QCPTOIMPF?.code === 0) {
+            vscode.window.showWarningMessage(`The data area QSYS/QCPTOIMPF exists on this system and may impact Code for IBM i functionality.`, {
+              detail: `For V5R3, the code for the command CPYTOIMPF had a major design change to increase functionality and performance. The QSYS/QCPTOIMPF data area lets developers keep the pre-V5R2 version of CPYTOIMPF. Code for IBM i cannot function correctly while this data area exists.`,
+              modal: true,
+            }, `Delete`, `Read more`).then(choice => {
+              switch (choice) {
+                case `Delete`:
+                  this.runCommand({
+                    command: `DLTOBJ OBJ(QSYS/QCPTOIMPF) OBJTYPE(*DTAARA)`,
+                    noLibList: true
+                  })
+                    .then((result) => {
+                      if (result?.code === 0) {
+                        vscode.window.showInformationMessage(`The data area QSYS/QCPTOIMPF has been deleted.`);
+                      } else {
+                        vscode.window.showInformationMessage(`Failed to delete the data area QSYS/QCPTOIMPF. Code for IBM i may not work as intended.`);
+                      }
+                    })
+                  break;
+                case `Read more`:
+                  vscode.env.openExternal(vscode.Uri.parse(`https://github.com/codefori/vscode-ibmi/issues/476#issuecomment-1018908018`));
+                  break;
+              }
+            });
+          }
+
+          const QCPFRMIMPF = await this.runCommand({
+            command: `CHKOBJ OBJ(QSYS/QCPFRMIMPF) OBJTYPE(*DTAARA)`,
+            noLibList: true
+          });
+
+          if (QCPFRMIMPF?.code === 0) {
+            vscode.window.showWarningMessage(`The data area QSYS/QCPFRMIMPF exists on this system and may impact Code for IBM i functionality.`, {
+              modal: false,
+            }, `Delete`, `Read more`).then(choice => {
+              switch (choice) {
+                case `Delete`:
+                  this.runCommand({
+                    command: `DLTOBJ OBJ(QSYS/QCPFRMIMPF) OBJTYPE(*DTAARA)`,
+                    noLibList: true
+                  })
+                    .then((result) => {
+                      if (result?.code === 0) {
+                        vscode.window.showInformationMessage(`The data area QSYS/QCPFRMIMPF has been deleted.`);
+                      } else {
+                        vscode.window.showInformationMessage(`Failed to delete the data area QSYS/QCPFRMIMPF. Code for IBM i may not work as intended.`);
+                      }
+                    })
+                  break;
+                case `Read more`:
+                  vscode.env.openExternal(vscode.Uri.parse(`https://github.com/codefori/vscode-ibmi/issues/476#issuecomment-1018908018`));
+                  break;
+              }
+            });
+          }
+        }
+
+        // give user option to set bash as default shell.
+        if (this.remoteFeatures[`bash`]) {
+          try {
+            //check users default shell
+
+            if (!commandShellResult.stderr) {
+              let usesBash = this.shell === IBMi.bashShellPath;
+              if (!usesBash) {
+                // make sure chsh is installed
+                if (this.remoteFeatures[`chsh`]) {
+                  vscode.window.showInformationMessage(`IBM recommends using bash as your default shell.`, `Set shell to bash`, `Read More`,).then(async choice => {
+                    switch (choice) {
+                      case `Set shell to bash`:
+                        const commandSetBashResult = await this.sendCommand({
+                          command: `/QOpenSys/pkgs/bin/chsh -s /QOpenSys/pkgs/bin/bash`
+                        });
+
+                        if (!commandSetBashResult.stderr) {
+                          vscode.window.showInformationMessage(`Shell is now bash! Reconnect for change to take effect.`);
+                          usesBash = true;
+                        } else {
+                          vscode.window.showInformationMessage(`Default shell WAS NOT changed to bash.`);
+                        }
+                        break;
+
+                      case `Read More`:
+                        vscode.env.openExternal(vscode.Uri.parse(`https://ibmi-oss-docs.readthedocs.io/en/latest/user_setup/README.html#step-4-change-your-default-shell-to-bash`));
+                        break;
+                    }
+                  });
+                }
+              }
+
+              if (usesBash) {
+                //Ensure /QOpenSys/pkgs/bin is found in $PATH
+                progress.report({
+                  message: `Checking /QOpenSys/pkgs/bin in $PATH.`
+                });
+
+                if ((!quickConnect || !cachedServerSettings?.pathChecked)) {
+                  const currentPaths = (await this.sendCommand({ command: "echo $PATH" })).stdout.split(":");
+                  const bashrcFile = `${defaultHomeDir}/.bashrc`;
+                  let bashrcExists = (await this.sendCommand({ command: `test -e ${bashrcFile}` })).code === 0;
+                  let reason;
+                  const requiredPaths = ["/QOpenSys/pkgs/bin", "/usr/bin", "/QOpenSys/usr/bin"]
+                  let missingPath;
+                  for (const requiredPath of requiredPaths) {
+                    if (!currentPaths.includes(requiredPath)) {
+                      reason = `Your $PATH shell environment variable does not include ${requiredPath}`;
+                      missingPath = requiredPath
+                      break;
+                    }
+                  }
+                  // If reason is still undefined, then we know the user has all the required paths. Then we don't 
+                  // need to check for their existence before checking the order of the required paths.
+                  if (!reason &&
+                    (currentPaths.indexOf("/QOpenSys/pkgs/bin") > currentPaths.indexOf("/usr/bin")
+                      || (currentPaths.indexOf("/QOpenSys/pkgs/bin") > currentPaths.indexOf("/QOpenSys/usr/bin")))) {
+                    reason = "/QOpenSys/pkgs/bin is not in the right position in your $PATH shell environment variable";
+                    missingPath = "/QOpenSys/pkgs/bin"
+                  }
+                  if (reason && await vscode.window.showWarningMessage(`${missingPath} not found in $PATH`, {
+                    modal: true,
+                    detail: `${reason}, so Code for IBM i may not function correctly. Would you like to ${bashrcExists ? "update" : "create"} ${bashrcFile} to fix this now?`,
+                  }, `Yes`)) {
+                    delayedOperations.push(async () => {
+                      this.appendOutput(`${bashrcExists ? "update" : "create"} ${bashrcFile}`);
+                      if (!bashrcExists) {
+                        // Add "/usr/bin" and "/QOpenSys/usr/bin" to the end of the path. This way we know that the user has 
+                        // all the required paths, but we don't overwrite the priority of other items on their path.
+                        const createBashrc = await this.sendCommand({ command: `echo "# Generated by Code for IBM i\nexport PATH=/QOpenSys/pkgs/bin:\\$PATH:/QOpenSys/usr/bin:/usr/bin" >> ${bashrcFile} && chown ${connectionObject.username.toLowerCase()} ${bashrcFile} && chmod 755 ${bashrcFile}` });
+                        if (createBashrc.code !== 0) {
+                          vscode.window.showWarningMessage(`Error creating ${bashrcFile}):\n${createBashrc.stderr}.\n\n Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: true });
+                        }
+                      }
+                      else {
+                        try {
+                          const content = this.content;
+                          if (content) {
+                            const bashrcContent = (await content.downloadStreamfile(bashrcFile)).split("\n");
+                            let replaced = false;
+                            bashrcContent.forEach((line, index) => {
+                              if (!replaced) {
+                                const pathRegex = /^((?:export )?PATH=)(.*)(?:)$/.exec(line);
+                                if (pathRegex) {
+                                  bashrcContent[index] = `${pathRegex[1]}/QOpenSys/pkgs/bin:${pathRegex[2]
+                                    .replace("/QOpenSys/pkgs/bin", "") //Removes /QOpenSys/pkgs/bin wherever it is
+                                    .replace("::", ":")}:/QOpenSys/usr/bin:/usr/bin`; //Removes double : in case /QOpenSys/pkgs/bin wasn't at the end
+                                  replaced = true;
+                                }
+                              }
+                            });
+
+                            if (!replaced) {
+                              bashrcContent.push(
+                                "",
+                                "# Generated by Code for IBM i",
+                                "export PATH=/QOpenSys/pkgs/bin:$PATH:/QOpenSys/usr/bin:/usr/bin"
+                              );
+                            }
+
+                            await content.writeStreamfile(bashrcFile, bashrcContent.join("\n"));
+                          }
+                        }
+                        catch (error) {
+                          vscode.window.showWarningMessage(`Error modifying PATH in ${bashrcFile}):\n${error}.\n\n Code for IBM i may not function correctly. Please contact your system administrator.`, { modal: true });
+                        }
+                      }
+                    });
+                  }
+                }
+              }
+            }
+          } catch (e) {
+            // Oh well...trying to set default shell is not worth stopping for.
+            console.log(e);
+          }
+        }
+
+        if (this.config.autoConvertIFSccsid) {
+          if (this.remoteFeatures.attr === undefined || this.remoteFeatures.iconv === undefined) {
+            this.config.autoConvertIFSccsid = false;
+            vscode.window.showWarningMessage(`EBCDIC streamfiles will not be rendered correctly since \`attr\` or \`iconv\` is not installed on the host. They should both exist in \`\\usr\\bin\`.`);
+          }
+        }
+
+        if (defaultHomeDir) {
+          if (!tempLibrarySet) {
+            vscode.window.showWarningMessage(`Code for IBM i will not function correctly until the temporary library has been corrected in the settings.`, `Open Settings`)
+              .then(result => {
+                switch (result) {
+                  case `Open Settings`:
+                    vscode.commands.executeCommand(`code-for-ibmi.showAdditionalSettings`);
+                    break;
+                }
+              });
+          }
+        } else {
+          vscode.window.showWarningMessage(`Code for IBM i may not function correctly until your user has a home directory.`);
+        }
+
+        // Validate configured library list.
+        if (quickConnect() && cachedServerSettings?.libraryListValidated === true) {
+          // Do nothing, library list is already checked.
+        } else {
+          if (this.config.libraryList) {
+            progress.report({
+              message: `Validate configured library list`
+            });
+            let validLibs: string[] = [];
+            let badLibs: string[] = [];
+
+            const result = await this.sendQsh({
+              command: [
+                `liblist -d ` + IBMi.escapeForShell(this.defaultUserLibraries.join(` `)),
+                ...this.config.libraryList.map(lib => `liblist -a ` + IBMi.escapeForShell(lib))
+              ].join(`; `)
+            });
+
+            if (result.stderr) {
+              const lines = result.stderr.split(`\n`);
+
+              lines.forEach(line => {
+                const badLib = this.config?.libraryList.find(lib => line.includes(`ibrary ${lib} `));
+
+                // If there is an error about the library, store it
+                if (badLib) badLibs.push(badLib);
+              });
+            }
+
+            if (result && badLibs.length > 0) {
+              validLibs = this.config.libraryList.filter(lib => !badLibs.includes(lib));
+              const chosen = await vscode.window.showWarningMessage(`The following ${badLibs.length > 1 ? `libraries` : `library`} does not exist: ${badLibs.join(`,`)}. Remove ${badLibs.length > 1 ? `them` : `it`} from the library list?`, `Yes`, `No`);
+              if (chosen === `Yes`) {
+                this.config!.libraryList = validLibs;
+              } else {
+                vscode.window.showWarningMessage(`The following libraries does not exist: ${badLibs.join(`,`)}.`);
+              }
+            }
+          }
+        }
+
+        let debugConfigLoaded = false
+        if ((!quickConnect || !cachedServerSettings?.debugConfigLoaded)) {
+          if (debugPTFInstalled()) {
+            try {
+              const debugServiceConfig = await new DebugConfiguration(this).load();
+              delete this.config.debugCertDirectory;
+              this.config.debugPort = debugServiceConfig.getOrDefault("DBGSRV_SECURED_PORT", "8005");
+              this.config.debugSepPort = debugServiceConfig.getOrDefault("DBGSRV_SEP_DAEMON_PORT", "8008");
+              debugConfigLoaded = true;
+            }
+            catch (error) {
+              vscode.window.showWarningMessage(`Could not load debug service configuration: ${error}`);
+            }
+          }
+        }
+
+        if ((!quickConnect || !cachedServerSettings?.maximumArgsLength)) {
+          //Compute the maximum admited length of a command's arguments. Source: Googling and https://www.in-ulm.de/~mascheck/various/argmax/#effectively_usable
+          this.maximumArgsLength = Number((await this.sendCommand({ command: "/QOpenSys/usr/bin/expr `/QOpenSys/usr/bin/getconf ARG_MAX` - `env|wc -c` - `env|wc -l` \\* 4 - 2048" })).stdout);
+        }
+        else {
+          this.maximumArgsLength = cachedServerSettings.maximumArgsLength;
+        }
+
+        if (this.sqlRunnerAvailable()) {
+          // Check for ASP information?
+          if (quickConnect() && cachedServerSettings?.aspInfo) {
+            this.aspInfo = cachedServerSettings.aspInfo;
+          } else {
+            progress.report({
+              message: `Checking for ASP information.`
+            });
+
+            //This is mostly a nice to have. We grab the ASP info so user's do
+            //not have to provide the ASP in the settings.
+            try {
+              const resultSet = await this.runSQL(`SELECT * FROM QSYS2.ASP_INFO`);
+              resultSet.forEach(row => {
+                if (row.DEVICE_DESCRIPTION_NAME && row.DEVICE_DESCRIPTION_NAME && row.DEVICE_DESCRIPTION_NAME !== `null`) {
+                  this.aspInfo[Number(row.ASP_NUMBER)] = String(row.DEVICE_DESCRIPTION_NAME);
+                }
+              });
+            } catch (e) {
+              //Oh well
+              progress.report({
+                message: `Failed to get ASP information.`
+              });
+            }
+          }
+
+          // Fetch conversion values?
+          if (quickConnect() && cachedServerSettings?.jobCcsid !== null && cachedServerSettings?.userDefaultCCSID && cachedServerSettings?.qccsid) {
+            this.qccsid = cachedServerSettings.qccsid;
+            this.userJobCcsid = cachedServerSettings.jobCcsid;
+            this.userDefaultCCSID = cachedServerSettings.userDefaultCCSID;
+          } else {
+            progress.report({
+              message: `Fetching conversion values.`
+            });
+
+            // Next, we're going to see if we can get the CCSID from the user or the system.
+            // Some things don't work without it!!!
+            try {
+
+              // we need to grab the system CCSID (QCCSID)
+              const [systemCCSID] = await this.runSQL(`select SYSTEM_VALUE_NAME, CURRENT_NUMERIC_VALUE from QSYS2.SYSTEM_VALUE_INFO where SYSTEM_VALUE_NAME = 'QCCSID'`);
+              if (typeof systemCCSID.CURRENT_NUMERIC_VALUE === 'number') {
+                this.qccsid = systemCCSID.CURRENT_NUMERIC_VALUE;
+              }
+
+              // we grab the users default CCSID
+              const [userInfo] = await this.runSQL(`select CHARACTER_CODE_SET_ID from table( QSYS2.QSYUSRINFO( USERNAME => upper('${this.currentUser}') ) )`);
+              if (userInfo.CHARACTER_CODE_SET_ID !== `null` && typeof userInfo.CHARACTER_CODE_SET_ID === 'number') {
+                this.userJobCcsid = userInfo.CHARACTER_CODE_SET_ID;
+              }
+
+              // if the job ccsid is *SYSVAL, then assign it to sysval
+              if (this.userJobCcsid === IBMi.CCSID_SYSVAL) {
+                this.userJobCcsid = this.qccsid;
+              }
+
+              // Let's also get the user's default CCSID
+              try {
+                const [activeJob] = await this.runSQL(`Select DEFAULT_CCSID From Table(QSYS2.ACTIVE_JOB_INFO( JOB_NAME_FILTER => '*', DETAILED_INFO => 'ALL' ))`);
+                this.userDefaultCCSID = Number(activeJob.DEFAULT_CCSID);
+              }
+              catch (error) {
+                const [defaultCCSID] = (await this.runCommand({ command: "DSPJOB OPTION(*DFNA)" }))
+                  .stdout
+                  .split("\n")
+                  .filter(line => line.includes("DFTCCSID"));
+
+                const defaultCCSCID = Number(defaultCCSID.split("DFTCCSID").at(1)?.trim());
+                if (defaultCCSCID && !isNaN(defaultCCSCID)) {
+                  this.userDefaultCCSID = defaultCCSCID;
+                }
+              }
+
+            } catch (e) {
+              // Oh well!
+              console.log(e);
+            }
+          }
+
+          let userCcsidNeedsFixing = false;
+          let sshdCcsidMismatch = false;
+
+          const showCcsidWarning = (message: string) => {
+            vscode.window.showWarningMessage(message, `Show documentation`).then(choice => {
+              if (choice === `Show documentation`) {
+                vscode.commands.executeCommand(`vscode.open`, `https://codefori.github.io/docs/tips/ccsid/`);
+              }
+            });
+          }
+
+          if (this.canUseCqsh) {
+            // If cqsh is available, but the user profile CCSID is bad, then cqsh won't work
+            if (this.getCcsid() === IBMi.CCSID_NOCONVERSION) {
+              userCcsidNeedsFixing = true;
+            }
+          }
+
+          else {
+            // If cqsh is not available, then we need to check the SSHD CCSID
+            this.sshdCcsid = await this.content.getSshCcsid();
+            if (this.sshdCcsid === this.getCcsid()) {
+              // If the SSHD CCSID matches the job CCSID (not the user profile!), then we're good.
+              // This means we can use regular qsh without worrying about translation because the SSHD and job CCSID match.
+              userCcsidNeedsFixing = false;
+            } else {
+              // If the SSHD CCSID does not match the job CCSID, then we need to warn the user
+              sshdCcsidMismatch = true;
+            }
+          }
+
+          if (userCcsidNeedsFixing) {
+            showCcsidWarning(`The job CCSID is set to ${IBMi.CCSID_NOCONVERSION}. This may cause issues with objects with variant characters. Please use CHGUSRPRF USER(${this.currentUser.toUpperCase()}) CCSID(${this.userDefaultCCSID}) to set your profile to the current default CCSID.`);
+          } else if (sshdCcsidMismatch) {
+            showCcsidWarning(`The CCSID of the SSH connection (${this.sshdCcsid}) does not match the job CCSID (${this.getCcsid()}). This may cause issues with objects with variant characters.`);
+          }
+
+          this.appendOutput(`\nCCSID information:\n`);
+          this.appendOutput(`\tQCCSID: ${this.qccsid}\n`);
+          this.appendOutput(`\tUser Job CCSID: ${this.userJobCcsid}\n`);
+          this.appendOutput(`\tUser Default CCSID: ${this.userDefaultCCSID}\n`);
+          if (this.sshdCcsid) {
+            this.appendOutput(`\tSSHD CCSID: ${this.sshdCcsid}\n`);
+          }
+
+          // We only do this check if we're on 7.3 or below.
+          if (this.systemVersion && this.systemVersion <= 7.3) {
+            progress.report({
+              message: `Checking PASE locale environment variables.`
+            });
+
+            const systemEnvVars = await this.content.getSysEnvVars();
+
+            const paseLang = systemEnvVars.PASE_LANG;
+            const paseCcsid = systemEnvVars.QIBM_PASE_CCSID;
+
+            if (paseLang === undefined || paseCcsid === undefined) {
+              showCcsidWarning(`The PASE environment variables PASE_LANG and QIBM_PASE_CCSID are not set correctly and is required for this OS version (${this.systemVersion}). This may cause issues with objects with variant characters.`);
+            } else if (paseCcsid !== `1208`) {
+              showCcsidWarning(`The PASE environment variable QIBM_PASE_CCSID is not set to 1208 and is required for this OS version (${this.systemVersion}). This may cause issues with objects with variant characters.`);
+            }
+          }
+
+          // We always need to fetch the local variants because 
+          // now we pickup CCSID changes faster due to cqsh
+          progress.report({
+            message: `Fetching local encoding values.`
+          });
+
+          const [variants] = await this.runSQL(`With VARIANTS ( HASH, AT, DOLLARSIGN ) as (`
+            + `  values ( cast( x'7B' as varchar(1) )`
+            + `         , cast( x'7C' as varchar(1) )`
+            + `         , cast( x'5B' as varchar(1) ) )`
+            + `)`
+            + `Select HASH concat AT concat DOLLARSIGN as LOCAL from VARIANTS`);
+
+          if (typeof variants.LOCAL === 'string' && variants.LOCAL !== `null`) {
+            this.variantChars.local = variants.LOCAL;
+          }
+        } else {
+          vscode.window.showWarningMessage(`The SQL runner is not available. This could mean that VS Code will not work for this connection. See our documentation for more information.`)
+        }
+
+        if (!reconnecting) {
+          for (const operation of delayedOperations) {
+            await operation();
+          }
+        }
+
+        GlobalStorage.get().setServerSettingsCache(this.currentConnectionName, {
+          lastCheckedOnVersion: currentExtensionVersion,
+          aspInfo: this.aspInfo,
+          qccsid: this.qccsid,
+          jobCcsid: this.userJobCcsid,
+          remoteFeatures: this.remoteFeatures,
+          remoteFeaturesKeys: Object.keys(this.remoteFeatures).sort().toString(),
+          badDataAreasChecked: true,
+          libraryListValidated: true,
+          pathChecked: true,
+          userDefaultCCSID: this.userDefaultCCSID,
+          debugConfigLoaded,
+          maximumArgsLength: this.maximumArgsLength
+        });
 
         return {
-          success: false,
-          error
+          success: true
         };
+      });
+
+    } catch (e: any) {
+
+      if (this.client.isConnected()) {
+        this.client.dispose();
       }
-      finally {
-        ConnectionConfiguration.update(this.config!);
+      if (reconnecting && await vscode.window.showWarningMessage(`Could not reconnect`, {
+        modal: true,
+        detail: `Reconnection to ${this.currentConnectionName} has failed. Would you like to try again?\n\n${e}`
+      }, `Yes`)) {
+        return this.connect(connectionObject, true);
       }
-    });
+
+      let error = e;
+      if (e.code === "ENOTFOUND") {
+        error = `Host is unreachable. Check the connection's hostname/IP address.`;
+      }
+      else if (e.code === "ECONNREFUSED") {
+        error = `Port ${connectionObject.port} is unreachable. Check the connection's port number or run command STRTCPSVR SERVER(*SSHD) on the host.`
+      }
+      else if (e.level === "client-authentication") {
+        error = `Check your credentials${e.message ? ` (${e.message})` : ''}.`;
+      }
+
+      return {
+        success: false,
+        error
+      };
+    }
+    finally {
+      ConnectionConfiguration.update(this.config!);
+    }
   }
 
   /**
@@ -1119,7 +1128,7 @@ export default class IBMi {
   }
 
   usingBash() {
-    return this.shell === bashShellPath;
+    return this.shell === IBMi.bashShellPath;
   }
 
   /**
@@ -1131,7 +1140,7 @@ export default class IBMi {
    *   `env` to customise them.
    */
   runCommand(data: RemoteCommand) {
-    return CompileTools.runCommand(instance, data);
+    return CompileTools.runCommand(this, data);
   }
 
   static escapeForShell(command: string) {
@@ -1197,20 +1206,6 @@ export default class IBMi {
     // Some simplification
     if (result.code === null) result.code = 0;
 
-    // Store the error
-    if (result.code && result.stderr) {
-      this.lastErrors.push({
-        command,
-        code: result.code,
-        stderr: result.stderr,
-        cwd: directory
-      });
-
-      // We don't want it to fill up too much.
-      if (this.lastErrors.length > 3)
-        this.lastErrors.shift();
-    }
-
     this.appendOutput(JSON.stringify(result, null, 4) + `\n\n`);
 
     return {
@@ -1249,7 +1244,7 @@ export default class IBMi {
     instance.fire(`disconnected`);
   }
 
-  async end() {
+  async dispose() {
     if (this.client.connection) {
       this.disconnect();
     }
@@ -1262,16 +1257,6 @@ export default class IBMi {
     if (this.outputChannelContent !== undefined) {
       this.outputChannelContent = undefined;
     }
-
-    await Promise.all([
-      vscode.commands.executeCommand("code-for-ibmi.refreshObjectBrowser"),
-      vscode.commands.executeCommand("code-for-ibmi.refreshLibraryListView"),
-      vscode.commands.executeCommand("code-for-ibmi.refreshIFSBrowser")
-    ]);
-
-    instance.setConnection(undefined);
-    await vscode.commands.executeCommand(`setContext`, `code-for-ibmi:connected`, false);
-    vscode.window.showInformationMessage(`Disconnected from ${this.currentHost}.`);
   }
 
   /**
@@ -1284,33 +1269,6 @@ export default class IBMi {
 
   public sqlRunnerAvailable() {
     return this.remoteFeatures[`QZDFMDB2.PGM`] !== undefined;
-  }
-
-  private async getSshCcsid() {
-    const sql = `
-    with SSH_DETAIL (id, iid) as (
-      select substring(job_name, locate('/', job_name, 15)+1, 10) as id, internal_job_id as iid from qsys2.netstat_job_info j where local_address = '0.0.0.0' and local_port = 22
-    )
-    select DEFAULT_CCSID, CCSID from table(QSYS2.ACTIVE_JOB_INFO( JOB_NAME_FILTER => (select id from SSH_DETAIL), DETAILED_INFO => 'ALL')) where INTERNAL_JOB_ID = (select iid from SSH_DETAIL)
-    `;
-
-    const [result] = await this.runSQL(sql);
-    return Number(result.CCSID === CCSID_NOCONVERSION ? result.DEFAULT_CCSID : result.CCSID);
-  }
-
-  async getSysEnvVars() {
-    const systemEnvVars = await this.runSQL([
-      `select ENVIRONMENT_VARIABLE_NAME, ENVIRONMENT_VARIABLE_VALUE`,
-      `from qsys2.environment_variable_info where environment_variable_type = 'SYSTEM'`
-    ].join(` `)) as { ENVIRONMENT_VARIABLE_NAME: string, ENVIRONMENT_VARIABLE_VALUE: string }[];
-
-    let result: { [name: string]: string; } = {};
-
-    systemEnvVars.forEach(row => {
-      result[row.ENVIRONMENT_VARIABLE_NAME] = row.ENVIRONMENT_VARIABLE_VALUE;
-    });
-
-    return result;
   }
 
   /**
@@ -1415,21 +1373,6 @@ export default class IBMi {
 
     return result
   }
-  async uploadFiles(files: { local: string | vscode.Uri, remote: string }[], options?: node_ssh.SSHPutFilesOptions) {
-    await this.client.putFiles(files.map(f => { return { local: this.fileToPath(f.local), remote: f.remote } }), options);
-  }
-
-  async downloadFile(localFile: string | vscode.Uri, remoteFile: string) {
-    await this.client.getFile(this.fileToPath(localFile), remoteFile);
-  }
-
-  async uploadDirectory(localDirectory: string | vscode.Uri, remoteDirectory: string, options?: node_ssh.SSHGetPutDirectoryOptions) {
-    await this.client.putDirectory(this.fileToPath(localDirectory), remoteDirectory, options);
-  }
-
-  async downloadDirectory(localDirectory: string | vscode.Uri, remoteDirectory: string, options?: node_ssh.SSHGetPutDirectoryOptions) {
-    await this.client.getDirectory(this.fileToPath(localDirectory), remoteDirectory, options);
-  }
 
   getLastDownloadLocation() {
     if (this.config?.lastDownloadLocation && existsSync(Tools.fixWindowsPath(this.config.lastDownloadLocation))) {
@@ -1444,15 +1387,6 @@ export default class IBMi {
     if (this.config && location && location !== this.config.lastDownloadLocation) {
       this.config.lastDownloadLocation = location;
       await ConnectionConfiguration.update(this.config);
-    }
-  }
-
-  fileToPath(file: string | vscode.Uri): string {
-    if (typeof file === "string") {
-      return Tools.fixWindowsPath(file);
-    }
-    else {
-      return file.fsPath;
     }
   }
 
@@ -1634,7 +1568,7 @@ export default class IBMi {
   }
 
   getCcsid() {
-    const fallbackToDefault = ((this.userJobCcsid < 1 || this.userJobCcsid === CCSID_NOCONVERSION) && this.userDefaultCCSID > 0);
+    const fallbackToDefault = ((this.userJobCcsid < 1 || this.userJobCcsid === IBMi.CCSID_NOCONVERSION) && this.userDefaultCCSID > 0);
     const ccsid = fallbackToDefault ? this.userDefaultCCSID : this.userJobCcsid;
     return ccsid;
   }
@@ -1646,19 +1580,5 @@ export default class IBMi {
       userDefaultCCSID: this.userDefaultCCSID,
       sshdCcsid: this.sshdCcsid
     };
-  }
-
-  async checkUserSpecialAuthorities(authorities: SpecialAuthorities[], user?: string) {
-    const profile = (user || this.currentUser).toLocaleUpperCase();
-    const [row] = await this.runSQL(
-      `select trim(coalesce(usr.special_authorities,'') concat ' ' concat coalesce(grp.special_authorities, '')) AUTHORITIES ` +
-      `from qsys2.user_info_basic usr ` +
-      `left join qsys2.user_info_basic grp on grp.authorization_name = usr.group_profile_name ` +
-      `where usr.authorization_name = '${profile}'`
-    );
-
-    const userAuthorities = row?.AUTHORITIES ? String(row.AUTHORITIES).split(" ").filter(Boolean).filter(Tools.distinct) : [];
-    const missing = authorities.filter(auth => !userAuthorities.includes(auth));
-    return { valid: !Boolean(missing.length), missing };
   }
 }

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -3,10 +3,11 @@ import fs from 'fs';
 import path from 'path';
 import tmp from 'tmp';
 import util from 'util';
-import { MarkdownString, window } from 'vscode';
+import * as node_ssh from "node-ssh";
+import { MarkdownString, Uri, window } from 'vscode';
 import { GetMemberInfo } from '../components/getMemberInfo';
 import { ObjectTypes } from '../filesystems/qsys/Objects';
-import { AttrOperands, CommandResult, IBMiError, IBMiMember, IBMiObject, IFSFile, QsysPath } from '../typings';
+import { AttrOperands, CommandResult, IBMiError, IBMiMember, IBMiObject, IFSFile, QsysPath, SpecialAuthorities } from '../typings';
 import { ConnectionConfiguration } from './Configuration';
 import { FilterType, parseFilter, singleGenericName } from './Filter';
 import { default as IBMi } from './IBMi';
@@ -29,12 +30,7 @@ export default class IBMiContent {
   constructor(readonly ibmi: IBMi) { }
 
   private get config(): ConnectionConfiguration.Parameters {
-    if (!this.ibmi.config) {
-      throw new Error("Please connect to an IBM i");
-    }
-    else {
-      return this.ibmi.config;
-    }
+    return this.ibmi.getConfig();
   }
 
   private getTempRemote(path: string) {
@@ -89,7 +85,7 @@ export default class IBMiContent {
       localPath = await tmpFile();
     }
 
-    await this.ibmi.downloadFile(localPath, remotePath);
+    await this.downloadFile(localPath, remotePath);
     const raw = await readFileAsync(localPath);
     return raw;
   }
@@ -176,7 +172,7 @@ export default class IBMiContent {
         if (!localPath) {
           localPath = await tmpFile();
         }
-        await this.ibmi.downloadFile(localPath, tempRmt);
+        await this.downloadFile(localPath, tempRmt);
         return await readFileAsync(localPath, `utf8`);
       } else {
         if (!retry) {
@@ -987,6 +983,21 @@ export default class IBMiContent {
     return Number((await this.ibmi.sendCommand({ command: `cd "${directory}" && (ls | wc -l)` })).stdout.trim());
   }
 
+
+  async checkUserSpecialAuthorities(authorities: SpecialAuthorities[], user?: string) {
+    const profile = (user || this.ibmi.currentUser).toLocaleUpperCase();
+    const [row] = await this.ibmi.runSQL(
+      `select trim(coalesce(usr.special_authorities,'') concat ' ' concat coalesce(grp.special_authorities, '')) AUTHORITIES ` +
+      `from qsys2.user_info_basic usr ` +
+      `left join qsys2.user_info_basic grp on grp.authorization_name = usr.group_profile_name ` +
+      `where usr.authorization_name = '${profile}'`
+    );
+
+    const userAuthorities = row?.AUTHORITIES ? String(row.AUTHORITIES).split(" ").filter(Boolean).filter(Tools.distinct) : [];
+    const missing = authorities.filter(auth => !userAuthorities.includes(auth));
+    return { valid: !Boolean(missing.length), missing };
+  }
+
   objectToToolTip(path: string, object: IBMiObject) {
     const tooltip = new MarkdownString(Tools.generateTooltipHtmlTable(path, {
       "Type": object.type,
@@ -1036,6 +1047,33 @@ export default class IBMiContent {
     return tooltip;
   }
 
+  async getSshCcsid() {
+    const sql = `
+    with SSH_DETAIL (id, iid) as (
+      select substring(job_name, locate('/', job_name, 15)+1, 10) as id, internal_job_id as iid from qsys2.netstat_job_info j where local_address = '0.0.0.0' and local_port = 22
+    )
+    select DEFAULT_CCSID, CCSID from table(QSYS2.ACTIVE_JOB_INFO( JOB_NAME_FILTER => (select id from SSH_DETAIL), DETAILED_INFO => 'ALL')) where INTERNAL_JOB_ID = (select iid from SSH_DETAIL)
+    `;
+
+    const [result] = await this.ibmi.runSQL(sql);
+    return Number(result.CCSID === IBMi.CCSID_NOCONVERSION ? result.DEFAULT_CCSID : result.CCSID);
+  }
+
+  async getSysEnvVars() {
+    const systemEnvVars = await this.ibmi.runSQL([
+      `select ENVIRONMENT_VARIABLE_NAME, ENVIRONMENT_VARIABLE_VALUE`,
+      `from qsys2.environment_variable_info where environment_variable_type = 'SYSTEM'`
+    ].join(` `)) as { ENVIRONMENT_VARIABLE_NAME: string, ENVIRONMENT_VARIABLE_VALUE: string }[];
+
+    let result: { [name: string]: string; } = {};
+
+    systemEnvVars.forEach(row => {
+      result[row.ENVIRONMENT_VARIABLE_NAME] = row.ENVIRONMENT_VARIABLE_VALUE;
+    });
+
+    return result;
+  }
+
   /**
    * Creates an empty unicode streamfile
    * @param path the full path to the streamfile
@@ -1047,6 +1085,22 @@ export default class IBMiContent {
     if (result.code !== 0) {
       throw new Error(result.stderr);
     }
+  }
+
+  async uploadFiles(files: { local: string | Uri, remote: string }[], options?: node_ssh.SSHPutFilesOptions) {
+    await this.ibmi.client.putFiles(files.map(f => { return { local: Tools.fileToPath(f.local), remote: f.remote } }), options);
+  }
+
+  async downloadFile(localFile: string | Uri, remoteFile: string) {
+    await this.ibmi.client.getFile(Tools.fileToPath(localFile), remoteFile);
+  }
+
+  async uploadDirectory(localDirectory: string | Uri, remoteDirectory: string, options?: node_ssh.SSHGetPutDirectoryOptions) {
+    await this.ibmi.client.putDirectory(Tools.fileToPath(localDirectory), remoteDirectory, options);
+  }
+
+  async downloadDirectory(localDirectory: string | Uri, remoteDirectory: string, options?: node_ssh.SSHGetPutDirectoryOptions) {
+    await this.ibmi.client.getDirectory(Tools.fileToPath(localDirectory), remoteDirectory, options);
   }
 }
 

--- a/src/api/Instance.ts
+++ b/src/api/Instance.ts
@@ -72,6 +72,7 @@ export default class Instance {
 
         if (result.success) {
           await this.setConnection(connection);
+          break;
 
         } else {
           await this.setConnection();

--- a/src/api/Instance.ts
+++ b/src/api/Instance.ts
@@ -54,7 +54,7 @@ export default class Instance {
           });
         }
 
-        await conn.dispose();
+        this.setConnection();
 
         if (reconnect) {
           await this.connect({...options, reconnecting: true});
@@ -75,7 +75,7 @@ export default class Instance {
           break;
 
         } else {
-          await this.setConnection();
+          await this.disconnect();
           if (options.reconnecting && await vscode.window.showWarningMessage(`Could not reconnect`, {
             modal: true,
             detail: `Reconnection has failed. Would you like to try again?\n\n${result.error || `No error provided.`}`
@@ -110,11 +110,11 @@ export default class Instance {
   }
 
   private async setConnection(connection?: IBMi) {
-    if (connection) {
-      if (this.connection) {
-        await this.connection.dispose();
-      }
+    if (this.connection) {
+      await this.connection.dispose();
+    }
 
+    if (connection) {
       this.connection = connection;
       this.storage.setConnectionName(connection.currentConnectionName);
       await GlobalStorage.get().setLastConnection(connection.currentConnectionName);

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -463,4 +463,13 @@ export namespace Tools {
     }
     return 0;
   }
+
+  export function fileToPath(file: string | vscode.Uri): string {
+    if (typeof file === "string") {
+      return Tools.fixWindowsPath(file);
+    }
+    else {
+      return file.fsPath;
+    }
+  }
 }

--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -77,7 +77,7 @@ async function getExtFileContent(hostInfo: HostInfo) {
  * @param imported if defined, gives the location and password of a local or remote (i.e. on the IFS) service certificate to import
  */
 export async function setup(connection: IBMi, imported?: ImportedCertificate) {
-  if (!(await connection.checkUserSpecialAuthorities(["*ALLOBJ"])).valid) {
+  if (!(await connection.getContent().checkUserSpecialAuthorities(["*ALLOBJ"])).valid) {
     throw new Error(`User ${connection.currentUser} doesn't have *ALLOBJ special authority`);
   }
   await vscode.window.withProgress({ title: "Setup debug service", location: vscode.ProgressLocation.Window }, async (task) => {
@@ -91,7 +91,7 @@ export async function setup(connection: IBMi, imported?: ImportedCertificate) {
       }
     }
 
-    const debugConfig = await new DebugConfiguration().load();
+    const debugConfig = await new DebugConfiguration(connection).load();
 
     const certificatePath = debugConfig.getRemoteServiceCertificatePath();
     const directory = dirname(certificatePath);
@@ -109,7 +109,7 @@ export async function setup(connection: IBMi, imported?: ImportedCertificate) {
       password = imported.password;
       if (imported.localFile) {
         setProgress("importing local certificate");
-        await connection.uploadFiles([{ local: imported.localFile, remote: debugConfig.getRemoteServiceCertificatePath() }]);
+        await connection.getContent().uploadFiles([{ local: imported.localFile, remote: debugConfig.getRemoteServiceCertificatePath() }]);
       }
       else if (imported.remoteFile) {
         setProgress("importing remote certificate");
@@ -214,9 +214,10 @@ export async function debugKeyFileExists(connection: IBMi, debugConfig: DebugCon
 }
 
 export async function remoteCertificatesExists(debugConfig?: DebugConfiguration) {
-  const content = instance.getContent();
-  if (content) {
-    debugConfig = debugConfig || await new DebugConfiguration().load();
+  const connection = instance.getConnection();
+  if (connection) {
+    const content = connection.getContent();
+    debugConfig = debugConfig || await new DebugConfiguration(connection).load();
     return await content.testStreamFile(debugConfig.getRemoteServiceCertificatePath(), "f") && await content.testStreamFile(debugConfig.getRemoteClientCertificatePath(), "f");
   }
   else {
@@ -225,13 +226,8 @@ export async function remoteCertificatesExists(debugConfig?: DebugConfiguration)
 }
 
 export async function downloadClientCert(connection: IBMi) {
-  const content = instance.getContent();
-  if (content) {
-    await content.downloadStreamfileRaw((await new DebugConfiguration().load()).getRemoteClientCertificatePath(), getLocalCertPath(connection));
-  }
-  else {
-    throw new Error("Not connected to an IBM i");
-  }
+  const content = connection.getContent();
+  await content.downloadStreamfileRaw((await new DebugConfiguration(connection).load()).getRemoteClientCertificatePath(), getLocalCertPath(connection));
 }
 
 export function getLocalCertPath(connection: IBMi) {
@@ -242,7 +238,7 @@ export function getLocalCertPath(connection: IBMi) {
 export async function checkClientCertificate(connection: IBMi, debugConfig?: DebugConfiguration) {
   const locaCertificatePath = getLocalCertPath(connection);
   if (existsSync(locaCertificatePath)) {
-    debugConfig = debugConfig || await new DebugConfiguration().load();
+    debugConfig = debugConfig || await new DebugConfiguration(connection).load();
     const remote = (await connection.sendCommand({ command: `cat ${debugConfig.getRemoteClientCertificatePath()}` }));
     if (!remote.code) {
       const localCertificate = readFileSync(locaCertificatePath).toString("utf-8");
@@ -263,7 +259,7 @@ export async function sanityCheck(connection: IBMi, content: IBMiContent) {
   //Since Code for IBM i v2.10.0, the debug configuration is managed from the debug service .env file
   //The encryption key is backed up since it's destroyed every time the service starts up
   //The remote certificate is only valid if the client certificate is found too
-  const debugConfig = await new DebugConfiguration().load();
+  const debugConfig = await new DebugConfiguration(connection).load();
 
   //Check if java home needs to be updated if the service got updated (e.g: v1 uses Java 8 and v2 uses Java 11)
   const javaHome = debugConfig.get("JAVA_HOME");
@@ -293,7 +289,7 @@ export async function sanityCheck(connection: IBMi, content: IBMiContent) {
       })
     }
   }
-  else if ((await connection.checkUserSpecialAuthorities(["*ALLOBJ"])).valid) {
+  else if ((await connection.getContent().checkUserSpecialAuthorities(["*ALLOBJ"])).valid) {
     try {
       if (legacyCertExists && !remoteCertExists) {
         //import legacy

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -279,7 +279,6 @@ export async function initialize(context: ExtensionContext) {
       Tools.withContext("code-for-ibmi:debugWorking", async () => {
         const connection = instance.getConnection();
         if (connection) {
-          const content = connection.getContent();
           const ptfInstalled = server.debugPTFInstalled();
 
           if (ptfInstalled) {

--- a/src/api/debug/index.ts
+++ b/src/api/debug/index.ts
@@ -259,7 +259,7 @@ export async function initialize(context: ExtensionContext) {
         if (doSetup) {
           Tools.withContext("code-for-ibmi:debugWorking", async () => {
             if (!(await server.getDebugServiceJob()) || await server.stopService(connection)) {
-              const debugConfig = await new DebugConfiguration().load();
+              const debugConfig = await new DebugConfiguration(connection).load();
               const clearResult = await connection.sendCommand({ command: `rm -f ${debugConfig.getRemoteServiceCertificatePath()} ${debugConfig.getRemoteClientCertificatePath()}` });
               if (clearResult.code) {
                 vscode.window.showErrorMessage(`Failed to clear existing certificate: ${clearResult.stderr}`);
@@ -278,12 +278,12 @@ export async function initialize(context: ExtensionContext) {
     vscode.commands.registerCommand(`code-for-ibmi.debug.setup.remote`, (doSetup?: 'Generate' | 'Import') =>
       Tools.withContext("code-for-ibmi:debugWorking", async () => {
         const connection = instance.getConnection();
-        const content = instance.getContent();
-        if (connection && content) {
+        if (connection) {
+          const content = connection.getContent();
           const ptfInstalled = server.debugPTFInstalled();
 
           if (ptfInstalled) {
-            const debugConfig = await new DebugConfiguration().load()
+            const debugConfig = await new DebugConfiguration(connection).load()
             const remoteCertsExists = await certificates.remoteCertificatesExists(debugConfig);
             if (remoteCertsExists && await certificates.debugKeyFileExists(connection, debugConfig) && debugConfig.getCode4iDebug()) {
               await certificates.downloadClientCert(connection);

--- a/src/api/debug/server.ts
+++ b/src/api/debug/server.ts
@@ -21,14 +21,14 @@ export async function isSEPSupported() {
 
 export async function startService(connection: IBMi) {
   const checkAuthority = async (user?: string) => {
-    if (!(await connection.checkUserSpecialAuthorities(["*ALLOBJ"], user)).valid) {
+    if (!(await connection.getContent().checkUserSpecialAuthorities(["*ALLOBJ"], user)).valid) {
       throw new Error(`User ${user || connection.currentUser} doesn't have *ALLOBJ special authority`);
     }
   };
 
   try {
     await checkAuthority();
-    const debugConfig = await new DebugConfiguration().load();
+    const debugConfig = await new DebugConfiguration(connection).load();
 
     const submitOptions = await window.showInputBox({
       title: l10n.t(`Debug Service submit options`),
@@ -95,7 +95,7 @@ export async function startService(connection: IBMi) {
 }
 
 export async function stopService(connection: IBMi) {
-  const debugConfig = await new DebugConfiguration().load();
+  const debugConfig = await new DebugConfiguration(connection).load();
   const endResult = await connection.sendCommand({
     command: `${path.posix.join(debugConfig.getRemoteServiceBin(), `stopDebugService.sh`)}`
   });

--- a/src/commands/actions.ts
+++ b/src/commands/actions.ts
@@ -1,0 +1,142 @@
+import path from "path";
+import { commands, TreeItem, Uri, WorkspaceFolder, window, Disposable } from "vscode";
+import { CompileTools } from "../api/CompileTools";
+import { ConnectionConfiguration } from "../api/Configuration";
+import { refreshDiagnosticsFromServer } from "../api/errors/diagnostics";
+import Instance from "../api/Instance";
+import { BrowserItem, Action, DeploymentMethod } from "../typings";
+
+export function registerActionsCommands(instance: Instance): Disposable[] {
+  return [
+    commands.registerCommand(`code-for-ibmi.runAction`, async (target: TreeItem | BrowserItem | Uri, group?: any, action?: Action, method?: DeploymentMethod, workspaceFolder?: WorkspaceFolder) => {
+      const connection = instance.getConnection()!;
+      const editor = window.activeTextEditor;
+      let uri;
+      let browserItem;
+      if (target) {
+        if ("fsPath" in target) {
+          uri = target;
+        }
+        else {
+          uri = target?.resourceUri;
+          if ("refresh" in target) {
+            browserItem = target;
+          }
+        }
+      }
+
+      uri = uri || editor?.document.uri;
+
+      if (uri) {
+        if (connection) {
+          const config = connection.getConfig();
+          let canRun = true;
+          if (editor && uri.path === editor.document.uri.path && editor.document.isDirty) {
+            if (config.autoSaveBeforeAction) {
+              await editor.document.save();
+            } else {
+              const result = await window.showWarningMessage(`The file must be saved to run Actions.`, `Save`, `Save automatically`, `Cancel`);
+              switch (result) {
+                case `Save`:
+                  await editor.document.save();
+                  canRun = true;
+                  break;
+                case `Save automatically`:
+                  config.autoSaveBeforeAction = true;
+                  await ConnectionConfiguration.update(config);
+                  await editor.document.save();
+                  canRun = true;
+                  break;
+                default:
+                  canRun = false;
+                  break;
+              }
+            }
+          }
+
+          if (canRun && [`member`, `streamfile`, `file`, 'object'].includes(uri.scheme)) {
+            return await CompileTools.runAction(instance, uri, action, method, browserItem, workspaceFolder);
+          }
+        }
+        else {
+          window.showErrorMessage('Please connect to an IBM i first');
+        }
+      }
+
+      return false;
+    }),
+
+    commands.registerCommand(`code-for-ibmi.openErrors`, async (qualifiedObject?: string) => {
+      interface ObjectDetail {
+        asp?: string;
+        lib: string;
+        object: string;
+        ext?: string;
+      }
+
+      const detail: ObjectDetail = {
+        asp: undefined,
+        lib: ``,
+        object: ``,
+        ext: undefined
+      };
+
+      let inputPath: string | undefined
+
+      if (qualifiedObject) {
+        // Value passed in via parameter
+        inputPath = qualifiedObject;
+
+      } else {
+        // Value collected from user input
+
+        let initialPath = ``;
+        const editor = window.activeTextEditor;
+        const connection = instance.getConnection();
+        
+        if (editor && connection) {
+          const config = connection.getConfig();
+          const uri = editor.document.uri;
+
+          if ([`member`, `streamfile`].includes(uri.scheme)) {
+
+            switch (uri.scheme) {
+              case `member`:
+                const memberPath = uri.path.split(`/`);
+                if (memberPath.length === 4) {
+                  detail.lib = memberPath[1];
+                } else if (memberPath.length === 5) {
+                  detail.asp = memberPath[1];
+                  detail.lib = memberPath[2];
+                }
+                break;
+              case `streamfile`:
+                detail.asp = (config.sourceASP && config.sourceASP.length > 0) ? config.sourceASP : undefined;
+                detail.lib = config.currentLibrary;
+                break;
+            }
+
+            const pathDetail = path.parse(editor.document.uri.path);
+            detail.object = pathDetail.name;
+            detail.ext = pathDetail.ext.substring(1);
+
+            initialPath = `${detail.lib}/${pathDetail.base}`;
+          }
+        }
+
+        inputPath = await window.showInputBox({
+          prompt: `Enter object path (LIB/OBJECT)`,
+          value: initialPath
+        });
+      }
+
+      if (inputPath) {
+        const [library, object] = inputPath.split(`/`);
+        if (library && object) {
+          const nameDetail = path.parse(object);
+          refreshDiagnosticsFromServer(instance, { library, object: nameDetail.name, extension: (nameDetail.ext.length > 1 ? nameDetail.ext.substring(1) : undefined) });
+        }
+      }
+    }),
+  ]
+}

--- a/src/commands/compare.ts
+++ b/src/commands/compare.ts
@@ -1,0 +1,117 @@
+import { commands, window, Uri, l10n, Disposable } from "vscode";
+import Instance from "../api/Instance";
+
+let selectedForCompare: Uri;
+
+export function registerCompareCommands(instance: Instance): Disposable[] {
+  return [
+    commands.registerCommand(`code-for-ibmi.selectForCompare`, async (node) => {
+      if (node) {
+        selectedForCompare = node.resourceUri;
+        window.showInformationMessage(`Selected ${node.path} for compare.`);
+      }
+    }),
+    commands.registerCommand(`code-for-ibmi.compareWithSelected`, async (node) => {
+      if (selectedForCompare) {
+        let uri;
+        if (node) {
+          uri = node.resourceUri;
+        } else {
+          const activeEditor = window.activeTextEditor;
+          const value = (activeEditor ? activeEditor.document.uri : selectedForCompare)
+            .with({ query: '' })
+            .toString();
+          const compareWith = await window.showInputBox({
+            prompt: `Enter the path to compare selected with`,
+            value,
+            title: `Compare with`
+          })
+
+          if (compareWith)
+            uri = Uri.parse(compareWith);
+        }
+
+        if (uri) {
+          commands.executeCommand(`diff`, selectedForCompare, uri);
+        } else {
+          window.showErrorMessage(`No compare to path provided.`);
+        }
+      } else {
+        window.showInformationMessage(`Nothing selected to compare.`);
+      }
+    }),
+
+    commands.registerCommand(`code-for-ibmi.compareCurrentFileWithMember`, async (node) => {
+      compareCurrentFile(node, `member`);
+    }),
+    commands.registerCommand(`code-for-ibmi.compareCurrentFileWithStreamFile`, async (node) => {
+      compareCurrentFile(node, `streamfile`);
+    }),
+    commands.registerCommand(`code-for-ibmi.compareCurrentFileWithLocal`, async (node) => {
+      compareCurrentFile(node, `file`);
+    }),
+    commands.registerCommand(`code-for-ibmi.compareWithActiveFile`, async (node) => {
+      let selectedFile;
+      if (node) {
+        if (node.scheme === `streamfile` || node.constructor.name === `IFSFileItem` || node.constructor.name === `ObjectBrowserItem`) {
+          selectedFile = node.resourceUri;
+        } else if (node.scheme === `file`) {
+          selectedFile = node
+        } else {
+          window.showInformationMessage(l10n.t(`No file is open or selected`));
+        }
+
+        let activeFile;
+        const editor = window.activeTextEditor;
+        if (editor) {
+          activeFile = editor.document.uri;
+          if (activeFile) {
+            commands.executeCommand(`diff`, activeFile, selectedFile);
+          } else {
+            window.showInformationMessage(l10n.t(`No file is open or selected`));
+          }
+        } else {
+          window.showInformationMessage(l10n.t(`No file is open or selected`));
+        }
+      } else {
+        window.showInformationMessage(l10n.t(`No file is open or selected`));
+      }
+    }),
+  ]
+}
+
+async function compareCurrentFile(node: any, scheme: `streamfile` | `file` | `member`) {
+  let currentFile: Uri | undefined;
+  // If we are comparing with an already targeted node
+  if (node) {
+    if (node.resourceUri) {
+      currentFile = node.resourceUri;
+    } else if (node.scheme === `file`) {
+      currentFile = node
+    }
+  } else {
+    // If we are comparing with the currently open file
+    const editor = window.activeTextEditor;
+    if (editor) {
+      currentFile = editor.document.uri;
+    }
+  }
+
+  if (currentFile) {
+    let compareWith = await window.showInputBox({
+      prompt: l10n.t(`Enter the path to compare selected with`),
+      title: l10n.t(`Compare with`),
+      value: currentFile.path
+    });
+
+    if (compareWith) {
+      if (scheme == 'member' && !compareWith.startsWith('/')) {
+        compareWith = `/${compareWith}`;
+      }
+      let uri = Uri.parse(`${scheme}:${compareWith}`);
+      commands.executeCommand(`vscode.diff`, currentFile, uri);
+    }
+  } else {
+    window.showInformationMessage(l10n.t(`No file is open or selected`));
+  }
+}

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -1,0 +1,33 @@
+import { commands, Disposable, ExtensionContext, window } from "vscode";
+import { ConnectionManager } from "../api/Configuration";
+import Instance from "../api/Instance";
+import { ConnectionData } from "../typings";
+import { safeDisconnect } from "../instantiate";
+
+export function registerConnectionCommands(context: ExtensionContext, instance: Instance): Disposable[] {
+
+  return [
+    commands.registerCommand(`code-for-ibmi.connectDirect`,
+      async (connectionData: ConnectionData, reloadSettings = false, savePassword = false): Promise<boolean> => {
+        const existingConnection = instance.getConnection();
+
+        if (existingConnection) {
+          return false;
+        }
+
+        if (savePassword && connectionData.password) {
+          await ConnectionManager.setStoredPassword(context, connectionData.name, connectionData.password);
+        }
+
+        return (await instance.connect({data: connectionData, reloadServerSettings: reloadSettings})).success;
+      }
+    ),
+    commands.registerCommand(`code-for-ibmi.disconnect`, async (silent?: boolean) => {
+      if (instance.getConnection()) {
+        await safeDisconnect();
+      } else if (!silent) {
+        window.showErrorMessage(`Not currently connected to any system.`);
+      }
+    }),
+  ]
+}

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -1,0 +1,453 @@
+import { commands, Disposable, l10n, QuickInputButton, QuickPickItem, QuickPickItemButtonEvent, QuickPickItemKind, Range, TextDocument, TextDocumentShowOptions, ThemeIcon, Uri, window } from "vscode";
+import IBMi from "../api/IBMi";
+import { MemberItem, OpenEditableOptions, WithPath } from "../typings";
+import Instance from "../api/Instance";
+import { Tools } from "../api/Tools";
+import { getUriFromPath, parseFSOptions } from "../filesystems/qsys/QSysFs";
+import { DefaultOpenMode, GlobalConfiguration } from "../api/Configuration";
+import path from "path";
+import { GetMemberInfo } from "../components/getMemberInfo";
+
+const CLEAR_RECENT = `$(trash) Clear recently opened`;
+const CLEAR_CACHED = `$(trash) Clear cached`;
+
+export function registerOpenCommands(instance: Instance): Disposable[] {
+
+  return [
+    commands.registerCommand(`code-for-ibmi.openEditable`, async (path: string, options?: OpenEditableOptions) => {
+      const connection = instance.getConnection()!;
+      console.log(path);
+      options = options || {};
+      options.readonly = options.readonly || connection.getContent().isProtectedPath(path);
+      if (!options.readonly) {
+        if (path.startsWith('/')) {
+          options.readonly = !await connection.getContent().testStreamFile(path, "w");
+        }
+        else {
+          const qsysObject = Tools.parseQSysPath(path);
+          const writable = await connection.getContent().checkObject({ library: qsysObject.library, name: qsysObject.name, type: '*FILE' }, ["*UPD"]);
+          if (!writable) {
+            options.readonly = true;
+          }
+        }
+      }
+
+      const uri = getUriFromPath(path, options);
+
+      const existingUri = Tools.findExistingDocumentUri(uri);
+
+      if (existingUri) {
+        const existingOptions = parseFSOptions(existingUri);
+        if (existingOptions.readonly !== options.readonly) {
+          window.showWarningMessage(`The file is already opened in another mode.`);
+          window.showTextDocument(existingUri);
+          return false;
+        }
+      }
+
+      try {
+        if(options.position){
+          await commands.executeCommand(`vscode.openWith`, uri, 'default', { selection: options.position } as TextDocumentShowOptions);
+        }
+        else{
+          await commands.executeCommand(`vscode.open`, uri);
+        }
+
+        // Add file to front of recently opened files list.
+        const recentLimit = GlobalConfiguration.get<number>(`recentlyOpenedFilesLimit`);
+        const storage = instance.getStorage();
+        if (recentLimit) {
+          const recent = storage!.getRecentlyOpenedFiles();
+          storage!.setRecentlyOpenedFiles([path, ...recent.filter((file) => file !== path).slice(0, recentLimit - 1)]);
+        } else {
+          storage!.clearRecentlyOpenedFiles();
+        }
+
+        return true;
+      } catch (e) {
+        console.log(e);
+        return false;
+      }
+    }),
+
+    commands.registerCommand("code-for-ibmi.browse", (item: WithPath | MemberItem) => {
+      return commands.executeCommand("code-for-ibmi.openWithDefaultMode", item, "browse" as DefaultOpenMode);
+    }),
+
+    commands.registerCommand("code-for-ibmi.edit", (item: WithPath | MemberItem) => {
+      return commands.executeCommand("code-for-ibmi.openWithDefaultMode", item, "edit" as DefaultOpenMode);
+    }),
+
+    commands.registerCommand("code-for-ibmi.openWithDefaultMode", (item: WithPath, overrideMode?: DefaultOpenMode, position?: Range) => {
+      const readonly = (overrideMode || GlobalConfiguration.get<DefaultOpenMode>("defaultOpenMode")) === "browse";
+      commands.executeCommand(`code-for-ibmi.openEditable`, item.path, { readonly, position } as OpenEditableOptions);
+    }),
+
+
+    commands.registerCommand("code-for-ibmi.refreshFile", async (uri?: Uri) => {
+      let doc: TextDocument | undefined;
+      if (uri) {
+        doc = Tools.findExistingDocument(uri);
+      } else {
+        const editor = window.activeTextEditor;
+        doc = editor?.document;
+      }
+
+      if (doc?.isDirty) {
+        window
+          .showWarningMessage(
+            l10n.t(`Your changes will be discarded`),
+            { modal: true },
+            l10n.t(`Continue`))
+          .then(result => {
+            if (result === l10n.t(`Continue`)) {
+              commands.executeCommand(`workbench.action.files.revert`);
+            }
+          });
+      } else {
+        commands.executeCommand(`workbench.action.files.revert`);
+      }
+    }),
+
+    commands.registerCommand(`code-for-ibmi.goToFileReadOnly`, async () => commands.executeCommand(`code-for-ibmi.goToFile`, true)),
+    commands.registerCommand(`code-for-ibmi.goToFile`, async (readonly?: boolean) => {
+      const compareIcon = new ThemeIcon('split-horizontal');
+      const compareButton: QuickInputButton = {
+        iconPath: compareIcon,
+        tooltip: l10n.t(`Compare with Active File`)
+      };
+
+      const LOADING_LABEL = `Please wait`;
+      const connection = instance.getConnection();
+      if (!connection) return;
+      
+      const storage = instance.getStorage();
+      const content = connection?.getContent();
+      let starRemoved: boolean = false;
+
+      if (!storage && !content && !connection) return;
+      let list: string[] = [];
+
+      // Get recently opened files - cut if limit has been reduced.
+      const recentLimit = GlobalConfiguration.get(`recentlyOpenedFilesLimit`) as number;
+      const recent = storage!.getRecentlyOpenedFiles();
+      if (recent.length > recentLimit) {
+        recent.splice(recentLimit);
+        storage!.setRecentlyOpenedFiles(recent);
+      }
+
+      const sources = storage!.getSourceList();
+      const dirs = Object.keys(sources);
+
+      let schemaItems: QuickPickItem[] = [];
+
+      dirs.forEach(dir => {
+        sources[dir].forEach(source => {
+          list.push(`${dir}${dir.endsWith(`/`) ? `` : `/`}${source}`);
+        });
+      });
+
+      const recentItems: QuickPickItem[] = recent.map(item => ({
+        label: item,
+        buttons: [compareButton]
+      }));
+      const listItems: QuickPickItem[] = list.map(item => ({
+        label: item,
+        buttons: [compareButton]
+      }));
+
+      const quickPick = window.createQuickPick();
+      quickPick.items = await createQuickPickItemsList(
+        ``,
+        [],
+        `Recent`,
+        recentItems,
+        `Cached`,
+        listItems
+      );
+      quickPick.canSelectMany = false;
+      (quickPick as any).sortByLabel = false; // https://github.com/microsoft/vscode/issues/73904#issuecomment-680298036
+      quickPick.placeholder = `Enter file path (format: LIB/SPF/NAME.ext (type '*' to search server) or /home/xx/file.txt)`;
+
+      quickPick.show();
+
+      // Create a cache for Schema if autosuggest enabled
+      if (schemaItems.length === 0 && connection?.enableSQL) {
+        content!.runSQL(`
+          select cast( SYSTEM_SCHEMA_NAME as char( 10 ) for bit data ) as SYSTEM_SCHEMA_NAME
+               , ifnull( cast( SCHEMA_TEXT as char( 50 ) for bit data ), '' ) as SCHEMA_TEXT
+            from QSYS2.SYSSCHEMAS
+           order by 1`
+        ).then(resultSetLibrary => {
+          schemaItems = resultSetLibrary.map(row => ({
+            label: String(row.SYSTEM_SCHEMA_NAME),
+            description: String(row.SCHEMA_TEXT)
+          }))
+        });
+      }
+
+      let filteredItems: QuickPickItem[] = [];
+
+      quickPick.onDidChangeValue(async () => {
+        if (quickPick.value === ``) {
+          quickPick.items = await createQuickPickItemsList(
+            ``,
+            [],
+            `Recent`,
+            recentItems,
+            `Cached`,
+            listItems
+          );
+          filteredItems = [];
+        } else {
+          if (!starRemoved && !list.includes(connection!.upperCaseName(quickPick.value))) {
+            quickPick.items = [connection!.upperCaseName(quickPick.value), ...list].map(label => ({
+              label: label,
+              buttons: [compareButton]
+            }));
+          }
+        }
+
+        // autosuggest
+        if (connection && connection.enableSQL && (!quickPick.value.startsWith(`/`)) && quickPick.value.endsWith(`*`)) {
+          const selectionSplit = connection!.upperCaseName(quickPick.value).split('/');
+          const lastPart = selectionSplit[selectionSplit.length - 1];
+          let filterText = lastPart.substring(0, lastPart.indexOf(`*`));
+
+          let resultSet: Tools.DB2Row[] = [];
+
+          switch (selectionSplit.length) {
+            case 1:
+              filteredItems = schemaItems.filter(schema => schema.label.startsWith(filterText));
+
+              // Using `kind` didn't make any difference because it's sorted alphabetically on label
+              quickPick.items = await createQuickPickItemsList(
+                `Libraries`,
+                filteredItems,
+                `Recent`,
+                recentItems,
+                `Cached`,
+                listItems
+              );
+
+              break;
+
+            case 2:
+              // Create cache
+              quickPick.busy = true;
+              quickPick.items = [
+                {
+                  label: LOADING_LABEL,
+                  alwaysShow: true,
+                  description: 'Searching files..',
+                },
+              ]
+
+              resultSet = await content!.runSQL(`
+                select ifnull( cast( SYSTEM_TABLE_NAME as char( 10 ) for bit data ), '' ) as SYSTEM_TABLE_NAME
+                     , ifnull( TABLE_TEXT, '' ) as TABLE_TEXT
+                  from QSYS2.SYSTABLES
+                 where SYSTEM_TABLE_SCHEMA = '${connection!.sysNameInAmerican(selectionSplit[0])}'
+                       and FILE_TYPE = 'S'
+                  ${filterText ? `and SYSTEM_TABLE_NAME like '${filterText}%'` : ``}
+                 order by 1
+              `);
+
+              const listFile: QuickPickItem[] = resultSet.map(row => ({
+                label: selectionSplit[0] + '/' + String(row.SYSTEM_TABLE_NAME),
+                description: String(row.TABLE_TEXT)
+              }))
+
+              filteredItems = listFile.filter(file => file.label.startsWith(selectionSplit[0] + '/' + filterText));
+
+              quickPick.items = await createQuickPickItemsList(
+                `Source files`,
+                filteredItems,
+                `Recent`,
+                recentItems,
+                `Cached`,
+                listItems
+              );
+              quickPick.busy = false;
+
+              break;
+
+            case 3:
+              // Create cache
+              quickPick.busy = true;
+              quickPick.items = [
+                {
+                  label: LOADING_LABEL,
+                  alwaysShow: true,
+                  description: 'Searching members..',
+                },
+              ]
+
+              filterText = filterText.endsWith(`.`) ? filterText.substring(0, filterText.length - 1) : filterText;
+
+              resultSet = await content!.runSQL(`
+                select cast( SYSTEM_TABLE_MEMBER as char( 10 ) for bit data ) as SYSTEM_TABLE_MEMBER
+                     , ifnull( PARTITION_TEXT, '' ) as PARTITION_TEXT
+                     , ifnull( SOURCE_TYPE, '' ) as SOURCE_TYPE
+                  from QSYS2.SYSPARTITIONSTAT
+                 where SYSTEM_TABLE_SCHEMA = '${connection!.sysNameInAmerican(selectionSplit[0])}'
+                       and SYSTEM_TABLE_NAME = '${connection!.sysNameInAmerican(selectionSplit[1])}'
+                  ${filterText ? `and SYSTEM_TABLE_MEMBER like '${connection!.sysNameInAmerican(filterText)}%'` : ``}
+                 order by 1
+              `);
+
+              const listMember = resultSet.map(row => ({
+                label: selectionSplit[0] + '/' + selectionSplit[1] + '/' + String(row.SYSTEM_TABLE_MEMBER) + '.' + String(row.SOURCE_TYPE),
+                description: String(row.PARTITION_TEXT)
+              }))
+
+              filteredItems = listMember.filter(member => member.label.startsWith(selectionSplit[0] + '/' + selectionSplit[1] + '/' + filterText));
+
+              quickPick.items = await createQuickPickItemsList(
+                `Members`,
+                filteredItems,
+                `Recent`,
+                recentItems,
+                `Cached`,
+                listItems
+              );
+              quickPick.busy = false;
+
+              break;
+
+            default:
+              break;
+          }
+
+          // We remove the asterisk from the value so that the user can continue typing
+          quickPick.value = quickPick.value.substring(0, quickPick.value.indexOf(`*`));
+          starRemoved = true;
+
+        } else {
+
+          if (filteredItems.length > 0 && !starRemoved) {
+            quickPick.items = await createQuickPickItemsList(
+              `Filter`,
+              filteredItems,
+              `Recent`,
+              recentItems,
+              `Cached`,
+              listItems
+            );
+          }
+        }
+        starRemoved = false;
+      });
+
+      quickPick.onDidAccept(async () => {
+        let selection = quickPick.selectedItems.length === 1 ? quickPick.selectedItems[0].label : undefined;
+        if (selection && selection !== LOADING_LABEL) {
+          if (selection === CLEAR_RECENT) {
+            recentItems.length = 0;
+            storage!.clearRecentlyOpenedFiles();
+            quickPick.items = await createQuickPickItemsList(
+              `Filter`,
+              filteredItems,
+              ``,
+              [],
+              `Cached`,
+              listItems
+            );
+            window.showInformationMessage(`Cleared previously opened files.`);
+          } else if (selection === CLEAR_CACHED) {
+            listItems.length = 0;
+            storage!.setSourceList({});
+            quickPick.items = await createQuickPickItemsList(
+              `Filter`,
+              filteredItems,
+              `Recent`,
+              recentItems,
+            );
+            window.showInformationMessage(`Cleared cached files.`);
+          } else {
+            const selectionSplit = connection!.upperCaseName(selection).split('/')
+            if (selectionSplit.length === 3 || selection.startsWith(`/`)) {
+
+              // When selection is QSYS path
+              if (!selection.startsWith(`/`) && connection) {
+                const library = selectionSplit[0];
+                const file = selectionSplit[1];
+                const member = path.parse(selectionSplit[2]);
+                member.ext = member.ext.substring(1);
+                const memberInfo = await connection.getContent().getMemberInfo(library, file, member.name);
+                if (!memberInfo) {
+                  window.showWarningMessage(`Source member ${library}/${file}/${member.base} does not exist.`);
+                  return;
+                } else if (memberInfo.name !== member.name || (member.ext && memberInfo.extension !== member.ext)) {
+                  window.showWarningMessage(`Member ${library}/${file}/${member.name} of type ${member.ext} does not exist.`);
+                  return;
+                }
+
+                member.base = `${member.name}.${member.ext || memberInfo.extension}`;
+                selection = `${library}/${file}/${member.base}`;
+              };
+
+              // When select is IFS path
+              if (selection.startsWith(`/`)) {
+                const streamFile = await content!.streamfileResolve([selection.substring(1)], [`/`]);
+                if (!streamFile) {
+                  window.showWarningMessage(`${selection} does not exist or is not a file.`);
+                  return;
+                }
+                selection = connection!.upperCaseName(selection) === connection!.upperCaseName(quickPick.value) ? quickPick.value : selection;
+              }
+              commands.executeCommand(`code-for-ibmi.openEditable`, selection, { readonly });
+              quickPick.hide();
+            } else {
+              quickPick.value = connection!.upperCaseName(selection) + '/'
+            }
+          }
+        }
+      });
+
+      quickPick.onDidTriggerItemButton((event: QuickPickItemButtonEvent<QuickPickItem>) => {
+        if (event.button.iconPath == compareIcon) {
+          let path: Uri;
+          let currentFile: Uri;
+          if (event.item.label.startsWith('/')) {
+            path = Uri.parse(`streamfile:${event.item.label}`);
+          } else {
+            path = Uri.parse(`member:/${event.item.label}`);
+          }
+
+          const editor = window.activeTextEditor;
+          if (editor) {
+            currentFile = editor.document.uri;
+            commands.executeCommand(`diff`, currentFile, path);
+            quickPick.hide();
+          }
+        }
+      });
+
+      quickPick.onDidHide(() => quickPick.dispose());
+      quickPick.show();
+
+    }),
+  ]
+}
+
+async function createQuickPickItemsList(
+  labelFiltered: string = ``, filtered: QuickPickItem[] = [],
+  labelRecent: string = ``, recent: QuickPickItem[] = [],
+  labelCached: string = ``, cached: QuickPickItem[] = [],
+) {
+  const clearRecentArray = [{ label: ``, kind: QuickPickItemKind.Separator }, { label: CLEAR_RECENT }];
+  const clearCachedArray = [{ label: ``, kind: QuickPickItemKind.Separator }, { label: CLEAR_CACHED }];
+
+  const returnedList: QuickPickItem[] = [
+    { label: labelFiltered, kind: QuickPickItemKind.Separator },
+    ...filtered,
+    { label: labelRecent, kind: QuickPickItemKind.Separator },
+    ...recent,
+    ...(recent.length != 0 ? clearRecentArray : []),
+    { label: labelCached, kind: QuickPickItemKind.Separator },
+    ...cached,
+    ...(cached.length != 0 ? clearCachedArray : [])
+  ];
+  return returnedList;
+}

--- a/src/commands/password.ts
+++ b/src/commands/password.ts
@@ -1,0 +1,87 @@
+import { commands, extensions, window, Disposable, ExtensionContext } from "vscode";
+import { ConnectionManager } from "../api/Configuration";
+import Instance from "../api/Instance";
+
+
+const passwordAttempts: { [extensionId: string]: number } = {}
+
+export function registerPasswordCommands(context: ExtensionContext, instance: Instance): Disposable[] {
+  return [
+    commands.registerCommand(`code-for-ibmi.getPassword`, async (extensionId: string, reason?: string) => {
+      if (extensionId) {
+        const extension = extensions.getExtension(extensionId);
+        const isValid = (extension && extension.isActive);
+        if (isValid) {
+          const connection = instance.getConnection();
+          const storage = instance.getStorage();
+          if (connection && storage) {
+            const displayName = extension.packageJSON.displayName || extensionId;
+
+            // Some logic to stop spam from extensions.
+            passwordAttempts[extensionId] = passwordAttempts[extensionId] || 0;
+            if (passwordAttempts[extensionId] > 1) {
+              throw new Error(`Password request denied for extension ${displayName}.`);
+            }
+
+            const storedPassword = await ConnectionManager.getStoredPassword(context, instance.getConnection()!.currentConnectionName);
+
+            if (storedPassword) {
+              let isAuthed = storage.getExtensionAuthorisation(extension) !== undefined;
+
+              if (!isAuthed) {
+                const detail = `The ${displayName} extension is requesting access to your password for this connection. ${reason ? `\n\nReason: ${reason}` : `The extension did not provide a reason for password access.`}`;
+                let done = false;
+                let modal = true;
+
+                while (!done) {
+                  const options: string[] = [`Allow`];
+
+                  if (modal) {
+                    options.push(`View on Marketplace`);
+                  } else {
+                    options.push(`Deny`);
+                  }
+
+                  const result = await window.showWarningMessage(
+                    modal ? `Password Request` : detail,
+                    {
+                      modal,
+                      detail,
+                    },
+                    ...options
+                  );
+
+                  switch (result) {
+                    case `Allow`:
+                      await storage.grantExtensionAuthorisation(extension);
+                      isAuthed = true;
+                      done = true;
+                      break;
+
+                    case `View on Marketplace`:
+                      commands.executeCommand('extension.open', extensionId);
+                      modal = false;
+                      break;
+
+                    default:
+                      done = true;
+                      break;
+                  }
+                }
+              }
+
+              if (isAuthed) {
+                return storedPassword;
+              } else {
+                passwordAttempts[extensionId]++;
+              }
+            }
+
+          } else {
+            throw new Error(`Not connected to an IBM i.`);
+          }
+        }
+      }
+    })
+  ]
+}

--- a/src/components/cqsh/index.ts
+++ b/src/components/cqsh/index.ts
@@ -45,7 +45,7 @@ export class CustomQSh implements IBMiComponent {
       return `Error`;
     }
 
-    await connection.uploadFiles([{ local: assetPath, remote: this.installPath }]);
+    await connection.getContent().uploadFiles([{ local: assetPath, remote: this.installPath }]);
 
     await connection.sendCommand({
       command: `chmod +x ${this.installPath}`,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,21 +71,6 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
       `profilesView`,
       new ProfilesView(context)
     ),
-    commands.registerCommand(`code-for-ibmi.connectDirect`,
-      async (connectionData: ConnectionData, reloadSettings = false, savePassword = false): Promise<boolean> => {
-        const existingConnection = instance.getConnection();
-
-        if (existingConnection) {
-          return false;
-        }
-
-        if (savePassword && connectionData.password) {
-          await ConnectionManager.setStoredPassword(context, connectionData.name, connectionData.password);
-        }
-
-        return (await new IBMi().connect(connectionData, undefined, reloadSettings)).success;
-      }
-    ),
     onCodeForIBMiConfigurationChange("connections", updateLastConnectionAndServerCache),
     onCodeForIBMiConfigurationChange("connectionSettings", async () => {
       const connection = instance.getConnection();

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -1,28 +1,22 @@
-import { Tools } from './api/Tools';
 
-import path from 'path';
 import * as vscode from "vscode";
-import { CompileTools } from './api/CompileTools';
-import { ConnectionConfiguration, ConnectionManager, DefaultOpenMode, GlobalConfiguration, onCodeForIBMiConfigurationChange } from "./api/Configuration";
+import { GlobalConfiguration, onCodeForIBMiConfigurationChange } from "./api/Configuration";
 import Instance from "./api/Instance";
 import { Terminal } from './api/Terminal';
 import { getDebugServiceDetails } from './api/debug/config';
 import { debugPTFInstalled, isDebugEngineRunning } from './api/debug/server';
-import { refreshDiagnosticsFromServer } from './api/errors/diagnostics';
 import { setupGitEventHandler } from './api/local/git';
-import { GetMemberInfo } from './components/getMemberInfo';
-import { QSysFS, getUriFromPath, parseFSOptions } from "./filesystems/qsys/QSysFs";
+import { QSysFS } from "./filesystems/qsys/QSysFs";
 import { SEUColorProvider } from "./languages/general/SEUColorProvider";
-import { Action, BrowserItem, DeploymentMethod, MemberItem, OpenEditableOptions, WithPath } from "./typings";
 import { ActionsUI } from './webviews/actions';
 import { VariablesUI } from "./webviews/variables";
+import { registerOpenCommands } from './commands/open';
+import { registerCompareCommands } from './commands/compare';
+import { registerActionsCommands } from './commands/actions';
+import { registerPasswordCommands } from './commands/password';
+import { registerConnectionCommands } from './commands/connection';
 
 export let instance: Instance;
-
-const passwordAttempts: { [extensionId: string]: number } = {}
-
-const CLEAR_RECENT = `$(trash) Clear recently opened`;
-const CLEAR_CACHED = `$(trash) Clear cached`;
 
 const disconnectBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 12);
 disconnectBarItem.command = {
@@ -38,9 +32,7 @@ connectedBarItem.command = {
   title: `Show connection settings`
 };
 
-let selectedForCompare: vscode.Uri;
-
-export async function disconnect(): Promise<boolean> {
+export async function safeDisconnect(): Promise<boolean> {
   let doDisconnect = true;
 
   for (const document of vscode.workspace.textDocuments) {
@@ -60,10 +52,7 @@ export async function disconnect(): Promise<boolean> {
   }
 
   if (doDisconnect) {
-    const connection = instance.getConnection();
-    if (connection) {
-      await connection.end();
-    }
+    await instance.disconnect();
   }
 
   return doDisconnect;
@@ -72,712 +61,28 @@ export async function disconnect(): Promise<boolean> {
 export async function loadAllofExtension(context: vscode.ExtensionContext) {
   // No connection when the extension is first activated
   vscode.commands.executeCommand(`setContext`, `code-for-ibmi:connected`, false);
+  vscode.workspace.getConfiguration().update(`workbench.editor.enablePreview`, false, true);
 
   instance = new Instance(context);
   context.subscriptions.push(
     connectedBarItem,
     disconnectBarItem,
-    vscode.commands.registerCommand(`code-for-ibmi.disconnect`, async (silent?: boolean) => {
-      if (instance.getConnection()) {
-        await disconnect();
-      } else if (!silent) {
-        vscode.window.showErrorMessage(`Not currently connected to any system.`);
-      }
-    }),
+
+    ...registerConnectionCommands(context, instance),
+
     onCodeForIBMiConfigurationChange("connectionSettings", updateConnectedBar),
-    vscode.commands.registerCommand(`code-for-ibmi.openEditable`, async (path: string, options?: OpenEditableOptions) => {
-      console.log(path);
-      options = options || {};
-      options.readonly = options.readonly || instance.getContent()?.isProtectedPath(path);
-      if (!options.readonly) {
-        if (path.startsWith('/')) {
-          options.readonly = !await instance.getContent()?.testStreamFile(path, "w");
-        }
-        else {
-          const qsysObject = Tools.parseQSysPath(path);
-          const writable = await instance.getContent()?.checkObject({ library: qsysObject.library, name: qsysObject.name, type: '*FILE' }, ["*UPD"]);
-          if (!writable) {
-            options.readonly = true;
-          }
-        }
-      }
 
-      const uri = getUriFromPath(path, options);
+    ...registerOpenCommands(instance),
 
-      const existingUri = Tools.findExistingDocumentUri(uri);
+    ...registerCompareCommands(instance),
 
-      if (existingUri) {
-        const existingOptions = parseFSOptions(existingUri);
-        if (existingOptions.readonly !== options.readonly) {
-          vscode.window.showWarningMessage(`The file is already opened in another mode.`);
-          vscode.window.showTextDocument(existingUri);
-          return false;
-        }
-      }
-
-      try {
-        if(options.position){
-          await vscode.commands.executeCommand(`vscode.openWith`, uri, 'default', { selection: options.position } as vscode.TextDocumentShowOptions);
-        }
-        else{
-          await vscode.commands.executeCommand(`vscode.open`, uri);
-        }
-
-        // Add file to front of recently opened files list.
-        const recentLimit = GlobalConfiguration.get<number>(`recentlyOpenedFilesLimit`);
-        const storage = instance.getStorage();
-        if (recentLimit) {
-          const recent = storage!.getRecentlyOpenedFiles();
-          storage!.setRecentlyOpenedFiles([path, ...recent.filter((file) => file !== path).slice(0, recentLimit - 1)]);
-        } else {
-          storage!.clearRecentlyOpenedFiles();
-        }
-
-        return true;
-      } catch (e) {
-        console.log(e);
-        return false;
-      }
-    }),
-
-    vscode.commands.registerCommand(`code-for-ibmi.selectForCompare`, async (node) => {
-      if (node) {
-        selectedForCompare = node.resourceUri;
-        vscode.window.showInformationMessage(`Selected ${node.path} for compare.`);
-      }
-    }),
-    vscode.commands.registerCommand(`code-for-ibmi.compareWithSelected`, async (node) => {
-      if (selectedForCompare) {
-        let uri;
-        if (node) {
-          uri = node.resourceUri;
-        } else {
-          const activeEditor = vscode.window.activeTextEditor;
-          const value = (activeEditor ? activeEditor.document.uri : selectedForCompare)
-            .with({ query: '' })
-            .toString();
-          const compareWith = await vscode.window.showInputBox({
-            prompt: `Enter the path to compare selected with`,
-            value,
-            title: `Compare with`
-          })
-
-          if (compareWith)
-            uri = vscode.Uri.parse(compareWith);
-        }
-
-        if (uri) {
-          vscode.commands.executeCommand(`vscode.diff`, selectedForCompare, uri);
-        } else {
-          vscode.window.showErrorMessage(`No compare to path provided.`);
-        }
-      } else {
-        vscode.window.showInformationMessage(`Nothing selected to compare.`);
-      }
-    }),
-
-    vscode.commands.registerCommand(`code-for-ibmi.compareCurrentFileWithMember`, async (node) => {
-      compareCurrentFile(node, `member`);
-    }),
-    vscode.commands.registerCommand(`code-for-ibmi.compareCurrentFileWithStreamFile`, async (node) => {
-      compareCurrentFile(node, `streamfile`);
-    }),
-    vscode.commands.registerCommand(`code-for-ibmi.compareCurrentFileWithLocal`, async (node) => {
-      compareCurrentFile(node, `file`);
-    }),
-    vscode.commands.registerCommand(`code-for-ibmi.compareWithActiveFile`, async (node) => {
-      let selectedFile;
-      if (node) {
-        if (node.scheme === `streamfile` || node.constructor.name === `IFSFileItem` || node.constructor.name === `ObjectBrowserItem`) {
-          selectedFile = node.resourceUri;
-        } else if (node.scheme === `file`) {
-          selectedFile = node
-        } else {
-          vscode.window.showInformationMessage(vscode.l10n.t(`No file is open or selected`));
-        }
-
-        let activeFile;
-        const editor = vscode.window.activeTextEditor;
-        if (editor) {
-          activeFile = editor.document.uri;
-          if (activeFile) {
-            vscode.commands.executeCommand(`vscode.diff`, activeFile, selectedFile);
-          } else {
-            vscode.window.showInformationMessage(vscode.l10n.t(`No file is open or selected`));
-          }
-        } else {
-          vscode.window.showInformationMessage(vscode.l10n.t(`No file is open or selected`));
-        }
-      } else {
-        vscode.window.showInformationMessage(vscode.l10n.t(`No file is open or selected`));
-      }
-    }),
-
-    vscode.commands.registerCommand(`code-for-ibmi.goToFileReadOnly`, async () => vscode.commands.executeCommand(`code-for-ibmi.goToFile`, true)),
-    vscode.commands.registerCommand(`code-for-ibmi.goToFile`, async (readonly?: boolean) => {
-      const compareIcon = new vscode.ThemeIcon('split-horizontal');
-      const compareButton: vscode.QuickInputButton = {
-        iconPath: compareIcon,
-        tooltip: vscode.l10n.t(`Compare with Active File`)
-      };
-
-      const LOADING_LABEL = `Please wait`;
-      const storage = instance.getStorage();
-      const content = instance.getContent();
-      const connection = instance.getConnection();
-      let starRemoved: boolean = false;
-
-      if (!storage && !content && !connection) return;
-      let list: string[] = [];
-
-      // Get recently opened files - cut if limit has been reduced.
-      const recentLimit = GlobalConfiguration.get(`recentlyOpenedFilesLimit`) as number;
-      const recent = storage!.getRecentlyOpenedFiles();
-      if (recent.length > recentLimit) {
-        recent.splice(recentLimit);
-        storage!.setRecentlyOpenedFiles(recent);
-      }
-
-      const sources = storage!.getSourceList();
-      const dirs = Object.keys(sources);
-
-      let schemaItems: vscode.QuickPickItem[] = [];
-
-      dirs.forEach(dir => {
-        sources[dir].forEach(source => {
-          list.push(`${dir}${dir.endsWith(`/`) ? `` : `/`}${source}`);
-        });
-      });
-
-      const recentItems: vscode.QuickPickItem[] = recent.map(item => ({
-        label: item,
-        buttons: [compareButton]
-      }));
-      const listItems: vscode.QuickPickItem[] = list.map(item => ({
-        label: item,
-        buttons: [compareButton]
-      }));
-
-      const quickPick = vscode.window.createQuickPick();
-      quickPick.items = await createQuickPickItemsList(
-        ``,
-        [],
-        `Recent`,
-        recentItems,
-        `Cached`,
-        listItems
-      );
-      quickPick.canSelectMany = false;
-      (quickPick as any).sortByLabel = false; // https://github.com/microsoft/vscode/issues/73904#issuecomment-680298036
-      quickPick.placeholder = `Enter file path (format: LIB/SPF/NAME.ext (type '*' to search server) or /home/xx/file.txt)`;
-
-      quickPick.show();
-
-      // Create a cache for Schema if autosuggest enabled
-      if (schemaItems.length === 0 && connection?.enableSQL) {
-        content!.runSQL(`
-          select cast( SYSTEM_SCHEMA_NAME as char( 10 ) for bit data ) as SYSTEM_SCHEMA_NAME
-               , ifnull( cast( SCHEMA_TEXT as char( 50 ) for bit data ), '' ) as SCHEMA_TEXT
-            from QSYS2.SYSSCHEMAS
-           order by 1`
-        ).then(resultSetLibrary => {
-          schemaItems = resultSetLibrary.map(row => ({
-            label: String(row.SYSTEM_SCHEMA_NAME),
-            description: String(row.SCHEMA_TEXT)
-          }))
-        });
-      }
-
-      let filteredItems: vscode.QuickPickItem[] = [];
-
-      quickPick.onDidChangeValue(async () => {
-        if (quickPick.value === ``) {
-          quickPick.items = await createQuickPickItemsList(
-            ``,
-            [],
-            `Recent`,
-            recentItems,
-            `Cached`,
-            listItems
-          );
-          filteredItems = [];
-        } else {
-          if (!starRemoved && !list.includes(connection!.upperCaseName(quickPick.value))) {
-            quickPick.items = [connection!.upperCaseName(quickPick.value), ...list].map(label => ({
-              label: label,
-              buttons: [compareButton]
-            }));
-          }
-        }
-
-        // autosuggest
-        if (connection && connection.enableSQL && (!quickPick.value.startsWith(`/`)) && quickPick.value.endsWith(`*`)) {
-          const selectionSplit = connection!.upperCaseName(quickPick.value).split('/');
-          const lastPart = selectionSplit[selectionSplit.length - 1];
-          let filterText = lastPart.substring(0, lastPart.indexOf(`*`));
-
-          let resultSet: Tools.DB2Row[] = [];
-
-          switch (selectionSplit.length) {
-            case 1:
-              filteredItems = schemaItems.filter(schema => schema.label.startsWith(filterText));
-
-              // Using `kind` didn't make any difference because it's sorted alphabetically on label
-              quickPick.items = await createQuickPickItemsList(
-                `Libraries`,
-                filteredItems,
-                `Recent`,
-                recentItems,
-                `Cached`,
-                listItems
-              );
-
-              break;
-
-            case 2:
-              // Create cache
-              quickPick.busy = true;
-              quickPick.items = [
-                {
-                  label: LOADING_LABEL,
-                  alwaysShow: true,
-                  description: 'Searching files..',
-                },
-              ]
-
-              resultSet = await content!.runSQL(`
-                select ifnull( cast( SYSTEM_TABLE_NAME as char( 10 ) for bit data ), '' ) as SYSTEM_TABLE_NAME
-                     , ifnull( TABLE_TEXT, '' ) as TABLE_TEXT
-                  from QSYS2.SYSTABLES
-                 where SYSTEM_TABLE_SCHEMA = '${connection!.sysNameInAmerican(selectionSplit[0])}'
-                       and FILE_TYPE = 'S'
-                  ${filterText ? `and SYSTEM_TABLE_NAME like '${filterText}%'` : ``}
-                 order by 1
-              `);
-
-              const listFile: vscode.QuickPickItem[] = resultSet.map(row => ({
-                label: selectionSplit[0] + '/' + String(row.SYSTEM_TABLE_NAME),
-                description: String(row.TABLE_TEXT)
-              }))
-
-              filteredItems = listFile.filter(file => file.label.startsWith(selectionSplit[0] + '/' + filterText));
-
-              quickPick.items = await createQuickPickItemsList(
-                `Source files`,
-                filteredItems,
-                `Recent`,
-                recentItems,
-                `Cached`,
-                listItems
-              );
-              quickPick.busy = false;
-
-              break;
-
-            case 3:
-              // Create cache
-              quickPick.busy = true;
-              quickPick.items = [
-                {
-                  label: LOADING_LABEL,
-                  alwaysShow: true,
-                  description: 'Searching members..',
-                },
-              ]
-
-              filterText = filterText.endsWith(`.`) ? filterText.substring(0, filterText.length - 1) : filterText;
-
-              resultSet = await content!.runSQL(`
-                select cast( SYSTEM_TABLE_MEMBER as char( 10 ) for bit data ) as SYSTEM_TABLE_MEMBER
-                     , ifnull( PARTITION_TEXT, '' ) as PARTITION_TEXT
-                     , ifnull( SOURCE_TYPE, '' ) as SOURCE_TYPE
-                  from QSYS2.SYSPARTITIONSTAT
-                 where SYSTEM_TABLE_SCHEMA = '${connection!.sysNameInAmerican(selectionSplit[0])}'
-                       and SYSTEM_TABLE_NAME = '${connection!.sysNameInAmerican(selectionSplit[1])}'
-                  ${filterText ? `and SYSTEM_TABLE_MEMBER like '${connection!.sysNameInAmerican(filterText)}%'` : ``}
-                 order by 1
-              `);
-
-              const listMember = resultSet.map(row => ({
-                label: selectionSplit[0] + '/' + selectionSplit[1] + '/' + String(row.SYSTEM_TABLE_MEMBER) + '.' + String(row.SOURCE_TYPE),
-                description: String(row.PARTITION_TEXT)
-              }))
-
-              filteredItems = listMember.filter(member => member.label.startsWith(selectionSplit[0] + '/' + selectionSplit[1] + '/' + filterText));
-
-              quickPick.items = await createQuickPickItemsList(
-                `Members`,
-                filteredItems,
-                `Recent`,
-                recentItems,
-                `Cached`,
-                listItems
-              );
-              quickPick.busy = false;
-
-              break;
-
-            default:
-              break;
-          }
-
-          // We remove the asterisk from the value so that the user can continue typing
-          quickPick.value = quickPick.value.substring(0, quickPick.value.indexOf(`*`));
-          starRemoved = true;
-
-        } else {
-
-          if (filteredItems.length > 0 && !starRemoved) {
-            quickPick.items = await createQuickPickItemsList(
-              `Filter`,
-              filteredItems,
-              `Recent`,
-              recentItems,
-              `Cached`,
-              listItems
-            );
-          }
-        }
-        starRemoved = false;
-      });
-
-      quickPick.onDidAccept(async () => {
-        let selection = quickPick.selectedItems.length === 1 ? quickPick.selectedItems[0].label : undefined;
-        if (selection && selection !== LOADING_LABEL) {
-          if (selection === CLEAR_RECENT) {
-            recentItems.length = 0;
-            storage!.clearRecentlyOpenedFiles();
-            quickPick.items = await createQuickPickItemsList(
-              `Filter`,
-              filteredItems,
-              ``,
-              [],
-              `Cached`,
-              listItems
-            );
-            vscode.window.showInformationMessage(`Cleared previously opened files.`);
-          } else if (selection === CLEAR_CACHED) {
-            listItems.length = 0;
-            storage!.setSourceList({});
-            quickPick.items = await createQuickPickItemsList(
-              `Filter`,
-              filteredItems,
-              `Recent`,
-              recentItems,
-            );
-            vscode.window.showInformationMessage(`Cleared cached files.`);
-          } else {
-            const selectionSplit = connection!.upperCaseName(selection).split('/')
-            if (selectionSplit.length === 3 || selection.startsWith(`/`)) {
-
-              const infoComponent = connection?.getComponent<GetMemberInfo>(GetMemberInfo.ID);
-
-              // When selection is QSYS path
-              if (!selection.startsWith(`/`) && infoComponent && connection) {
-                const library = selectionSplit[0];
-                const file = selectionSplit[1];
-                const member = path.parse(selectionSplit[2]);
-                member.ext = member.ext.substring(1);
-                const memberInfo = await infoComponent.getMemberInfo(connection, library, file, member.name);
-                if (!memberInfo) {
-                  vscode.window.showWarningMessage(`Source member ${library}/${file}/${member.base} does not exist.`);
-                  return;
-                } else if (memberInfo.name !== member.name || (member.ext && memberInfo.extension !== member.ext)) {
-                  vscode.window.showWarningMessage(`Member ${library}/${file}/${member.name} of type ${member.ext} does not exist.`);
-                  return;
-                }
-
-                member.base = `${member.name}.${member.ext || memberInfo.extension}`;
-                selection = `${library}/${file}/${member.base}`;
-              };
-
-              // When select is IFS path
-              if (selection.startsWith(`/`)) {
-                const streamFile = await content!.streamfileResolve([selection.substring(1)], [`/`]);
-                if (!streamFile) {
-                  vscode.window.showWarningMessage(`${selection} does not exist or is not a file.`);
-                  return;
-                }
-                selection = connection!.upperCaseName(selection) === connection!.upperCaseName(quickPick.value) ? quickPick.value : selection;
-              }
-              vscode.commands.executeCommand(`code-for-ibmi.openEditable`, selection, { readonly });
-              quickPick.hide();
-            } else {
-              quickPick.value = connection!.upperCaseName(selection) + '/'
-            }
-          }
-        }
-      });
-
-      quickPick.onDidTriggerItemButton((event: vscode.QuickPickItemButtonEvent<vscode.QuickPickItem>) => {
-        if (event.button.iconPath == compareIcon) {
-          let path: vscode.Uri;
-          let currentFile: vscode.Uri;
-          if (event.item.label.startsWith('/')) {
-            path = vscode.Uri.parse(`streamfile:${event.item.label}`);
-          } else {
-            path = vscode.Uri.parse(`member:/${event.item.label}`);
-          }
-
-          const editor = vscode.window.activeTextEditor;
-          if (editor) {
-            currentFile = editor.document.uri;
-            vscode.commands.executeCommand(`vscode.diff`, currentFile, path);
-            quickPick.hide();
-          }
-        }
-      });
-
-      quickPick.onDidHide(() => quickPick.dispose());
-      quickPick.show();
-
-    }),
-    vscode.commands.registerCommand(`code-for-ibmi.runAction`, async (target: vscode.TreeItem | BrowserItem | vscode.Uri, group?: any, action?: Action, method?: DeploymentMethod, workspaceFolder?: vscode.WorkspaceFolder) => {
-      const editor = vscode.window.activeTextEditor;
-      let uri;
-      let browserItem;
-      if (target) {
-        if ("fsPath" in target) {
-          uri = target;
-        }
-        else {
-          uri = target?.resourceUri;
-          if ("refresh" in target) {
-            browserItem = target;
-          }
-        }
-      }
-
-      uri = uri || editor?.document.uri;
-
-      if (uri) {
-        const config = instance.getConfig();
-        if (config) {
-          let canRun = true;
-          if (editor && uri.path === editor.document.uri.path && editor.document.isDirty) {
-            if (config.autoSaveBeforeAction) {
-              await editor.document.save();
-            } else {
-              const result = await vscode.window.showWarningMessage(`The file must be saved to run Actions.`, `Save`, `Save automatically`, `Cancel`);
-              switch (result) {
-                case `Save`:
-                  await editor.document.save();
-                  canRun = true;
-                  break;
-                case `Save automatically`:
-                  config.autoSaveBeforeAction = true;
-                  await ConnectionConfiguration.update(config);
-                  await editor.document.save();
-                  canRun = true;
-                  break;
-                default:
-                  canRun = false;
-                  break;
-              }
-            }
-          }
-
-          if (canRun && [`member`, `streamfile`, `file`, 'object'].includes(uri.scheme)) {
-            return await CompileTools.runAction(instance, uri, action, method, browserItem, workspaceFolder);
-          }
-        }
-        else {
-          vscode.window.showErrorMessage('Please connect to an IBM i first');
-        }
-      }
-
-      return false;
-    }),
-
-    vscode.commands.registerCommand(`code-for-ibmi.openErrors`, async (qualifiedObject?: string) => {
-      interface ObjectDetail {
-        asp?: string;
-        lib: string;
-        object: string;
-        ext?: string;
-      }
-
-      const detail: ObjectDetail = {
-        asp: undefined,
-        lib: ``,
-        object: ``,
-        ext: undefined
-      };
-
-      let inputPath: string | undefined
-
-      if (qualifiedObject) {
-        // Value passed in via parameter
-        inputPath = qualifiedObject;
-
-      } else {
-        // Value collected from user input
-
-        let initialPath = ``;
-        const editor = vscode.window.activeTextEditor;
-
-        if (editor) {
-          const config = instance.getConfig()!;
-          const uri = editor.document.uri;
-
-          if ([`member`, `streamfile`].includes(uri.scheme)) {
-
-            switch (uri.scheme) {
-              case `member`:
-                const memberPath = uri.path.split(`/`);
-                if (memberPath.length === 4) {
-                  detail.lib = memberPath[1];
-                } else if (memberPath.length === 5) {
-                  detail.asp = memberPath[1];
-                  detail.lib = memberPath[2];
-                }
-                break;
-              case `streamfile`:
-                detail.asp = (config.sourceASP && config.sourceASP.length > 0) ? config.sourceASP : undefined;
-                detail.lib = config.currentLibrary;
-                break;
-            }
-
-            const pathDetail = path.parse(editor.document.uri.path);
-            detail.object = pathDetail.name;
-            detail.ext = pathDetail.ext.substring(1);
-
-            initialPath = `${detail.lib}/${pathDetail.base}`;
-          }
-        }
-
-        inputPath = await vscode.window.showInputBox({
-          prompt: `Enter object path (LIB/OBJECT)`,
-          value: initialPath
-        });
-      }
-
-      if (inputPath) {
-        const [library, object] = inputPath.split(`/`);
-        if (library && object) {
-          const nameDetail = path.parse(object);
-          refreshDiagnosticsFromServer(instance, { library, object: nameDetail.name, extension: (nameDetail.ext.length > 1 ? nameDetail.ext.substring(1) : undefined) });
-        }
-      }
-    }),
+    ...registerActionsCommands(instance),
 
     ...Terminal.registerTerminalCommands(context),
 
-    vscode.commands.registerCommand(`code-for-ibmi.getPassword`, async (extensionId: string, reason?: string) => {
-      if (extensionId) {
-        const extension = vscode.extensions.getExtension(extensionId);
-        const isValid = (extension && extension.isActive);
-        if (isValid) {
-          const connection = instance.getConnection();
-          const storage = instance.getStorage();
-          if (connection && storage) {
-            const displayName = extension.packageJSON.displayName || extensionId;
+    ...registerPasswordCommands(context, instance),
 
-            // Some logic to stop spam from extensions.
-            passwordAttempts[extensionId] = passwordAttempts[extensionId] || 0;
-            if (passwordAttempts[extensionId] > 1) {
-              throw new Error(`Password request denied for extension ${displayName}.`);
-            }
-
-            const storedPassword = await ConnectionManager.getStoredPassword(context, instance.getConnection()!.currentConnectionName);
-
-            if (storedPassword) {
-              let isAuthed = storage.getExtensionAuthorisation(extension) !== undefined;
-
-              if (!isAuthed) {
-                const detail = `The ${displayName} extension is requesting access to your password for this connection. ${reason ? `\n\nReason: ${reason}` : `The extension did not provide a reason for password access.`}`;
-                let done = false;
-                let modal = true;
-
-                while (!done) {
-                  const options: string[] = [`Allow`];
-
-                  if (modal) {
-                    options.push(`View on Marketplace`);
-                  } else {
-                    options.push(`Deny`);
-                  }
-
-                  const result = await vscode.window.showWarningMessage(
-                    modal ? `Password Request` : detail,
-                    {
-                      modal,
-                      detail,
-                    },
-                    ...options
-                  );
-
-                  switch (result) {
-                    case `Allow`:
-                      await storage.grantExtensionAuthorisation(extension);
-                      isAuthed = true;
-                      done = true;
-                      break;
-
-                    case `View on Marketplace`:
-                      vscode.commands.executeCommand('extension.open', extensionId);
-                      modal = false;
-                      break;
-
-                    default:
-                      done = true;
-                      break;
-                  }
-                }
-              }
-
-              if (isAuthed) {
-                return storedPassword;
-              } else {
-                passwordAttempts[extensionId]++;
-              }
-            }
-
-          } else {
-            throw new Error(`Not connected to an IBM i.`);
-          }
-        }
-      }
-    }),
-
-    vscode.commands.registerCommand("code-for-ibmi.browse", (item: WithPath | MemberItem) => {
-      return vscode.commands.executeCommand("code-for-ibmi.openWithDefaultMode", item, "browse" as DefaultOpenMode);
-    }),
-
-    vscode.commands.registerCommand("code-for-ibmi.edit", (item: WithPath | MemberItem) => {
-      return vscode.commands.executeCommand("code-for-ibmi.openWithDefaultMode", item, "edit" as DefaultOpenMode);
-    }),
-
-    vscode.commands.registerCommand("code-for-ibmi.openWithDefaultMode", (item: WithPath, overrideMode?: DefaultOpenMode, position?: vscode.Range) => {
-      const readonly = (overrideMode || GlobalConfiguration.get<DefaultOpenMode>("defaultOpenMode")) === "browse";
-      vscode.commands.executeCommand(`code-for-ibmi.openEditable`, item.path, { readonly, position } as OpenEditableOptions);
-    }),
     vscode.commands.registerCommand("code-for-ibmi.updateConnectedBar", updateConnectedBar),
-
-    vscode.commands.registerCommand("code-for-ibmi.refreshFile", async (uri?: vscode.Uri) => {
-      let doc: vscode.TextDocument | undefined;
-      if (uri) {
-        doc = Tools.findExistingDocument(uri);
-      } else {
-        const editor = vscode.window.activeTextEditor;
-        doc = editor?.document;
-      }
-
-      if (doc?.isDirty) {
-        vscode.window
-          .showWarningMessage(
-            vscode.l10n.t(`Your changes will be discarded`),
-            { modal: true },
-            vscode.l10n.t(`Continue`))
-          .then(result => {
-            if (result === vscode.l10n.t(`Continue`)) {
-              vscode.commands.executeCommand(`workbench.action.files.revert`);
-            }
-          });
-      } else {
-        vscode.commands.executeCommand(`workbench.action.files.revert`);
-      }
-    }),
   );
 
   ActionsUI.initialize(context);
@@ -803,8 +108,9 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
 }
 
 async function updateConnectedBar() {
-  const config = instance.getConfig();
-  if (config) {
+  const connection = instance.getConnection();
+  if (connection) {
+    const config = instance.getConfig()!;
     connectedBarItem.text = `$(${config.readOnlyMode ? "lock" : "settings-gear"}) ${config.name}`;
   }
 
@@ -822,7 +128,8 @@ async function updateConnectedBar() {
 }
 
 async function onConnected() {
-  const config = instance.getConfig();
+  const connection = instance.getConnection()!;
+  const config = connection.getConfig();
 
   [
     connectedBarItem,
@@ -832,7 +139,7 @@ async function onConnected() {
   updateConnectedBar();
 
   // Enable the profile view if profiles exist.
-  vscode.commands.executeCommand(`setContext`, `code-for-ibmi:hasProfiles`, (config?.connectionProfiles || []).length > 0);
+  vscode.commands.executeCommand(`setContext`, `code-for-ibmi:hasProfiles`, (config.connectionProfiles || []).length > 0);
 }
 
 async function onDisconnected() {
@@ -857,59 +164,3 @@ async function onDisconnected() {
   ].forEach(barItem => barItem.hide())
 }
 
-async function createQuickPickItemsList(
-  labelFiltered: string = ``, filtered: vscode.QuickPickItem[] = [],
-  labelRecent: string = ``, recent: vscode.QuickPickItem[] = [],
-  labelCached: string = ``, cached: vscode.QuickPickItem[] = [],
-) {
-  const clearRecentArray = [{ label: ``, kind: vscode.QuickPickItemKind.Separator }, { label: CLEAR_RECENT }];
-  const clearCachedArray = [{ label: ``, kind: vscode.QuickPickItemKind.Separator }, { label: CLEAR_CACHED }];
-
-  const returnedList: vscode.QuickPickItem[] = [
-    { label: labelFiltered, kind: vscode.QuickPickItemKind.Separator },
-    ...filtered,
-    { label: labelRecent, kind: vscode.QuickPickItemKind.Separator },
-    ...recent,
-    ...(recent.length != 0 ? clearRecentArray : []),
-    { label: labelCached, kind: vscode.QuickPickItemKind.Separator },
-    ...cached,
-    ...(cached.length != 0 ? clearCachedArray : [])
-  ];
-  return returnedList;
-}
-
-async function compareCurrentFile(node: any, scheme: `streamfile` | `file` | `member`) {
-  let currentFile: vscode.Uri | undefined;
-  // If we are comparing with an already targeted node
-  if (node) {
-    if (node.resourceUri) {
-      currentFile = node.resourceUri;
-    } else if (node.scheme === `file`) {
-      currentFile = node
-    }
-  } else {
-    // If we are comparing with the currently open file
-    const editor = vscode.window.activeTextEditor;
-    if (editor) {
-      currentFile = editor.document.uri;
-    }
-  }
-
-  if (currentFile) {
-    let compareWith = await vscode.window.showInputBox({
-      prompt: vscode.l10n.t(`Enter the path to compare selected with`),
-      title: vscode.l10n.t(`Compare with`),
-      value: currentFile.path
-    });
-
-    if (compareWith) {
-      if (scheme == 'member' && !compareWith.startsWith('/')) {
-        compareWith = `/${compareWith}`;
-      }
-      let uri = vscode.Uri.parse(`${scheme}:${compareWith}`);
-      vscode.commands.executeCommand(`vscode.diff`, currentFile, uri);
-    }
-  } else {
-    vscode.window.showInformationMessage(vscode.l10n.t(`No file is open or selected`));
-  }
-}

--- a/src/testing/action.ts
+++ b/src/testing/action.ts
@@ -63,7 +63,8 @@ export const ActionSuite: TestSuite = {
   tests: [
     {
       name: `Variable expansion test`, test: async () => {
-        const result = await CompileTools.runCommand(instance, {
+        const connection = instance.getConnection()!;
+        const result = await CompileTools.runCommand(connection, {
           command: 'echo "&CURLIB &MYTEXT"',
           env: { '&MYTEXT': `&BRANCHLIB &BRANCH`, '&BRANCHLIB': 'MYLIB', '&BRANCH': 'my/lib' },
           environment: `pase`

--- a/src/views/debugView.ts
+++ b/src/views/debugView.ts
@@ -72,7 +72,7 @@ class DebugBrowser implements vscode.TreeDataProvider<BrowserItem> {
   private async getRootItems() {
     const connection = instance.getConnection();
     if (connection) {
-      const debugConfig = await new DebugConfiguration().load();
+      const debugConfig = await new DebugConfiguration(connection).load();
       const keyFileExists = await debugKeyFileExists(connection, debugConfig);
 
       const certificates: Certificates = {

--- a/src/views/helpView.ts
+++ b/src/views/helpView.ts
@@ -133,7 +133,7 @@ async function downloadLogs() {
       location: vscode.ProgressLocation.Notification,
       title: vscode.l10n.t(`Gathering logs...`),
     }, async () => {
-      const codeForIBMiLog = connection.outputChannelContent;
+      const codeForIBMiLog = connection.getOutputChannelContent();
       if (codeForIBMiLog !== undefined) {
         logs.push({
           label: vscode.l10n.t(`Code for IBM i Log`),
@@ -144,7 +144,7 @@ async function downloadLogs() {
         });
       }
 
-      const debugConfig = await new DebugConfiguration().load();
+      const debugConfig = await new DebugConfiguration(connection).load();
       try {
         const debugServiceLogPath = `${debugConfig.getRemoteServiceWorkDir()}/DebugService_log.txt`;
         const debugServiceLog = (await content.downloadStreamfileRaw(debugServiceLogPath));

--- a/src/views/ifsBrowser.ts
+++ b/src/views/ifsBrowser.ts
@@ -512,14 +512,14 @@ export function initializeIFSBrowser(context: vscode.ExtensionContext) {
             try {
               if (filesToUpload.length) {
                 progress.report({ message: l10n.t(`sending {0} file(s)...`, filesToUpload.length) });
-                await connection.uploadFiles(filesToUpload, { concurrency: 5 });
+                await connection.getContent().uploadFiles(filesToUpload, { concurrency: 5 });
               }
 
               if (directoriesToUpload.length) {
                 for (const directory of directoriesToUpload) {
                   const name = path.basename(directory.fsPath);
                   progress.report({ message: l10n.t(`sending {0} directory...`, name) })
-                  await connection.uploadDirectory(directory, path.posix.join(root, name), { concurrency: 5 })
+                  await connection.getContent().uploadDirectory(directory, path.posix.join(root, name), { concurrency: 5 })
                 }
               }
 
@@ -875,19 +875,19 @@ Please type "{0}" to confirm deletion.`, dirName);
 
                     if (proceed) {
                       mkdirSync(target, { recursive: true });
-                      await ibmi.downloadDirectory(target, targetPath, { concurrency: 5 });
+                      await ibmi.getContent().downloadDirectory(target, targetPath, { concurrency: 5 });
                     }
                   }
                   else {
                     if (!existsSync(target) || await vscode.window.showWarningMessage(l10n.t(`{0} already exists.
 Do you want to replace it?`, target), { modal: true }, l10n.t(`{0} already exists.
 Do you want to replace it?`, target))) {
-                      await ibmi.downloadFile(target, targetPath);
+                      await ibmi.getContent().downloadFile(target, targetPath);
                     }
                   }
                 }
                 else {
-                  await ibmi.downloadFile(downloadLocation!, targetPath);
+                  await ibmi.getContent().downloadFile(downloadLocation!, targetPath);
                 }
               }
               vscode.window.showInformationMessage(l10n.t(`Download complete`), l10n.t(`Open`))

--- a/src/views/objectBrowser.ts
+++ b/src/views/objectBrowser.ts
@@ -904,7 +904,7 @@ Do you want to replace it?`, item.name), skipAllLabel, overwriteLabel, overwrite
               await contentApi.runSQL(copyToStreamFiles);
 
               task.report({ message: vscode.l10n.t(`getting streamfiles`), increment: 33 })
-              await connection.downloadDirectory(downloadLocation!, directory);
+              await connection.getContent().downloadDirectory(downloadLocation!, directory);
               vscode.window.showInformationMessage(vscode.l10n.t(`Members download complete.`), vscode.l10n.t(`Open`))
                 .then(open => open ? vscode.commands.executeCommand('revealFileInOS', saveIntoDirectory ? vscode.Uri.joinPath(downloadLocationURI, toBeDownloaded[0].name.toLocaleLowerCase()) : downloadLocationURI) : undefined);
             });

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -95,7 +95,7 @@ export class Login {
 
               if (data.password || data.privateKeyPath) {
                 try {
-                  const connected = await new IBMi().connect(data, false, false, toDoOnConnected);
+                  const connected = await instance.connect({data, onConnectedOperations: toDoOnConnected});
                   if (connected.success) {
                     if (newConnection) {
                       vscode.window.showInformationMessage(`Connected to ${data.host}! Would you like to configure this connection?`, `Open configuration`).then(async (selectionA) => {
@@ -171,7 +171,7 @@ export class Login {
       }
 
       try {
-        const connected = await new IBMi().connect(connectionConfig, undefined, reloadServerSettings, toDoOnConnected);
+        const connected = await instance.connect({data: connectionConfig, onConnectedOperations: toDoOnConnected, reloadServerSettings});
         if (connected.success) {
           vscode.window.showInformationMessage(`Connected to ${connectionConfig.host}!`);
         } else {

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -2,7 +2,7 @@ import vscode, { l10n, ThemeIcon } from "vscode";
 import { ConnectionConfiguration, ConnectionManager } from "../../api/Configuration";
 import { CustomUI, Section } from "../../api/CustomUI";
 import IBMi from "../../api/IBMi";
-import { disconnect, instance } from "../../instantiate";
+import { safeDisconnect, instance } from "../../instantiate";
 import { ConnectionData } from '../../typings';
 
 type NewLoginSettings = ConnectionData & {
@@ -21,7 +21,7 @@ export class Login {
   static async show(context: vscode.ExtensionContext) {
     const connection = instance.getConnection();
     if (connection) {
-      if (!disconnect()) return;
+      if (!safeDisconnect()) return;
     }
 
     const connectionTab = new Section()
@@ -115,7 +115,7 @@ export class Login {
                     }
 
                   } else {
-                    vscode.window.showErrorMessage(`Not connected to ${data.host}! ${connected.error.message || connected.error}`);
+                    vscode.window.showErrorMessage(`Not connected to ${data.host}! ${connected.error}`);
                   }
                 } catch (e) {
                   vscode.window.showErrorMessage(`Error connecting to ${data.host}! ${e}`);
@@ -145,7 +145,7 @@ export class Login {
       // If the user is already connected and trying to connect to a different system, disconnect them first
       if (name !== existingConnection.currentConnectionName) {
         vscode.window.showInformationMessage(`Disconnecting from ${existingConnection.currentHost}.`);
-        if (!await disconnect()) return false;
+        if (!await safeDisconnect()) return false;
       }
     }
 
@@ -175,7 +175,7 @@ export class Login {
         if (connected.success) {
           vscode.window.showInformationMessage(`Connected to ${connectionConfig.host}!`);
         } else {
-          vscode.window.showErrorMessage(`Not connected to ${connectionConfig.host}! ${connected.error.message || connected.error}`);
+          vscode.window.showErrorMessage(`Not connected to ${connectionConfig.host}! ${connected.error}`);
         }
 
         return true;


### PR DESCRIPTION
Begin the process of deprecating legacy APIs/getters by updating references throughout the codebase to use new connection methods. This change enhances code maintainability and prepares for future improvements.

* Creates new generic `connect` and `disconnect` methods in `instance`, which is safer than calling `new IBMi()` to set the instance in the `connect` method.
* Split up `instantiate` so it doesn't hard code all commands inside of it.
* Move timeout handler and reconnect logic out of IBMi class.
* Remove all uses of `instance` in the IBMi class.