### PR TITLE
Fix getAttributes for files with spaces and enhance tests

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -957,15 +957,15 @@ export default class IBMiContent {
       target = localPath;
     }
 
-    target = IBMi.escapeForShell(target);
-
     let result: CommandResult;
 
     if (assumeMember) {
+      target = IBMi.escapeForShell(target);
       result = await this.ibmi.sendQsh({ command: `${this.ibmi.remoteFeatures.attr} -p ${target} ${operands.join(" ")}`});
     } else {
+      target = Tools.escapePath(target, true);
       // Take {DOES_THIS_WORK: `YESITDOES`} away, and all of a sudden names with # aren't found.
-      result = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.attr} -p ${target} ${operands.join(" ")}`, env: {DOES_THIS_WORK: `YESITDOES`}});
+      result = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.attr} -p "${target}" ${operands.join(" ")}`, env: {DOES_THIS_WORK: `YESITDOES`}});
     }
 
     if (result.code === 0) {

--- a/src/testing/encoding.ts
+++ b/src/testing/encoding.ts
@@ -92,6 +92,26 @@ export const EncodingSuite: TestSuite = {
       }
     },
     {
+      name: `Files and directories with spaces`, test: async () => {
+        const connection = instance.getConnection()!;
+
+        await connection.withTempDirectory(async tempDir => {
+          const dirWithSpace = path.posix.join(tempDir, `hello world`);
+          const fileName = `hello world.txt`;
+          const nameWithSpace = path.posix.join(dirWithSpace, fileName);
+
+          await connection.sendCommand({command: `mkdir -p "${dirWithSpace}"`});
+          await connection.content.createStreamFile(nameWithSpace);
+
+          const resolved = await connection.content.streamfileResolve([fileName], [tempDir, dirWithSpace]);
+          assert.strictEqual(resolved, nameWithSpace);
+
+          const attributes = await connection.content.getAttributes(resolved, `CCSID`);
+          assert.ok(attributes);
+        });
+      }
+    },
+    {
       name: `Run variants through shells`, test: async () => {
         const connection = instance.getConnection();
 

--- a/src/testing/encoding.ts
+++ b/src/testing/encoding.ts
@@ -96,18 +96,36 @@ export const EncodingSuite: TestSuite = {
         const connection = instance.getConnection()!;
 
         await connection.withTempDirectory(async tempDir => {
-          const dirWithSpace = path.posix.join(tempDir, `hello world`);
+          const dirName = `hello world`;
+          const dirWithSpace = path.posix.join(tempDir, dirName);
           const fileName = `hello world.txt`;
           const nameWithSpace = path.posix.join(dirWithSpace, fileName);
 
           await connection.sendCommand({command: `mkdir -p "${dirWithSpace}"`});
           await connection.content.createStreamFile(nameWithSpace);
 
+          // Resolve and get attributes
           const resolved = await connection.content.streamfileResolve([fileName], [tempDir, dirWithSpace]);
           assert.strictEqual(resolved, nameWithSpace);
 
           const attributes = await connection.content.getAttributes(resolved, `CCSID`);
           assert.ok(attributes);
+
+          // Write and read the files
+          const uri = Uri.from({scheme: `streamfile`, path: nameWithSpace});
+          await workspace.fs.writeFile(uri, Buffer.from(`Hello world`, `utf8`));
+
+          const streamfileContents = await workspace.fs.readFile(uri);
+          assert.ok(streamfileContents.toString().includes(`Hello world`));
+
+          // List files
+          const files = await connection.content.getFileList(tempDir);
+          assert.strictEqual(files.length, 1);
+          assert.ok(files.some(f => f.name === dirName && f.path === dirWithSpace));
+
+          const files2 = await connection.content.getFileList(dirWithSpace);
+          assert.strictEqual(files2.length, 1);
+          assert.ok(files2.some(f => f.name === fileName && f.path === nameWithSpace));
         });
       }
     },


### PR DESCRIPTION
Address issues with retrieving attributes for files that contain spaces in their names. Add additional test logic to ensure proper handling of such files and directories.