### PR TITLE
Return default CCSID when no result is found in runSQL query

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -1015,6 +1015,11 @@ export default class IBMiContent {
     `;
 
     const [result] = await this.ibmi.runSQL(sql);
+    
+    if (!result) {
+      return this.ibmi.getCcsids().qccsid;
+    }
+
     return Number(result.CCSID === IBMi.CCSID_NOCONVERSION ? result.DEFAULT_CCSID : result.CCSID);
   }
 


### PR DESCRIPTION
Ensure the function returns the default CCSID when the runSQL query yields no results.

I have found a system (`common1.iinthecloud.com`) which returns no rows when trying to get the CCSID of the SSHD job. If that is the case, then we just return the system QCCSID.