### PR TITLE
Fix/breadcrumb browse

### DIFF
--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -1,9 +1,9 @@
 import { parse as parsePath } from "path";
 import { parse, ParsedUrlQueryInput, stringify } from "querystring";
 import vscode, { FilePermission, FileSystemError } from "vscode";
-import { onCodeForIBMiConfigurationChange } from "../../config/Configuration";
 import IBMi from "../../api/IBMi";
 import { Tools } from "../../api/Tools";
+import { onCodeForIBMiConfigurationChange } from "../../config/Configuration";
 import { instance } from "../../instantiate";
 import { IBMiMember, QsysFsOptions, QsysPath } from "../../typings";
 import { ExtendedIBMiContent } from "./extendedContent";
@@ -101,8 +101,8 @@ export class QSysFS implements vscode.FileSystemProvider {
         }
         const type = pathLength > 3 ? vscode.FileType.File : vscode.FileType.Directory;
         const connection = instance.getConnection();
-        if (path !== '/' && connection) {
-            const member = type === vscode.FileType.File ? parsePath(path).name : undefined;
+        if (connection && type === vscode.FileType.File) {
+            const member = parsePath(path).name;
             const qsysPath = { ...Tools.parseQSysPath(path), member };
             const attributes = await this.getMemberAttributes(connection, qsysPath);
             if (attributes) {
@@ -129,7 +129,7 @@ export class QSysFS implements vscode.FileSystemProvider {
     }
 
     async getMemberAttributes(connection: IBMi, path: QsysPath & { member?: string }) {
-        const loadAttributes = async () => await connection.content.getAttributes(path, "CREATE_TIME", "MODIFY_TIME", "DATA_SIZE");
+        const loadAttributes = async () => await connection.getContent().getAttributes(path, "CREATE_TIME", "MODIFY_TIME", "DATA_SIZE");
 
         path.asp = path.asp || this.getLibraryASP(connection, path.library);
         let attributes = await loadAttributes();


### PR DESCRIPTION
### Changes
This fixes the breadcrumbs navigation for members.

![image](https://github.com/user-attachments/assets/040cbdad-46e3-47a2-b830-63c22aa4f421)

The call to `getMemberAttributes` made by `stat` would fail for physical files, preventing the navigation from working (clicking on it would do nothing).

This PR fixes this by preventing stat from getting attributes except for members.
It also fixes the library listing in the breadcrumb (clicking on the library would only show QSYS and then it would fail to list anything relevant). QSYS FS now uses a dedicated call to `OBJECT_STATISTICS`, using `*ALLSIMPLE` since all we need is a list of names.

### How to test this PR
1. Open a member
2. Click on a path element in the breadcrumb and try to
* [ ] List libraries
* [ ] List files
* [ ] List members 

### Checklist
* [x] have tested my change