### PR TITLE
Correctly check GetNewLibl component state

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -8,7 +8,7 @@ import { IBMiComponent } from "../components/component";
 import { CopyToImport } from "../components/copyToImport";
 import { CustomQSh } from '../components/cqsh';
 import { ComponentManager } from "../components/manager";
-import { CommandData, CommandResult, ConnectionData, IBMiMember, RemoteCommand, SpecialAuthorities, WrapResult } from "../typings";
+import { CommandData, CommandResult, ConnectionData, IBMiMember, RemoteCommand, WrapResult } from "../typings";
 import { CompileTools } from "./CompileTools";
 import { ConnectionConfiguration } from "./Configuration";
 import IBMiContent from "./IBMiContent";
@@ -407,15 +407,6 @@ export default class IBMi {
           progress.report({
             message: `Checking installed components on host IBM i.`
           });
-
-          // We need to check if our remote programs are installed.
-          remoteApps.push(
-            {
-              path: `/QSYS.lib/${this.upperCaseName(this.config.tempLibrary)}.lib/`,
-              names: [`GETNEWLIBL.PGM`],
-              specific: `GE*.PGM`
-            }
-          );
 
           //Next, we see what pase features are available (installed via yum)
           //This may enable certain features in the future.

--- a/src/components/getMemberInfo.ts
+++ b/src/components/getMemberInfo.ts
@@ -35,10 +35,9 @@ export class GetMemberInfo implements IBMiComponent {
   }
 
   async update(connection: IBMi): Promise<ComponentState> {
-    const config = connection.config!;
     return connection.withTempDirectory(async tempDir => {
       const tempSourcePath = posix.join(tempDir, `getMemberInfo.sql`);
-      await connection.content.writeStreamfileRaw(tempSourcePath, getSource(config.tempLibrary, this.procedureName, this.currentVersion));
+      await connection.getContent().writeStreamfileRaw(tempSourcePath, getSource(connection.getConfig().tempLibrary, this.procedureName, this.currentVersion));
       const result = await connection.runCommand({
         command: `RUNSQLSTM SRCSTMF('${tempSourcePath}') COMMIT(*NONE) NAMING(*SQL)`,
         cwd: `/`,


### PR DESCRIPTION
### Changes
`GetNewLibl` component state was not checked as it should. Instead of being checked in the corresponding component, it was added to the `IBMi::remoteApps` global array to be checked as a remote feature. This caused two issues:
- The actual version of `GetNewLibl` was not checked
- A new entry for checking `GetNewLibl` was added to the global array with each 'non-quick connect' connection attempts
![image](https://github.com/user-attachments/assets/471a2d9c-64ba-4efa-909f-ac32411920a6)

This PR fixes this by:
- Not checking `GetNewLibl` as a remote feature anymore
- Handling `GetNewLibl` version in its component object

### How to test this PR
1. Connect
2. Check that `GetNewLibl` procedure get created in the connection temporary library with the version in its comment

### Checklist
* [x] have tested my change