### PR TITLE
Fix/multilibfilter

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -473,7 +473,11 @@ export default class IBMiContent {
   }
 
   async getLibraries(filters: { library: string; filterType?: FilterType }) {
-    return this.getObjectList({ library: "QSYS", object: filters.library, types: ["*LIB"], filterType: filters.filterType });
+    const libraries = [];
+    for(const library of filters.library.split(",")){
+      libraries.push(...await this.getObjectList({ library: "QSYS", object: library.trim(), types: ["*LIB"], filterType: filters.filterType }));
+    }
+    return libraries;    
   }
 
   /**

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -473,11 +473,13 @@ export default class IBMiContent {
   }
 
   async getLibraries(filters: { library: string; filterType?: FilterType }) {
-    const libraries = [];
-    for(const library of filters.library.split(",")){
-      libraries.push(...await this.getObjectList({ library: "QSYS", object: library.trim(), types: ["*LIB"], filterType: filters.filterType }));
+    const libraries: IBMiObject[] = [];
+    for (const library of filters.library.split(",")) {
+      (await this.getObjectList({ library: "QSYS", object: library.trim(), types: ["*LIB"], filterType: filters.filterType }))
+        .filter(lib => !libraries.find(l => l.name === lib.name))
+        .forEach(lib => libraries.push(lib));
     }
-    return libraries;    
+    return libraries;
   }
 
   /**
@@ -946,7 +948,7 @@ export default class IBMiContent {
   }
 
   async getAttributes(path: string | (QsysPath & { member?: string }), ...operands: AttrOperands[]) {
-    const localPath = typeof path === `string` ? path : {...path};
+    const localPath = typeof path === `string` ? path : { ...path };
     const assumeMember = typeof localPath === `object`;
     let target: string;
 
@@ -965,11 +967,11 @@ export default class IBMiContent {
 
     if (assumeMember) {
       target = IBMi.escapeForShell(target);
-      result = await this.ibmi.sendQsh({ command: `${this.ibmi.remoteFeatures.attr} -p ${target} ${operands.join(" ")}`});
+      result = await this.ibmi.sendQsh({ command: `${this.ibmi.remoteFeatures.attr} -p ${target} ${operands.join(" ")}` });
     } else {
       target = Tools.escapePath(target, true);
       // Take {DOES_THIS_WORK: `YESITDOES`} away, and all of a sudden names with # aren't found.
-      result = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.attr} -p "${target}" ${operands.join(" ")}`, env: {DOES_THIS_WORK: `YESITDOES`}});
+      result = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.attr} -p "${target}" ${operands.join(" ")}`, env: { DOES_THIS_WORK: `YESITDOES` } });
     }
 
     if (result.code === 0) {
@@ -1054,7 +1056,7 @@ export default class IBMiContent {
   }
 }
 
-function safeIsoValue(date: Date|undefined) {
+function safeIsoValue(date: Date | undefined) {
   try {
     return date ? date.toISOString().slice(0, 19).replace(`T`, ` `) : ``;
   } catch (e) {


### PR DESCRIPTION
### Changes
Fixes #2405

Setting multiple libraries in a filter would result in the filter showing nothing when expanded.
![image](https://github.com/user-attachments/assets/a6d26160-8f9c-4dcd-a962-ddac02f53e27)

Each library name filter must be treated independently; this PR changes the `getLibraries` method to perform a call to `getObjectList` for each library name filter.

### How to test this PR
1. Create a filter with multiple library filter names
2. Run the `Content API` tests

### Checklist
* [x] have tested my change
* [x] have created one or more test cases