### PR TITLE
Fix missing workflow permissions to post comment

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,9 +1,11 @@
 on: pull_request
-    
+
 jobs:
   release:
     name: Validation
     runs-on: ubuntu-latest
+    permissions: 
+      pull-requests: write
     steps:
       - name: Use Node.js 20
         uses: actions/setup-node@v3


### PR DESCRIPTION
### Changes

Add `pull-requests: write` permissions to PR workflow so it can post comments