### PR TITLE
New connection settings `Connection Timeout` field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@ibm/ibmi-eventf-parser": "^1.0.2",
-				"@vscode-elements/elements": "^1.9.0",
+				"@vscode-elements/elements": "^1.9.1",
 				"adm-zip": "^0.5.14",
 				"crc-32": "https://cdn.sheetjs.com/crc-32-latest/crc-32-latest.tgz",
 				"csv": "^6.2.1",
@@ -346,9 +346,10 @@
 			"license": "MIT"
 		},
 		"node_modules/@vscode-elements/elements": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@vscode-elements/elements/-/elements-1.9.0.tgz",
-			"integrity": "sha512-OjoACdO2elyZ8qVxaClN/JUODejusYC1YVOU6ekHULdWuVoU1nAXRh31Smm89M+Z7UezaAH2mXIP9aZ3q4nnjA==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@vscode-elements/elements/-/elements-1.9.1.tgz",
+			"integrity": "sha512-OqNqE6vD4gbmu8L5UBAHuiU/cclLDsEb1gikJvuzEY7jVQOU0jFR70gFdk/aQikWFcKzVMoXqgO+lIKPSK0IUw==",
+			"license": "MIT",
 			"dependencies": {
 				"lit": "^3.2.1"
 			}

--- a/package.json
+++ b/package.json
@@ -2983,7 +2983,7 @@
 	},
 	"dependencies": {
 		"@ibm/ibmi-eventf-parser": "^1.0.2",
-		"@vscode-elements/elements": "^1.9.0",
+		"@vscode-elements/elements": "^1.9.1",
 		"adm-zip": "^0.5.14",
 		"crc-32": "https://cdn.sheetjs.com/crc-32-latest/crc-32-latest.tgz",
 		"csv": "^6.2.1",

--- a/src/api/CustomUI.ts
+++ b/src/api/CustomUI.ts
@@ -329,7 +329,7 @@ export class CustomUI extends Section {
                   }
                 }
 
-                if(field.inputType === "number"){                  
+                if(field.inputType === "number"){
                   const numberValue = Number(currentValue);
                   isInvalid = isNaN(numberValue) ||
                     (field.min !== undefined && numberValue < Number(field.min)) ||
@@ -398,7 +398,10 @@ export class CustomUI extends Section {
             // Setup the input fields for validation
             for (const field of inputFields) {
               const fieldElement = document.getElementById(field.id);
-              fieldElement.onkeyup = (e) => {validateInputs()};
+              fieldElement.onkeyup = (e) => {validateInputs()};              
+              if(field.inputType === "number"){
+                fieldElement.onmousewheel = (e) => {validateInputs()};
+              }
             }
 
             // Now many buttons can be pressed to submit

--- a/src/api/CustomUI.ts
+++ b/src/api/CustomUI.ts
@@ -329,6 +329,13 @@ export class CustomUI extends Section {
                   }
                 }
 
+                if(field.inputType === "number"){                  
+                  const numberValue = Number(currentValue);
+                  isInvalid = isNaN(numberValue) ||
+                    (field.min !== undefined && numberValue < Number(field.min)) ||
+                    (field.max !== undefined && numberValue > Number(field.max));
+                }
+
                 if (isInvalid) {
                   fieldElement.setAttribute("invalid", "true");
                   isValid = false;
@@ -578,6 +585,7 @@ export class Field {
                 ${this.maxlength ? `maxlength="${this.maxlength}"` : ``}
                 ${this.min ? `min="${this.min}"` : ``}
                 ${this.max ? `max="${this.max}"` : ``}
+                ${this.inputType === 'number' ? `step="1"` : ``}
                 >
               <${tag}>
           </vscode-form-group>`;

--- a/src/api/CustomUI.ts
+++ b/src/api/CustomUI.ts
@@ -398,10 +398,7 @@ export class CustomUI extends Section {
             // Setup the input fields for validation
             for (const field of inputFields) {
               const fieldElement = document.getElementById(field.id);
-              fieldElement.onkeyup = (e) => {validateInputs()};              
-              if(field.inputType === "number"){
-                fieldElement.onmousewheel = (e) => {validateInputs()};
-              }
+              fieldElement.addEventListener("change", (e) => {validateInputs()});              
             }
 
             // Now many buttons can be pressed to submit

--- a/src/api/CustomUI.ts
+++ b/src/api/CustomUI.ts
@@ -41,6 +41,8 @@ interface WebviewMessageRequest {
   data?: any;
 }
 
+type InputType = "text" | "number";
+
 export class Section {
   readonly fields: Field[] = [];
 
@@ -61,7 +63,7 @@ export class Section {
     return this;
   }
 
-  addInput(id: string, label: string, description?: string, options?: { default?: string, readonly?: boolean, rows?: number, minlength?: number, maxlength?: number, regexTest?: string }) {
+  addInput(id: string, label: string, description?: string, options?: { default?: string, readonly?: boolean, rows?: number, minlength?: number, maxlength?: number, regexTest?: string, inputType?: InputType, min?:number, max?:number }) {
     const input = Object.assign(new Field('input', id, label, description), options);
     this.addField(input);
     return this;
@@ -505,6 +507,9 @@ export class Field {
   public minlength?: number;
   public maxlength?: number;
   public regexTest?: string;
+  public inputType?: InputType;
+  public min?: number;
+  public max?: number;
 
   constructor(readonly type: FieldType, readonly id: string, readonly label: string, readonly description?: string) {
 
@@ -565,12 +570,16 @@ export class Field {
               ${this.renderLabel()}
               ${this.renderDescription()}              
               <${tag} class="long-input" id="${this.id}" name="${this.id}" 
+                ${this.inputType ? `type="${this.inputType}"` : ``} 
                 ${this.default ? `value="${this.default}"` : ``} 
                 ${this.readonly ? `readonly` : ``} 
                 ${multiline ? `rows="${this.rows}" resize="vertical"` : ''}
                 ${this.minlength ? `minlength="${this.minlength}"` : ``} 
-                ${this.maxlength ? `maxlength="${this.maxlength}"` : ``}>
-              /${tag}>
+                ${this.maxlength ? `maxlength="${this.maxlength}"` : ``}
+                ${this.min ? `min="${this.min}"` : ``}
+                ${this.max ? `max="${this.max}"` : ``}
+                >
+              <${tag}>
           </vscode-form-group>`;
 
       case `paragraph`:

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -8,7 +8,7 @@ import { IBMiComponent } from "../components/component";
 import { CopyToImport } from "../components/copyToImport";
 import { CustomQSh } from '../components/cqsh';
 import { ComponentManager } from "../components/manager";
-import { CommandData, CommandResult, ConnectionData, IBMiMember, RemoteCommand, SpecialAuthorities, WrapResult } from "../typings";
+import { CommandData, CommandResult, ConnectionData, IBMiMember, RemoteCommand, WrapResult } from "../typings";
 import { CompileTools } from "./CompileTools";
 import { ConnectionConfiguration } from "./Configuration";
 import IBMiContent from "./IBMiContent";
@@ -76,7 +76,7 @@ export default class IBMi {
    */
   content = new IBMiContent(this);
 
-  client: node_ssh.NodeSSH|undefined;
+  client: node_ssh.NodeSSH | undefined;
   currentHost: string = ``;
   currentPort: number = 22;
   currentUser: string = ``;
@@ -106,7 +106,7 @@ export default class IBMi {
   //Maximum admited length for command's argument - any command whose arguments are longer than this won't be executed by the shell
   maximumArgsLength = 0;
 
-  private disconnectedCallback: (DisconnectCallback)|undefined;
+  private disconnectedCallback: (DisconnectCallback) | undefined;
 
   /**
    * Will only be called once per connection.

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -85,6 +85,7 @@ export interface ConnectionData {
   password?: string;
   privateKeyPath?: string;
   keepaliveInterval?: number;
+  readyTimeout?: number;
 }
 
 export interface Server {

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -29,12 +29,13 @@ export class Login {
       .addInput(`host`, l10n.t(`Host or IP Address`), undefined, { minlength: 1 })
       .addInput(`port`, l10n.t(`Port (SSH)`), ``, { default: `22`, minlength: 1, maxlength: 5, regexTest: `^\\d+$` })
       .addInput(`username`, l10n.t(`Username`), undefined, { minlength: 1, maxlength: 10 })
-      .addInput(`readyTimeout`, l10n.t(`Connection Timeout (in milliseconds)`), l10n.t(`How long to wait for the SSH handshake to complete.`), { inputType: "number", min: 1, default: "20000" })
       .addHorizontalRule()
       .addParagraph(l10n.t(`Only provide either the password or a private key - not both.`))
       .addPassword(`password`, l10n.t(`Password`))
       .addCheckbox(`savePassword`, l10n.t(`Save Password`))
-      .addFile(`privateKeyPath`, l10n.t(`Private Key`), l10n.t(`OpenSSH, RFC4716, or PPK formats are supported.`));
+      .addFile(`privateKeyPath`, l10n.t(`Private Key`), l10n.t(`OpenSSH, RFC4716, or PPK formats are supported.`))
+      .addHorizontalRule()
+      .addInput(`readyTimeout`, l10n.t(`Connection Timeout (in milliseconds)`), l10n.t(`How long to wait for the SSH handshake to complete.`), { inputType: "number", min: 1, default: "20000" });
 
     const tempTab = new Section()
       .addInput(`tempLibrary`, `Temporary library`, `Temporary library. Cannot be QTEMP.`, { default: `ILEDITOR`, minlength: 1, maxlength: 10 })

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -27,7 +27,7 @@ export class Login {
     const connectionTab = new Section()
       .addInput(`name`, `Connection Name`, undefined, { minlength: 1 })
       .addInput(`host`, l10n.t(`Host or IP Address`), undefined, { minlength: 1 })
-      .addInput(`port`, l10n.t(`Port (SSH)`), ``, { default: `22`, minlength: 1, maxlength: 5, regexTest: `^\\d+$` })
+      .addInput(`port`, l10n.t(`Port (SSH)`), ``, { default: `22`, min: 1, max: 65535, inputType: "number" })
       .addInput(`username`, l10n.t(`Username`), undefined, { minlength: 1, maxlength: 10 })
       .addHorizontalRule()
       .addParagraph(l10n.t(`Only provide either the password or a private key - not both.`))

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -362,11 +362,12 @@ export class SettingsUI {
               .addInput(`host`, vscode.l10n.t(`Host or IP Address`), undefined, { default: stored.host, minlength: 1 })
               .addInput(`port`, vscode.l10n.t(`Port (SSH)`), undefined, { default: String(stored.port), minlength: 1, maxlength: 5, regexTest: `^\\d+$` })
               .addInput(`username`, vscode.l10n.t(`Username`), undefined, { default: stored.username, minlength: 1 })
-              .addInput(`readyTimeout`, vscode.l10n.t(`Connection Timeout (in milliseconds)`), vscode.l10n.t(`How long to wait for the SSH handshake to complete.`), { inputType: "number", min: 1, default: stored.readyTimeout ? String(stored.readyTimeout) : "20000" })
               .addHorizontalRule()
               .addParagraph(vscode.l10n.t(`Only provide either the password or a private key - not both.`))
               .addPassword(`password`, `${vscode.l10n.t(`Password`)}${storedPassword ? ` (${vscode.l10n.t(`stored`)})` : ``}`, vscode.l10n.t("Only provide a password if you want to update an existing one or set a new one."))
               .addFile(`privateKeyPath`, `${vscode.l10n.t(`Private Key`)}${privateKeyPath ? ` (${vscode.l10n.t(`Private Key`)}: ${privateKeyPath})` : ``}`, privateKeyWarning + vscode.l10n.t("Only provide a private key if you want to update from the existing one or set one.") + '<br />' + vscode.l10n.t("OpenSSH, RFC4716 and PPK formats are supported."))
+              .addHorizontalRule()
+              .addInput(`readyTimeout`, vscode.l10n.t(`Connection Timeout (in milliseconds)`), vscode.l10n.t(`How long to wait for the SSH handshake to complete.`), { inputType: "number", min: 1, default: stored.readyTimeout ? String(stored.readyTimeout) : "20000" })              
               .addButtons(
                 { id: `submitButton`, label: vscode.l10n.t(`Save`), requiresValidation: true },
                 { id: `removeAuth`, label: vscode.l10n.t(`Remove auth methods`) }

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -360,7 +360,7 @@ export class SettingsUI {
             const privateKeyWarning = !privateKeyPath || existsSync(privateKeyPath) ? "" : "<b>⚠️ This private key doesn't exist on this system! ⚠️</b></br></br>";
             const ui = new CustomUI()
               .addInput(`host`, vscode.l10n.t(`Host or IP Address`), undefined, { default: stored.host, minlength: 1 })
-              .addInput(`port`, vscode.l10n.t(`Port (SSH)`), undefined, { default: String(stored.port), minlength: 1, maxlength: 5, regexTest: `^\\d+$` })
+              .addInput(`port`, vscode.l10n.t(`Port (SSH)`), undefined, { default: String(stored.port), min: 1, max: 65535, inputType: "number" })
               .addInput(`username`, vscode.l10n.t(`Username`), undefined, { default: stored.username, minlength: 1 })
               .addHorizontalRule()
               .addParagraph(vscode.l10n.t(`Only provide either the password or a private key - not both.`))

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -362,6 +362,8 @@ export class SettingsUI {
               .addInput(`host`, vscode.l10n.t(`Host or IP Address`), undefined, { default: stored.host, minlength: 1 })
               .addInput(`port`, vscode.l10n.t(`Port (SSH)`), undefined, { default: String(stored.port), minlength: 1, maxlength: 5, regexTest: `^\\d+$` })
               .addInput(`username`, vscode.l10n.t(`Username`), undefined, { default: stored.username, minlength: 1 })
+              .addInput(`readyTimeout`, vscode.l10n.t(`Connection Timeout (in milliseconds)`), vscode.l10n.t(`How long to wait for the SSH handshake to complete.`), { inputType: "number", min: 1, default: stored.readyTimeout ? String(stored.readyTimeout) : "20000" })
+              .addHorizontalRule()
               .addParagraph(vscode.l10n.t(`Only provide either the password or a private key - not both.`))
               .addPassword(`password`, `${vscode.l10n.t(`Password`)}${storedPassword ? ` (${vscode.l10n.t(`stored`)})` : ``}`, vscode.l10n.t("Only provide a password if you want to update an existing one or set a new one."))
               .addFile(`privateKeyPath`, `${vscode.l10n.t(`Private Key`)}${privateKeyPath ? ` (${vscode.l10n.t(`Private Key`)}: ${privateKeyPath})` : ``}`, privateKeyWarning + vscode.l10n.t("Only provide a private key if you want to update from the existing one or set one.") + '<br />' + vscode.l10n.t("OpenSSH, RFC4716 and PPK formats are supported."))
@@ -410,6 +412,7 @@ export class SettingsUI {
 
                 //Fix values before assigning the data
                 data.port = Number(data.port);
+                data.readyTimeout = Number(data.readyTimeout);
                 delete data.password;
                 delete data.buttons;
 


### PR DESCRIPTION
### Changes
Resolves #2442 and #2440.

This PR adds a new `readyTimeout` field to the connection settings (i.e. to the `ConnectionData` type). This field is described [here](https://github.com/mscdex/ssh2#client-methods).

A new `number` input has been added to the Connection/Login Settings to manage this field:
![image](https://github.com/user-attachments/assets/e2340c26-a798-46d3-80bb-0e4fb6d17879)

The `CustomUI` class has been enhanced to support the `number` input type as well as its `min` and `max` attributes.
The SSH port field has been turned into a `number` input.

### How to test this PR
1. Create a new connection with wrong credentials
2. Change the `Connection Timeout` field to 1000 (i.e. 1 second)
3. Try to connect: the connection attempt must fail after 1 second
4. Change the `Connection Timeout` field to 5000
5. Try to connect: the connection attempt must fail after 5 seconds

### Checklist
* [x] have tested my change