### PR TITLE
Manage custom `C4iDebugService.env` file to store Debug Service configuration

### DIFF
--- a/src/api/debug/certificates.ts
+++ b/src/api/debug/certificates.ts
@@ -210,7 +210,7 @@ export async function setup(connection: IBMi, imported?: ImportedCertificate) {
 }
 
 export async function debugKeyFileExists(connection: IBMi, debugConfig: DebugConfiguration) {
-  return await connection.content.testStreamFile(`${debugConfig.getRemoteServiceWorkDir()}/.code4i.debug`, "f");
+  return await connection.getContent().testStreamFile(`${debugConfig.getRemoteServiceWorkDir()}/.code4i.debug`, "f");
 }
 
 export async function remoteCertificatesExists(debugConfig?: DebugConfiguration) {

--- a/src/api/debug/server.ts
+++ b/src/api/debug/server.ts
@@ -4,7 +4,7 @@ import { instance } from "../../instantiate";
 import { CustomUI } from "../CustomUI";
 import IBMi from "../IBMi";
 import { Tools } from "../Tools";
-import { DebugConfiguration, getDebugServiceDetails } from "./config";
+import { DEBUG_CONFIG_FILE, DebugConfiguration, getDebugServiceDetails, ORIGINAL_DEBUG_CONFIG_FILE } from "./config";
 
 export type DebugJob = {
   name: string
@@ -28,6 +28,10 @@ export async function startService(connection: IBMi) {
 
   try {
     await checkAuthority();
+    const debugServiceVersion = (await getDebugServiceDetails()).semanticVersion();
+    const prestartCommand = (debugServiceVersion.major >= 2 && debugServiceVersion.patch >= 1) ?
+      `export DEBUG_SERVICE_EXTERNAL_CONFIG_FILE=${DEBUG_CONFIG_FILE}` :
+      `cp ${DEBUG_CONFIG_FILE} ${ORIGINAL_DEBUG_CONFIG_FILE}`
     const debugConfig = await new DebugConfiguration(connection).load();
 
     const submitOptions = await window.showInputBox({
@@ -41,7 +45,7 @@ export async function startService(connection: IBMi) {
       if (submitUser && submitUser !== "*CURRENT") {
         await checkAuthority(submitUser);
       }
-      const command = `SBMJOB CMD(STRQSH CMD('${connection.remoteFeatures[`bash`]} -c /QIBM/ProdData/IBMiDebugService/bin/startDebugService.sh')) JOB(DBGSVCE) ${submitOptions}`
+      const command = `SBMJOB CMD(STRQSH CMD('${connection.remoteFeatures[`bash`]} -c ''${prestartCommand}; /QIBM/ProdData/IBMiDebugService/bin/startDebugService.sh''')) JOB(DBGSVCE) ${submitOptions}`
       const submitResult = await connection.runCommand({ command, cwd: debugConfig.getRemoteServiceWorkDir(), noLibList: true });
       if (submitResult.code === 0) {
         const submitMessage = Tools.parseMessages(submitResult.stderr || submitResult.stdout).findId("CPC1221")?.text;
@@ -229,7 +233,7 @@ async function openQPRINT(connection: IBMi, job: string) {
       .setOptions({ fullWidth: true })
       .loadPage(`${job} QPRINT`);
   }
-  else{
+  else {
     window.showWarningMessage(`No QPRINT spooled file found for job ${job}!`);
   }
 }

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -6,15 +6,15 @@ import { Terminal } from './api/Terminal';
 import { getDebugServiceDetails } from './api/debug/config';
 import { debugPTFInstalled, isDebugEngineRunning } from './api/debug/server';
 import { setupGitEventHandler } from './api/local/git';
+import { registerActionsCommands } from './commands/actions';
+import { registerCompareCommands } from './commands/compare';
+import { registerConnectionCommands } from './commands/connection';
+import { registerOpenCommands } from './commands/open';
+import { registerPasswordCommands } from './commands/password';
 import { QSysFS } from "./filesystems/qsys/QSysFs";
 import { SEUColorProvider } from "./languages/general/SEUColorProvider";
 import { ActionsUI } from './webviews/actions';
 import { VariablesUI } from "./webviews/variables";
-import { registerOpenCommands } from './commands/open';
-import { registerCompareCommands } from './commands/compare';
-import { registerActionsCommands } from './commands/actions';
-import { registerPasswordCommands } from './commands/password';
-import { registerConnectionCommands } from './commands/connection';
 
 export let instance: Instance;
 
@@ -108,9 +108,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
 }
 
 async function updateConnectedBar() {
-  const connection = instance.getConnection();
-  if (connection) {
-    const config = instance.getConfig()!;
+  const config = instance.getConnection()?.getConfig();
+  if (config) {
     connectedBarItem.text = `$(${config.readOnlyMode ? "lock" : "settings-gear"}) ${config.name}`;
   }
 
@@ -128,9 +127,7 @@ async function updateConnectedBar() {
 }
 
 async function onConnected() {
-  const connection = instance.getConnection()!;
-  const config = connection.getConfig();
-
+  const config = instance.getConnection()?.getConfig();
   [
     connectedBarItem,
     disconnectBarItem,
@@ -139,7 +136,7 @@ async function onConnected() {
   updateConnectedBar();
 
   // Enable the profile view if profiles exist.
-  vscode.commands.executeCommand(`setContext`, `code-for-ibmi:hasProfiles`, (config.connectionProfiles || []).length > 0);
+  vscode.commands.executeCommand(`setContext`, `code-for-ibmi:hasProfiles`, (config?.connectionProfiles || []).length > 0);
 }
 
 async function onDisconnected() {


### PR DESCRIPTION
### Changes
Resolves #2416

Applying Debug Service's PTF resets the `/QIBM/ProdData/IBMiDebugService` folder, including the `DebugService.env` holding Code for IBM i debug service config changes.

Since Debug Service 2.0.1, it is possible to use a custom `.env` file the start script will load when starting the debug service.
To take advantage of this, Code for IBM i will create a copy of the `/QIBM/ProdData/IBMiDebugService/bin/DebugService.env` into `/QIBM/UserData/IBMiDebugService/C4iDebugService.env` when connecting to a system, if `C4iDebugService.env` doesn't exist.
`/QIBM/ProdData/IBMiDebugService/bin/DebugService.env` won't me changed anymore and only `C4iDebugService.env` will be updated and used by Code for IBM i.

Starting the Debug Service >= 2.0.1 will set the `DEBUG_SERVICE_EXTERNAL_CONFIG_FILE` env variable before running the start script.
When starting the Debug Service < 2.0.1, `/QIBM/UserData/IBMiDebugService/C4iDebugService.env` is copied and overwrites `/QIBM/ProdData/IBMiDebugService/bin/DebugService.env` (to mimic v 2.0.1 behavior).

### How to test this PR
1. Connect
2. Check file `/QIBM/UserData/IBMiDebugService/C4iDebugService.env` has been created and is a copy of `/QIBM/ProdData/IBMiDebugService/bin/DebugService.env`
3. Start the Debug Service

### Checklist
* [x] have tested my change