### PR TITLE
Enhance runCommand with error handling and event callbacks

### DIFF
--- a/src/api/tests/suites/connection.test.ts
+++ b/src/api/tests/suites/connection.test.ts
@@ -4,6 +4,7 @@ import { Tools } from '../../Tools';
 import { CONNECTION_TIMEOUT, disposeConnection, newConnection } from '../connection';
 import IBMi from '../../IBMi';
 import { getJavaHome } from '../../configuration/DebugConfiguration';
+import { CompileTools } from '../../CompileTools';
 
 describe(`connection tests`, {concurrent: true}, () => {
   let connection: IBMi
@@ -216,6 +217,25 @@ describe(`connection tests`, {concurrent: true}, () => {
 
     // Test that QSYSINC is before QSYS2
     expect(qtempIndex < qsysincIndex).toBeTruthy();
+  });
+
+  it('runCommand (ILE, variable expansion)', async () => {    const config = connection.getConfig();
+
+    const result = await CompileTools.runCommand(connection, 
+      {
+        command: `CRTDTAARA DTAARA(&SCOOBY/TEST) TYPE(*CHAR) LEN(10)`,
+        environment: `ile`,
+        env: {'&SCOOBY': `QTEMP`},
+      },
+      {
+        commandConfirm: async (command) => {
+          expect(command).toBe(`CRTDTAARA DTAARA(QTEMP/TEST) TYPE(*CHAR) LEN(10)`);
+          return command;
+        }
+      }
+    );
+
+    expect(result?.code).toBe(0);
   });
 
   it('withTempDirectory and countFiles', async () => {    const content = connection.getContent()!;


### PR DESCRIPTION
Patrick B raised an issue with me directly about this issue. 

>When I use the default commands I get the variable names in the prompt, but the command runs with the proper values.
>
> I have a couple of custom actions that aren't working properly...the variable names appear in the form, and are also used in the command:

This new change fixes the issue where the variables were appearing in both confirmation UIs before they were expanded.

Include unit tests for variable expansion in ILE commands.