### PR TITLE
Refactor component management and add state caching

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -247,8 +247,6 @@ export default class IBMi {
 
       this.appendOutput(`Code for IBM i, version ${currentExtensionVersion}\n\n`);
 
-      let tempLibrarySet = false;
-
       callbacks.progress({
         message: `Loading configuration.`
       });
@@ -428,10 +426,17 @@ export default class IBMi {
           message: `Checking installed components on host IBM i: Java`
         });
         const javaCheck = async (root: string) => await this.content.testStreamFile(`${root}/bin/java`, 'x') ? root : undefined;
-        this.remoteFeatures.jdk80 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit`);
-        this.remoteFeatures.jdk11 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk11/64bit`);
-        this.remoteFeatures.openjdk11 = await javaCheck(`/QOpensys/pkgs/lib/jvm/openjdk-11`);
-        this.remoteFeatures.jdk17 = await javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk17/64bit`);
+        [
+          this.remoteFeatures.jdk80,
+          this.remoteFeatures.jdk11,
+          this.remoteFeatures.openjdk11,
+          this.remoteFeatures.jdk17
+        ] = await Promise.all([
+          javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk80/64bit`),
+          javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk11/64bit`),
+          javaCheck(`/QOpensys/pkgs/lib/jvm/openjdk-11`),
+          javaCheck(`/QOpenSys/QIBM/ProdData/JavaVM/jdk17/64bit`)
+        ]);
       }
 
       if (this.remoteFeatures.uname) {
@@ -506,64 +511,14 @@ export default class IBMi {
       }
 
       callbacks.progress({
-        message: `Checking temporary library configuration.`
+        message: `Checking temporary directory and temporary library configuration.`
       });
 
-      //Next, we need to check the temp lib (where temp outfile data lives) exists
-      const createdTempLib = await this.runCommand({
-        command: `CRTLIB LIB(${this.config.tempLibrary}) TEXT('Code for i temporary objects. May be cleared.')`,
-        noLibList: true
-      });
 
-      if (createdTempLib.code === 0) {
-        tempLibrarySet = true;
-      } else {
-        const messages = Tools.parseMessages(createdTempLib.stderr);
-        if (messages.findId(`CPF2158`) || messages.findId(`CPF2111`)) { //Already exists, hopefully ok :)
-          tempLibrarySet = true;
-        }
-        else if (messages.findId(`CPD0032`)) { //Can't use CRTLIB
-          const tempLibExists = await this.runCommand({
-            command: `CHKOBJ OBJ(QSYS/${this.config.tempLibrary}) OBJTYPE(*LIB)`,
-            noLibList: true
-          });
-
-          if (tempLibExists.code === 0) {
-            //We're all good if no errors
-            tempLibrarySet = true;
-          } else if (currentLibrary && !currentLibrary.startsWith(`Q`)) {
-            //Using ${currentLibrary} as the temporary library for temporary data.
-            this.config.tempLibrary = currentLibrary;
-            tempLibrarySet = true;
-          }
-        }
-      }
-
-      callbacks.progress({
-        message: `Checking temporary directory configuration.`
-      });
-
-      let tempDirSet = false;
-      // Next, we need to check if the temp directory exists
-      let result = await this.sendCommand({
-        command: `[ -d "${this.config.tempDir}" ]`
-      });
-
-      if (result.code === 0) {
-        // Directory exists
-        tempDirSet = true;
-      } else {
-        // Directory does not exist, try to create it
-        let result = await this.sendCommand({
-          command: `mkdir -p ${this.config.tempDir}`
-        });
-        if (result.code === 0) {
-          // Directory created
-          tempDirSet = true;
-        } else {
-          // Directory not created
-        }
-      }
+      const [tempLibrarySet, tempDirSet] = await Promise.all([
+        this.ensureTempLibraryExists(currentLibrary),
+        this.ensureTempDirectory()
+      ]);
 
       if (!tempDirSet) {
         this.config.tempDir = `/tmp`;
@@ -618,19 +573,20 @@ export default class IBMi {
           message: `Checking for bad data areas.`
         });
 
-        const QCPTOIMPF = await this.runCommand({
-          command: `CHKOBJ OBJ(QSYS/QCPTOIMPF) OBJTYPE(*DTAARA)`,
-          noLibList: true
-        });
+        const [QCPTOIMPF, QCPFRMIMPF] = await Promise.all([
+          this.runCommand({
+            command: `CHKOBJ OBJ(QSYS/QCPTOIMPF) OBJTYPE(*DTAARA)`,
+            noLibList: true
+          }),
+          this.runCommand({
+            command: `CHKOBJ OBJ(QSYS/QCPFRMIMPF) OBJTYPE(*DTAARA)`,
+            noLibList: true
+          })
+        ]);
 
         if (QCPTOIMPF?.code === 0) {
           callbacks.uiErrorHandler(this, `QCPTOIMPF_exists`);
         }
-
-        const QCPFRMIMPF = await this.runCommand({
-          command: `CHKOBJ OBJ(QSYS/QCPFRMIMPF) OBJTYPE(*DTAARA)`,
-          noLibList: true
-        });
 
         if (QCPFRMIMPF?.code === 0) {
           callbacks.uiErrorHandler(this, `QCPFRMIMPF_exists`);
@@ -973,6 +929,74 @@ export default class IBMi {
     finally {
       IBMi.connectionManager.update(this.config!);
     }
+  }
+
+  private async ensureTempLibraryExists(fallbackTempLib: string) {
+    let tempLibrarySet: boolean = false;
+
+    if (!this.config) {
+      return false;
+    }
+
+    const createdTempLib = await this.runCommand({
+      command: `CRTLIB LIB(${this.config.tempLibrary}) TEXT('Code for i temporary objects. May be cleared.')`,
+      noLibList: true
+    });
+
+    if (createdTempLib.code === 0) {
+      tempLibrarySet = true;
+    } else {
+      const messages = Tools.parseMessages(createdTempLib.stderr);
+      if (messages.findId(`CPF2158`) || messages.findId(`CPF2111`)) { //Already exists, hopefully ok :)
+        tempLibrarySet = true;
+      }
+      else if (messages.findId(`CPD0032`)) { //Can't use CRTLIB
+        const tempLibExists = await this.runCommand({
+          command: `CHKOBJ OBJ(QSYS/${this.config.tempLibrary}) OBJTYPE(*LIB)`,
+          noLibList: true
+        });
+
+        if (tempLibExists.code === 0) {
+          //We're all good if no errors
+          tempLibrarySet = true;
+        } else if (fallbackTempLib && !fallbackTempLib.startsWith(`Q`)) {
+          //Using ${currentLibrary} as the temporary library for temporary data.
+          this.config.tempLibrary = fallbackTempLib;
+          tempLibrarySet = true;
+        }
+      }
+    }
+
+    return tempLibrarySet;
+  }
+
+  private async ensureTempDirectory() {
+    let tempDirSet: boolean = false;
+
+    if (!this.config) {
+      return false;
+    }
+
+    let result = await this.sendCommand({
+      command: `[ -d "${this.config.tempDir}" ]`
+    });
+
+    if (result.code === 0) {
+      // Directory exists
+      tempDirSet = true;
+    } else {
+      // Directory does not exist, try to create it
+      let result = await this.sendCommand({
+        command: `mkdir -p ${this.config.tempDir}`
+      });
+      if (result.code === 0) {
+        // Directory created
+        tempDirSet = true;
+      } else {
+        // Directory not created
+      }
+    }
+    return tempDirSet;
   }
 
   /**

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -458,9 +458,10 @@ export default class IBMi {
       }
 
       callbacks.progress({ message: `Checking Code for IBM i components.` });
-      await this.componentManager.startup();
 
-      const componentStates = await this.componentManager.getState();
+      this.componentManager.startup(cachedServerSettings?.installedComponents);
+
+      const componentStates = await this.componentManager.getInstallState();
       this.appendOutput(`\nCode for IBM i components:\n`);
       for (const state of componentStates) {
         this.appendOutput(`\t${state.id.name} (${state.id.version}): ${state.state}\n`);
@@ -895,6 +896,7 @@ export default class IBMi {
         qccsid: this.qccsid,
         jobCcsid: this.userJobCcsid,
         remoteFeatures: this.remoteFeatures,
+        installedComponents: this.componentManager.getInstallState(),
         remoteFeaturesKeys: Object.keys(this.remoteFeatures).sort().toString(),
         badDataAreasChecked: true,
         libraryListValidated: true,
@@ -1284,7 +1286,7 @@ export default class IBMi {
   }
 
   getComponentStates() {
-    return this.componentManager.getState();
+    return this.componentManager.getInstallState();
   }
 
   /**

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -459,7 +459,7 @@ export default class IBMi {
 
       callbacks.progress({ message: `Checking Code for IBM i components.` });
 
-      this.componentManager.startup(cachedServerSettings?.installedComponents);
+      this.componentManager.startup(quickConnect() ? cachedServerSettings?.installedComponents : []);
 
       const componentStates = await this.componentManager.getInstallState();
       this.appendOutput(`\nCode for IBM i components:\n`);

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -896,7 +896,7 @@ export default class IBMi {
         qccsid: this.qccsid,
         jobCcsid: this.userJobCcsid,
         remoteFeatures: this.remoteFeatures,
-        installedComponents: this.componentManager.getInstallState(),
+        installedComponents: componentStates,
         remoteFeaturesKeys: Object.keys(this.remoteFeatures).sort().toString(),
         badDataAreasChecked: true,
         libraryListValidated: true,

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -459,7 +459,7 @@ export default class IBMi {
 
       callbacks.progress({ message: `Checking Code for IBM i components.` });
 
-      this.componentManager.startup(quickConnect() ? cachedServerSettings?.installedComponents : []);
+      await this.componentManager.startup(quickConnect() ? cachedServerSettings?.installedComponents : []);
 
       const componentStates = await this.componentManager.getInstallState();
       this.appendOutput(`\nCode for IBM i components:\n`);

--- a/src/api/components/component.ts
+++ b/src/api/components/component.ts
@@ -7,6 +7,11 @@ export type ComponentIdentification = {
   version: number
 }
 
+export type ComponentInstallState = {
+  id: ComponentIdentification
+  state: ComponentState
+}
+
 /**
  * Defines a component that is managed per IBM i.
  * 
@@ -37,6 +42,8 @@ export type IBMiComponent = {
    * @returns a human-readable name
    */
   getIdentification(): ComponentIdentification;
+
+  setInstallDirectory?(installDirectory: string): Promise<void>;
 
   /**
    * @returns the component's {@link ComponentState state} on the IBM i

--- a/src/api/components/cqsh/index.ts
+++ b/src/api/components/cqsh/index.ts
@@ -23,6 +23,10 @@ export class CustomQSh implements IBMiComponent {
     return `${id.name}_${id.version}`;
   }
 
+  async setInstallDirectory(installDirectory: string): Promise<void> {
+    this.installPath = path.posix.join(installDirectory, this.getFileName());
+  }
+
   async getRemoteState(connection: IBMi, installDirectory: string): Promise<ComponentState> {
     this.installPath = path.posix.join(installDirectory, this.getFileName());
     const result = await connection.content.testStreamFile(this.installPath, "x");

--- a/src/api/components/getMemberInfo.ts
+++ b/src/api/components/getMemberInfo.ts
@@ -15,7 +15,7 @@ export class GetMemberInfo implements IBMiComponent {
   }
 
   getIdentification() {
-    return { name: GetMemberInfo.ID, version: this.installedVersion };
+    return { name: GetMemberInfo.ID, version: this.currentVersion };
   }
 
   async getRemoteState(connection: IBMi): Promise<ComponentState> {
@@ -47,6 +47,7 @@ export class GetMemberInfo implements IBMiComponent {
       if (result.code) {
         return `Error`;
       } else {
+        this.installedVersion = this.currentVersion;
         return `Installed`;
       }
     });

--- a/src/api/components/getNewLibl.ts
+++ b/src/api/components/getNewLibl.ts
@@ -13,7 +13,7 @@ export class GetNewLibl implements IBMiComponent {
   }
 
   getIdentification() {
-    return { name: GetNewLibl.ID, version: this.installedVersion };
+    return { name: GetNewLibl.ID, version: this.currentVersion };
   }
 
   async getRemoteState(connection: IBMi): Promise<ComponentState> {
@@ -45,6 +45,7 @@ export class GetNewLibl implements IBMiComponent {
       });
 
       if (!result.code) {
+        this.installedVersion = this.currentVersion;
         return `Installed`;
       } else {
         return `Error`;

--- a/src/api/components/manager.ts
+++ b/src/api/components/manager.ts
@@ -1,6 +1,6 @@
 
 import IBMi from "../IBMi";
-import { ComponentState, IBMiComponent } from "./component";
+import { ComponentIdentification, ComponentInstallState, ComponentState, IBMiComponent } from "./component";
 
 interface ExtensionContextI {
   extension: {
@@ -37,11 +37,13 @@ export const extensionComponentRegistry = new ComponentRegistry();
 export class ComponentManager {
   private readonly registered: Map<string, IBMiComponentRuntime> = new Map;
 
-  constructor(private readonly connection: IBMi) {
+  constructor(private readonly connection: IBMi) {}
 
+  public getComponentIds(): ComponentIdentification[] {
+    return Array.from(extensionComponentRegistry.getComponents().values()).flatMap(a => a.flat()).map(c => c.getIdentification());
   }
 
-  public getState() {
+  public getInstallState(): ComponentInstallState[] {
     return Array.from(this.registered.keys()).map(k => {
       const comp = this.registered.get(k)!;
       return {
@@ -51,11 +53,38 @@ export class ComponentManager {
     });
   }
 
-  public async startup() {
+  public shouldUpdate(lastInstalled: ComponentInstallState[] = []) {
+    return this.getComponentIds().some(c => {
+      const installed = lastInstalled.find(i => i.id.name === c.name);
+      if (!installed) {
+        return true;
+      };
+
+      const sameVersion = (installed.id.version === c.version);
+      if (!sameVersion) {
+        return true;
+      }
+
+      return false;
+    });
+  }
+
+  public async startup(lastInstalled: ComponentInstallState[] = []) {
     const components = Array.from(extensionComponentRegistry.getComponents().values()).flatMap(a => a.flat());
     for (const component of components) {
       await component.reset?.();
-      this.registered.set(component.getIdentification().name, await new IBMiComponentRuntime(this.connection, component).check());
+      const newComponent = new IBMiComponentRuntime(this.connection, component);
+
+      const installed = lastInstalled.find(i => i.id.name === component.getIdentification().name);
+      const sameVersion = installed && (installed.id.version === component.getIdentification().version);
+
+      if (!installed || !sameVersion) {
+        await newComponent.check();
+      } else {
+        newComponent.overrideState(installed.state);
+      }
+
+      this.registered.set(component.getIdentification().name, newComponent);
     }
   }
 
@@ -90,6 +119,12 @@ class IBMiComponentRuntime {
 
   getState() {
     return this.state;
+  }
+
+  async overrideState(newState: ComponentState) {
+    const installDir = await this.getInstallDirectory();
+    await this.component.setInstallDirectory?.(installDir);
+    this.state = newState;
   }
 
   async check() {

--- a/src/api/components/manager.ts
+++ b/src/api/components/manager.ts
@@ -53,22 +53,6 @@ export class ComponentManager {
     });
   }
 
-  public shouldUpdate(lastInstalled: ComponentInstallState[] = []) {
-    return this.getComponentIds().some(c => {
-      const installed = lastInstalled.find(i => i.id.name === c.name);
-      if (!installed) {
-        return true;
-      };
-
-      const sameVersion = (installed.id.version === c.version);
-      if (!sameVersion) {
-        return true;
-      }
-
-      return false;
-    });
-  }
-
   public async startup(lastInstalled: ComponentInstallState[] = []) {
     const components = Array.from(extensionComponentRegistry.getComponents().values()).flatMap(a => a.flat());
     for (const component of components) {

--- a/src/api/configuration/storage/CodeForIStorage.ts
+++ b/src/api/configuration/storage/CodeForIStorage.ts
@@ -1,3 +1,4 @@
+import { ComponentInstallState } from "../../components/component";
 import { ConnectionData } from "../../types";
 import { BaseStorage } from "./BaseStorage";
 const SERVER_SETTINGS_CACHE_PREFIX = `serverSettingsCache_`;
@@ -20,6 +21,7 @@ export type CachedServerSettings = {
   qccsid: number | null;
   jobCcsid: number | null
   remoteFeatures: { [name: string]: string | undefined }
+  installedComponents: ComponentInstallState[],
   remoteFeaturesKeys: string | null
   badDataAreasChecked: boolean | null
   libraryListValidated: boolean | null


### PR DESCRIPTION
Improve code readability and maintainability by refactoring library and directory checks into separate methods. Introduce caching for component states to enhance connection performance.

Adds the component stats to the settings cache and validation each one individually. This will allow us to update one component without updating them all again.

Before:

![slow](https://github.com/user-attachments/assets/c9a247d7-3c38-4eb0-b8ba-7726408c7be8)

After:

![fast](https://github.com/user-attachments/assets/7c57322f-7384-4d09-8cbf-47e685d778bc)
