### PR TITLE
Fixed GETMBRINFO status fetch crashing on system with undefind Runtime CCSID

### DIFF
--- a/src/components/getMemberInfo.ts
+++ b/src/components/getMemberInfo.ts
@@ -19,7 +19,7 @@ export class GetMemberInfo implements IBMiComponent {
   }
 
   async getRemoteState(connection: IBMi): Promise<ComponentState> {
-    const [result] = await connection.runSQL(`select LONG_COMMENT from qsys2.sysroutines where routine_schema = '${connection.config?.tempLibrary.toUpperCase()}' and routine_name = '${this.procedureName}'`);
+    const [result] = await connection.runSQL(`select cast(LONG_COMMENT as VarChar(200)) LONG_COMMENT from qsys2.sysroutines where routine_schema = '${connection.config?.tempLibrary.toUpperCase()}' and routine_name = '${this.procedureName}'`);
     if (result?.LONG_COMMENT) {
       const comment = result.LONG_COMMENT as string;
       const dash = comment.indexOf('-');


### PR DESCRIPTION
### Changes
`LONG_COMMENT` field in `qsys2.sysroutines` is VARGRAPHIC so the query used to fetch GETMBRINFO version crashes on systems with undefined Runtime CCSID since converting from CCSID 1200 to 65535 is not possible.

This PR casts `LONG_COMMENT` to `VARCHAR` to prevent the crash from happening.

### How to test this PR
1. Connect
2. Open the connection settings
3. Go to the Components tab
4. GetMemberInfo must show `(version 1): Installed` (before the PR, with Runtime CCSID 65535, it would show `(version 0): Error`

### Checklist
* [x] have tested my change