### PR TITLE
Fix `No default` deployment method not properly set

### DIFF
--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -306,6 +306,7 @@ export class SettingsUI {
                         break;
                       case `defaultDeploymentMethod`:
                         if (data[key] === 'No Default') data[key] = '';
+                        break;
                     }
                   }
 

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -304,6 +304,8 @@ export class SettingsUI {
                           .filter(item => item !== ``)
                           .filter(Tools.distinct);
                         break;
+                      case `defaultDeploymentMethod`:
+                        if (data[key] === 'No Default') data[key] = '';
                     }
                   }
 


### PR DESCRIPTION
### Changes

Fixes #2398

### How to test this PR

Examples:

1. Set `Default Deployment Method` to `No Default`
2. You should be prompted for deployment method without error.

### Checklist

* [x] have tested my change