### PR TITLE
Log regarding *EVENTF being missing from command string. #2500

### DIFF
--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -34,525 +34,524 @@ export async function runAction(instance: Instance, uri: vscode.Uri, customActio
   const connection = instance.getConnection();
 
   const uriOptions = parseFSOptions(uri);
-  if (connection) {
-    const config = connection.getConfig();
-    const content = connection.getContent();
+  if (!connection) {
+    throw new Error("Please connect to an IBM i first")
+  }
+  const config = connection.getConfig();
+  const content = connection.getContent();
 
-    const extension = uri.path.substring(uri.path.lastIndexOf(`.`) + 1).toUpperCase();
-    const fragment = uri.fragment.toUpperCase();
+  const extension = uri.path.substring(uri.path.lastIndexOf(`.`) + 1).toUpperCase();
+  const fragment = uri.fragment.toUpperCase();
 
-    const isProtected = uriOptions.readonly || config?.readOnlyMode;
+  const isProtected = uriOptions.readonly || config?.readOnlyMode;
 
-    if (!workspaceFolder) {
-      workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+  if (!workspaceFolder) {
+    workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+  }
+  let remoteCwd = config?.homeDirectory || `.`;
+
+  let availableActions: { label: string; action: Action; }[] = [];
+  if (!customAction) {
+    // First we grab a copy the predefined Actions in the VS Code settings
+    const allActions = [...IBMi.connectionManager.get<Action[]>(`actions`) || []];
+
+    // Then, if we're being called from a local file
+    // we fetch the Actions defined from the workspace.
+    if (workspaceFolder && uri.scheme === `file`) {
+      const localActions = await getLocalActions(workspaceFolder);
+      allActions.push(...localActions);
     }
-    let remoteCwd = config?.homeDirectory || `.`;
 
-    let availableActions: { label: string; action: Action; }[] = [];
-    if (!customAction) {
-      // First we grab a copy the predefined Actions in the VS Code settings
-      const allActions = [...IBMi.connectionManager.get<Action[]>(`actions`) || []];
+    // We make sure all extensions are uppercase
+    allActions.forEach(action => {
+      if (action.extensions) {
+        action.extensions = action.extensions.map(ext => ext.toUpperCase());
+      };
+    });
 
-      // Then, if we're being called from a local file
-      // we fetch the Actions defined from the workspace.
-      if (workspaceFolder && uri.scheme === `file`) {
-        const localActions = await getLocalActions(workspaceFolder);
-        allActions.push(...localActions);
+    // Then we get all the available Actions for the current context
+    availableActions = allActions.filter(action => action.type === uri.scheme && (!action.extensions || action.extensions.includes(extension) || action.extensions.includes(fragment) || action.extensions.includes(`GLOBAL`)) && (!isProtected || action.runOnProtected))
+      .sort((a, b) => (actionUsed.get(b.name) || 0) - (actionUsed.get(a.name) || 0))
+      .map(action => ({
+        label: action.name,
+        action
+      }));
+  }
+
+  //when a member is protected (read only)
+  if (isProtected) {
+    vscode.window.showErrorMessage(`Action cannot be applied on a read only member.`);
+    return false;
+  }
+
+  //No compile commands
+  if (!(customAction || availableActions.length)) {
+    vscode.window.showErrorMessage(`No compile commands found for ${uri.scheme}-${extension}.`);
+    return false;
+  }
+
+  const chosenAction = customAction || ((availableActions.length === 1) ? availableActions[0] : await vscode.window.showQuickPick(availableActions))?.action;
+  if (!chosenAction) {
+    return false;
+  }
+
+  actionUsed.set(chosenAction.name, Date.now());
+  const environment = chosenAction.environment || `ile`;
+
+  let workspaceId: number | undefined = undefined;
+
+  // If we are running an Action for a local file, we need a deploy directory even if they are not
+  // deploying the file. This is because we need to know the relative path of the file to the deploy directory.
+  if (workspaceFolder && chosenAction.type === `file`) {
+    if (chosenAction.deployFirst) {
+      const deployResult = await DeployTools.launchDeploy(workspaceFolder.index, method);
+      if (deployResult !== undefined) {
+        workspaceId = deployResult.workspaceId;
+        remoteCwd = deployResult.remoteDirectory;
+      } else {
+        vscode.window.showWarningMessage(`Action "${chosenAction.name}" was cancelled.`);
+        return false;
+      }
+    } else {
+      workspaceId = workspaceFolder.index;
+      const deployPath = DeployTools.getRemoteDeployDirectory(workspaceFolder);
+      if (deployPath) {
+        remoteCwd = deployPath;
+      } else {
+        vscode.window.showWarningMessage(`No deploy directory setup for this workspace. Cancelling Action.`);
+        return false;
+      }
+    }
+  }
+
+  let fromWorkspace: WorkspaceFolder | undefined;
+
+  if (chosenAction.type === `file` && vscode.workspace.workspaceFolders) {
+    fromWorkspace = vscode.workspace.workspaceFolders[workspaceId || 0];
+  }
+
+  const variables: Variable = {};
+  const evfeventInfo: EvfEventInfo = {
+    object: '',
+    library: '',
+    extension,
+    workspace: fromWorkspace
+  };
+
+  if (workspaceFolder) {
+    const envFileVars = await getEnvConfig(workspaceFolder);
+    Object.entries(envFileVars).forEach(([key, value]) => variables[`&${key}`] = value);
+  }
+
+  switch (chosenAction.type) {
+    case `member`:
+      const memberDetail = connection.parserMemberPath(uri.path);
+      evfeventInfo.library = memberDetail.library;
+      evfeventInfo.object = memberDetail.name;
+      evfeventInfo.extension = memberDetail.extension;
+      evfeventInfo.asp = memberDetail.asp;
+
+      variables[`&OPENLIBL`] = memberDetail.library.toLowerCase();
+      variables[`&OPENLIB`] = memberDetail.library;
+
+      variables[`&OPENSPFL`] = memberDetail.file.toLowerCase();
+      variables[`&OPENSPF`] = memberDetail.file;
+
+      variables[`&OPENMBRL`] = memberDetail.name.toLowerCase();
+      variables[`&OPENMBR`] = memberDetail.name;
+
+      variables[`&EXTL`] = memberDetail.extension.toLowerCase();
+      variables[`&EXT`] = memberDetail.extension;
+      break;
+
+    case `file`:
+    case `streamfile`:
+      const pathData = path.parse(uri.path);
+      const basename = pathData.base;
+      const ext = pathData.ext ? (pathData.ext.startsWith(`.`) ? pathData.ext.substring(1) : pathData.ext) : ``;
+      const parent = path.parse(pathData.dir).base;
+      let name = pathData.name;
+
+      // Logic to handle second extension, caused by bob.
+      const bobTypes = [`.PGM`, `.SRVPGM`];
+      const secondName = path.parse(name);
+      if (secondName.ext && bobTypes.includes(secondName.ext.toUpperCase())) {
+        name = secondName.name;
       }
 
-      // We make sure all extensions are uppercase
-      allActions.forEach(action => {
-        if (action.extensions) {
-          action.extensions = action.extensions.map(ext => ext.toUpperCase());
-        };
-      });
+      // Remove bob text convention
+      if (name.includes(`-`)) {
+        name = name.substring(0, name.indexOf(`-`));
+      }
 
-      // Then we get all the available Actions for the current context
-      availableActions = allActions.filter(action => action.type === uri.scheme && (!action.extensions || action.extensions.includes(extension) || action.extensions.includes(fragment) || action.extensions.includes(`GLOBAL`)) && (!isProtected || action.runOnProtected))
-        .sort((a, b) => (actionUsed.get(b.name) || 0) - (actionUsed.get(a.name) || 0))
-        .map(action => ({
-          label: action.name,
-          action
-        }));
+      if (variables[`&CURLIB`]) {
+        evfeventInfo.library = variables[`&CURLIB`];
+
+      } else {
+        evfeventInfo.library = config.currentLibrary;
+      }
+
+      evfeventInfo.library = evfeventInfo.library.toUpperCase();
+      evfeventInfo.object = name.toUpperCase();
+      evfeventInfo.extension = ext;
+
+      if (chosenAction.command.includes(`&SRCFILE`)) {
+        variables[`&SRCLIB`] = evfeventInfo.library;
+        variables[`&SRCPF`] = `QTMPSRC`;
+        variables[`&SRCFILE`] = `${evfeventInfo.library}/QTMPSRC`;
+      }
+
+      switch (chosenAction.type) {
+        case `file`:
+          variables[`&LOCALPATH`] = uri.fsPath;
+          if (fromWorkspace) {
+            const relativePath = path.relative(fromWorkspace.uri.path, uri.path).split(path.sep).join(path.posix.sep);
+            variables[`&RELATIVEPATH`] = relativePath;
+
+            // We need to make sure the remote path is posix
+            const fullPath = path.posix.join(remoteCwd, relativePath);
+            variables[`&FULLPATH`] = fullPath;
+            variables[`{path}`] = fullPath;
+            variables[`&WORKDIR`] = remoteCwd;
+            variables[`&FILEDIR`] = path.posix.parse(fullPath).dir;
+
+            const branch = getGitBranch(fromWorkspace);
+            if (branch) {
+              variables[`&BRANCHLIB`] = getBranchLibraryName(branch);
+              variables[`&BRANCH`] = branch;
+              variables[`{branch}`] = branch;
+            }
+          }
+          break;
+
+        case `streamfile`:
+          const relativePath = path.posix.relative(remoteCwd, uri.path);
+          variables[`&RELATIVEPATH`] = relativePath;
+
+          const fullName = uri.path;
+          variables[`&FULLPATH`] = fullName;
+          variables[`&FILEDIR`] = path.parse(fullName).dir;
+          break;
+      }
+
+      variables[`&PARENT`] = parent;
+
+      variables[`&BASENAME`] = basename;
+      variables[`{filename}`] = basename;
+
+      variables[`&NAMEL`] = name.toLowerCase();
+      variables[`&NAME`] = name;
+
+      variables[`&EXTL`] = extension.toLowerCase();
+      variables[`&EXT`] = extension;
+      break;
+
+    case `object`:
+      const [_, library, fullName] = uri.path.toUpperCase().split(`/`);
+      const object = fullName.substring(0, fullName.lastIndexOf(`.`));
+
+      evfeventInfo.library = library;
+      evfeventInfo.object = object;
+
+      variables[`&LIBRARYL`] = library.toLowerCase();
+      variables[`&LIBRARY`] = library;
+
+      variables[`&NAMEL`] = object.toLowerCase();
+      variables[`&NAME`] = object;
+
+      variables[`&TYPEL`] = extension.toLowerCase();
+      variables[`&TYPE`] = extension;
+
+      variables[`&EXTL`] = extension.toLowerCase();
+      variables[`&EXT`] = extension;
+      break;
+  }
+
+  const viewControl = IBMi.connectionManager.get<string>(`postActionView`) || "none";
+  const outputBuffer: string[] = [];
+  let actionName = chosenAction.name;
+  let hasRun = false;
+
+  const commandConfirm = async (commandString: string): Promise<string> => {
+    const commands = commandString.split(`\n`).filter(command => command.trim().length > 0);
+    const promptedCommands = [];
+    for (let command of commands) {
+      if (command.startsWith(`?`)) {
+        command = await vscode.window.showInputBox({ prompt: `Run Command`, value: command.substring(1) }) || '';
+      } else {
+        command = await showCustomInputs(`Run Command`, command, chosenAction.name || `Command`);
+      }
+      promptedCommands.push(command);
+      if (!command) break;
     }
 
-    if (customAction || availableActions.length) {
-      const chosenAction = customAction || ((availableActions.length === 1) ? availableActions[0] : await vscode.window.showQuickPick(availableActions))?.action;
-      if (chosenAction) {
-        actionUsed.set(chosenAction.name, Date.now());
-        const environment = chosenAction.environment || `ile`;
+    return !promptedCommands.includes(``) ? promptedCommands.join(`\n`) : ``;
+  }
 
-        let workspaceId: number | undefined = undefined;
+  const exitCode = await new Promise<number>(resolve =>
+    tasks.executeTask({
+      isBackground: true,
+      name: chosenAction.name,
+      definition: { type: `ibmi` },
+      scope: workspaceFolder,
+      source: 'IBM i',
+      presentationOptions: {
+        showReuseMessage: true,
+        clear: IBMi.connectionManager.get<boolean>(`clearOutputEveryTime`),
+        focus: false,
+        reveal: (viewControl === `task` ? TaskRevealKind.Always : TaskRevealKind.Never),
+      },
+      problemMatchers: [],
+      runOptions: {},
+      group: TaskGroup.Build,
+      execution: new CustomExecution(async (e) => {
+        const writeEmitter = new vscode.EventEmitter<string>();
+        const closeEmitter = new vscode.EventEmitter<number>();
 
-        // If we are running an Action for a local file, we need a deploy directory even if they are not
-        // deploying the file. This is because we need to know the relative path of the file to the deploy directory.
-        if (workspaceFolder && chosenAction.type === `file`) {
-          if (chosenAction.deployFirst) {
-            const deployResult = await DeployTools.launchDeploy(workspaceFolder.index, method);
-            if (deployResult !== undefined) {
-              workspaceId = deployResult.workspaceId;
-              remoteCwd = deployResult.remoteDirectory;
-            } else {
-              vscode.window.showWarningMessage(`Action "${chosenAction.name}" was cancelled.`);
-              return false;
-            }
-          } else {
-            workspaceId = workspaceFolder.index;
-            const deployPath = DeployTools.getRemoteDeployDirectory(workspaceFolder);
-            if (deployPath) {
-              remoteCwd = deployPath;
-            } else {
-              vscode.window.showWarningMessage(`No deploy directory setup for this workspace. Cancelling Action.`);
-              return false;
-            }
-          }
-        }
+        writeEmitter.event(s => outputBuffer.push(s));
+        closeEmitter.event(resolve);
 
-        let fromWorkspace: WorkspaceFolder | undefined;
+        const term: Pseudoterminal = {
+          onDidWrite: writeEmitter.event,
+          onDidClose: closeEmitter.event,
+          open: async (initialDimensions: vscode.TerminalDimensions | undefined) => {
+            let successful = false;
+            let problemsFetched = false;
 
-        if (chosenAction.type === `file` && vscode.workspace.workspaceFolders) {
-          fromWorkspace = vscode.workspace.workspaceFolders[workspaceId || 0];
-        }
+            try {
+              writeEmitter.fire(`Running Action: ${chosenAction.name} (${new Date().toLocaleTimeString()})` + CompileTools.NEWLINE);
 
-        const variables: Variable = {};
-        const evfeventInfo: EvfEventInfo = {
-          object: '',
-          library: '',
-          extension,
-          workspace: fromWorkspace
-        };
+              // If &SRCFILE is set, we need to copy the file to a temporary source file from the IFS
+              if (variables[`&FULLPATH`] && variables[`&SRCFILE`] && evfeventInfo.object) {
+                const [lib, srcpf] = variables[`&SRCFILE`].split(`/`);
 
-        if (workspaceFolder) {
-          const envFileVars = await getEnvConfig(workspaceFolder);
-          Object.entries(envFileVars).forEach(([key, value]) => variables[`&${key}`] = value);
-        }
+                const createSourceFile = content.toCl(`CRTSRCPF`, {
+                  rcdlen: 112, //NICE: this configurable in a VS Code setting?
+                  file: `${lib}/${srcpf}`,
+                });
 
-        switch (chosenAction.type) {
-          case `member`:
-            const memberDetail = connection.parserMemberPath(uri.path);
-            evfeventInfo.library = memberDetail.library;
-            evfeventInfo.object = memberDetail.name;
-            evfeventInfo.extension = memberDetail.extension;
-            evfeventInfo.asp = memberDetail.asp;
+                const copyFromStreamfile = content.toCl(`CPYFRMSTMF`, {
+                  fromstmf: variables[`&FULLPATH`],
+                  tombr: `'${Tools.qualifyPath(lib, srcpf, evfeventInfo.object)}'`,
+                  mbropt: `*REPLACE`,
+                  dbfccsid: `*FILE`,
+                  stmfccsid: 1208,
+                });
 
-            variables[`&OPENLIBL`] = memberDetail.library.toLowerCase();
-            variables[`&OPENLIB`] = memberDetail.library;
+                // We don't care if this fails. Usually it's because the source file already exists.
+                await CompileTools.runCommand(connection, { command: createSourceFile, environment: `ile`, noLibList: true });
 
-            variables[`&OPENSPFL`] = memberDetail.file.toLowerCase();
-            variables[`&OPENSPF`] = memberDetail.file;
+                // Attempt to copy to member
+                const copyResult = await CompileTools.runCommand(connection, { command: copyFromStreamfile, environment: `ile`, noLibList: true });
 
-            variables[`&OPENMBRL`] = memberDetail.name.toLowerCase();
-            variables[`&OPENMBR`] = memberDetail.name;
+                if (copyResult.code !== 0) {
+                  writeEmitter.fire(`Failed to copy file to a temporary member.\n\t${copyResult.stderr}\n\n`);
+                  closeEmitter.fire(copyResult.code || 1);
+                }
+              }
 
-            variables[`&EXTL`] = memberDetail.extension.toLowerCase();
-            variables[`&EXT`] = memberDetail.extension;
-            break;
+              const commandResult = await CompileTools.runCommand(connection,
+                {
+                  title: chosenAction.name,
+                  environment,
+                  command: chosenAction.command,
+                  cwd: remoteCwd,
+                  env: variables,
+                }, {
+                writeEvent: (content) => writeEmitter.fire(content),
+                commandConfirm
+              }
+              );
 
-          case `file`:
-          case `streamfile`:
-            const pathData = path.parse(uri.path);
-            const basename = pathData.base;
-            const ext = pathData.ext ? (pathData.ext.startsWith(`.`) ? pathData.ext.substring(1) : pathData.ext) : ``;
-            const parent = path.parse(pathData.dir).base;
-            let name = pathData.name;
+              if (commandResult && commandResult.code !== CompileTools.DID_NOT_RUN) {
+                hasRun = true;
+                const isIleCommand = environment === `ile`;
 
-            // Logic to handle second extension, caused by bob.
-            const bobTypes = [`.PGM`, `.SRVPGM`];
-            const secondName = path.parse(name);
-            if (secondName.ext && bobTypes.includes(secondName.ext.toUpperCase())) {
-              name = secondName.name;
-            }
+                const useLocalEvfevent =
+                  fromWorkspace && chosenAction.postDownload &&
+                  (chosenAction.postDownload.includes(`.evfevent`) || chosenAction.postDownload.includes(`.evfevent/`));
 
-            // Remove bob text convention
-            if (name.includes(`-`)) {
-              name = name.substring(0, name.indexOf(`-`));
-            }
+                const possibleObject = getObjectFromCommand(commandResult.command);
+                if (isIleCommand && possibleObject) {
+                  Object.assign(evfeventInfo, possibleObject);
+                }
 
-            if (variables[`&CURLIB`]) {
-              evfeventInfo.library = variables[`&CURLIB`];
+                actionName = (isIleCommand && possibleObject ? `${chosenAction.name} for ${evfeventInfo.library}/${evfeventInfo.object}` : actionName);
+                successful = (commandResult.code === 0 || commandResult.code === null);
 
-            } else {
-              evfeventInfo.library = config.currentLibrary;
-            }
+                writeEmitter.fire(CompileTools.NEWLINE);
 
-            evfeventInfo.library = evfeventInfo.library.toUpperCase();
-            evfeventInfo.object = name.toUpperCase();
-            evfeventInfo.extension = ext;
+                if (useLocalEvfevent) {
+                  writeEmitter.fire(`Fetching errors from .evfevent.${CompileTools.NEWLINE}`);
 
-            if (chosenAction.command.includes(`&SRCFILE`)) {
-              variables[`&SRCLIB`] = evfeventInfo.library;
-              variables[`&SRCPF`] = `QTMPSRC`;
-              variables[`&SRCFILE`] = `${evfeventInfo.library}/QTMPSRC`;
-            }
-
-            switch (chosenAction.type) {
-              case `file`:
-                variables[`&LOCALPATH`] = uri.fsPath;
-                if (fromWorkspace) {
-                  const relativePath = path.relative(fromWorkspace.uri.path, uri.path).split(path.sep).join(path.posix.sep);
-                  variables[`&RELATIVEPATH`] = relativePath;
-
-                  // We need to make sure the remote path is posix
-                  const fullPath = path.posix.join(remoteCwd, relativePath);
-                  variables[`&FULLPATH`] = fullPath;
-                  variables[`{path}`] = fullPath;
-                  variables[`&WORKDIR`] = remoteCwd;
-                  variables[`&FILEDIR`] = path.posix.parse(fullPath).dir;
-
-                  const branch = getGitBranch(fromWorkspace);
-                  if (branch) {
-                    variables[`&BRANCHLIB`] = getBranchLibraryName(branch);
-                    variables[`&BRANCH`] = branch;
-                    variables[`{branch}`] = branch;
+                }
+                else if (evfeventInfo.object && evfeventInfo.library) {
+                  if (chosenAction.command.includes(`*EVENTF`)) {
+                    writeEmitter.fire(`Fetching errors for ${evfeventInfo.library}/${evfeventInfo.object}.` + CompileTools.NEWLINE);
+                    refreshDiagnosticsFromServer(instance, evfeventInfo);
+                    problemsFetched = true;
+                  } else if (chosenAction.command.trimStart().toUpperCase().startsWith(`CRT`)) {
+                    writeEmitter.fire(`*EVENTF not found in command string. Not fetching errors for ${evfeventInfo.library}/${evfeventInfo.object}.` + CompileTools.NEWLINE);
                   }
                 }
-                break;
 
-              case `streamfile`:
-                const relativePath = path.posix.relative(remoteCwd, uri.path);
-                variables[`&RELATIVEPATH`] = relativePath;
+                if (chosenAction.type === `file` && chosenAction.postDownload?.length) {
+                  if (fromWorkspace) {
+                    const remoteDir = remoteCwd;
+                    const localDir = fromWorkspace.uri;
 
-                const fullName = uri.path;
-                variables[`&FULLPATH`] = fullName;
-                variables[`&FILEDIR`] = path.parse(fullName).dir;
-                break;
-            }
+                    const postDownloads: { type: vscode.FileType, localPath: string, remotePath: string }[] = [];
+                    const downloadDirectories = new Set<vscode.Uri>();
+                    for (const download of chosenAction.postDownload) {
+                      const remotePath = path.posix.join(remoteDir, download);
+                      const localPath = vscode.Uri.joinPath(localDir, download).path;
 
-            variables[`&PARENT`] = parent;
+                      let type: vscode.FileType;
+                      if (await content.isDirectory(remotePath)) {
+                        downloadDirectories.add(vscode.Uri.joinPath(localDir, download));
+                        type = vscode.FileType.Directory;
+                      }
+                      else {
+                        const directory = path.parse(download).dir;
+                        if (directory) {
+                          downloadDirectories.add(vscode.Uri.joinPath(localDir, directory));
+                        }
+                        type = vscode.FileType.File;
+                      }
 
-            variables[`&BASENAME`] = basename;
-            variables[`{filename}`] = basename;
+                      postDownloads.push({ remotePath, localPath, type })
+                    }
 
-            variables[`&NAMEL`] = name.toLowerCase();
-            variables[`&NAME`] = name;
-
-            variables[`&EXTL`] = extension.toLowerCase();
-            variables[`&EXT`] = extension;
-            break;
-
-          case `object`:
-            const [_, library, fullName] = uri.path.toUpperCase().split(`/`);
-            const object = fullName.substring(0, fullName.lastIndexOf(`.`));
-
-            evfeventInfo.library = library;
-            evfeventInfo.object = object;
-
-            variables[`&LIBRARYL`] = library.toLowerCase();
-            variables[`&LIBRARY`] = library;
-
-            variables[`&NAMEL`] = object.toLowerCase();
-            variables[`&NAME`] = object;
-
-            variables[`&TYPEL`] = extension.toLowerCase();
-            variables[`&TYPE`] = extension;
-
-            variables[`&EXTL`] = extension.toLowerCase();
-            variables[`&EXT`] = extension;
-            break;
-        }
-
-        const viewControl = IBMi.connectionManager.get<string>(`postActionView`) || "none";
-        const outputBuffer: string[] = [];
-        let actionName = chosenAction.name;
-        let hasRun = false;
-
-        const commandConfirm = async (commandString: string): Promise<string> => {
-          const commands = commandString.split(`\n`).filter(command => command.trim().length > 0);
-          const promptedCommands = [];
-          for (let command of commands) {
-            if (command.startsWith(`?`)) {
-              command = await vscode.window.showInputBox({ prompt: `Run Command`, value: command.substring(1) }) || '';
-            } else {
-              command = await showCustomInputs(`Run Command`, command, chosenAction.name || `Command`);
-            }
-            promptedCommands.push(command);
-            if (!command) break;
-          }
-
-          return !promptedCommands.includes(``) ? promptedCommands.join(`\n`) : ``;
-        }
-
-        const exitCode = await new Promise<number>(resolve =>
-          tasks.executeTask({
-            isBackground: true,
-            name: chosenAction.name,
-            definition: { type: `ibmi` },
-            scope: workspaceFolder,
-            source: 'IBM i',
-            presentationOptions: {
-              showReuseMessage: true,
-              clear: IBMi.connectionManager.get<boolean>(`clearOutputEveryTime`),
-              focus: false,
-              reveal: (viewControl === `task` ? TaskRevealKind.Always : TaskRevealKind.Never),
-            },
-            problemMatchers: [],
-            runOptions: {},
-            group: TaskGroup.Build,
-            execution: new CustomExecution(async (e) => {
-              const writeEmitter = new vscode.EventEmitter<string>();
-              const closeEmitter = new vscode.EventEmitter<number>();
-
-              writeEmitter.event(s => outputBuffer.push(s));
-              closeEmitter.event(resolve);
-
-              const term: Pseudoterminal = {
-                onDidWrite: writeEmitter.event,
-                onDidClose: closeEmitter.event,
-                open: async (initialDimensions: vscode.TerminalDimensions | undefined) => {
-                  let successful = false;
-                  let problemsFetched = false;
-
-                  try {
-                    writeEmitter.fire(`Running Action: ${chosenAction.name} (${new Date().toLocaleTimeString()})` + CompileTools.NEWLINE);
-
-                    // If &SRCFILE is set, we need to copy the file to a temporary source file from the IFS
-                    if (variables[`&FULLPATH`] && variables[`&SRCFILE`] && evfeventInfo.object) {
-                      const [lib, srcpf] = variables[`&SRCFILE`].split(`/`);
-
-                      const createSourceFile = content.toCl(`CRTSRCPF`, {
-                        rcdlen: 112, //NICE: this configurable in a VS Code setting?
-                        file: `${lib}/${srcpf}`,
-                      });
-
-                      const copyFromStreamfile = content.toCl(`CPYFRMSTMF`, {
-                        fromstmf: variables[`&FULLPATH`],
-                        tombr: `'${Tools.qualifyPath(lib, srcpf, evfeventInfo.object)}'`,
-                        mbropt: `*REPLACE`,
-                        dbfccsid: `*FILE`,
-                        stmfccsid: 1208,
-                      });
-
-                      // We don't care if this fails. Usually it's because the source file already exists.
-                      await CompileTools.runCommand(connection, { command: createSourceFile, environment: `ile`, noLibList: true });
-
-                      // Attempt to copy to member
-                      const copyResult = await CompileTools.runCommand(connection, { command: copyFromStreamfile, environment: `ile`, noLibList: true });
-
-                      if (copyResult.code !== 0) {
-                        writeEmitter.fire(`Failed to copy file to a temporary member.\n\t${copyResult.stderr}\n\n`);
-                        closeEmitter.fire(copyResult.code || 1);
+                    //Clear and create every local download directories
+                    for (const downloadPath of downloadDirectories) {
+                      try {
+                        const stat = await vscode.workspace.fs.stat(downloadPath); //Check if target exists
+                        if (stat.type !== vscode.FileType.Directory) {
+                          if (await vscode.window.showWarningMessage(`${downloadPath} exists but is a file.`, "Delete and create directory")) {
+                            await vscode.workspace.fs.delete(downloadPath);
+                            throw new Error("Create directory");
+                          }
+                        }
+                        else if (stat.type === vscode.FileType.Directory) {
+                          await vscode.workspace.fs.delete(downloadPath, { recursive: true });
+                          throw new Error("Create directory");
+                        }
+                      }
+                      catch (e) {
+                        //Either fs.stat did not find the folder or it wasn't a folder and it's been deleted above
+                        try {
+                          await vscode.workspace.fs.createDirectory(downloadPath)
+                        }
+                        catch (error) {
+                          vscode.window.showWarningMessage(`Failed to create download path ${downloadPath}: ${error}`);
+                          console.log(error);
+                          closeEmitter.fire(1);
+                        }
                       }
                     }
 
-                    const commandResult = await CompileTools.runCommand(connection,
-                      {
-                        title: chosenAction.name,
-                        environment,
-                        command: chosenAction.command,
-                        cwd: remoteCwd,
-                        env: variables,
-                      }, {
-                        writeEvent: (content) => writeEmitter.fire(content),
-                        commandConfirm
+                    // Then we download the files that is specified.
+                    const downloads = postDownloads.map(
+                      async (postDownload) => {
+                        const content = connection.getContent();
+                        if (postDownload.type === vscode.FileType.Directory) {
+                          return content.downloadDirectory(postDownload.localPath, postDownload.remotePath, { recursive: true, concurrency: 5 });
+                        } else {
+                          return content.downloadFile(postDownload.localPath, postDownload.remotePath);
+                        }
                       }
                     );
 
-                    if (commandResult && commandResult.code !== CompileTools.DID_NOT_RUN) {
-                      hasRun = true;
-                      const isIleCommand = environment === `ile`;
+                    await Promise.all(downloads)
+                      .then(async result => {
+                        // Done!
+                        writeEmitter.fire(`Downloaded files as part of Action: ${chosenAction.postDownload!.join(`, `)}\n`);
 
-                      const useLocalEvfevent =
-                        fromWorkspace && chosenAction.postDownload &&
-                        (chosenAction.postDownload.includes(`.evfevent`) || chosenAction.postDownload.includes(`.evfevent/`));
-
-                      const possibleObject = getObjectFromCommand(commandResult.command);
-                      if (isIleCommand && possibleObject) {
-                        Object.assign(evfeventInfo, possibleObject);
-                      }
-
-                      actionName = (isIleCommand && possibleObject ? `${chosenAction.name} for ${evfeventInfo.library}/${evfeventInfo.object}` : actionName);
-                      successful = (commandResult.code === 0 || commandResult.code === null);
-
-                      writeEmitter.fire(CompileTools.NEWLINE);
-
-                      if (useLocalEvfevent) {
-                        writeEmitter.fire(`Fetching errors from .evfevent.${CompileTools.NEWLINE}`);
-
-                      }
-                      else if (evfeventInfo.object && evfeventInfo.library) {
-                        if (chosenAction.command.includes(`*EVENTF`)) {
-                          writeEmitter.fire(`Fetching errors for ${evfeventInfo.library}/${evfeventInfo.object}.` + CompileTools.NEWLINE);
-                          refreshDiagnosticsFromServer(instance, evfeventInfo);
+                        // Process locally downloaded evfevent files:
+                        if (useLocalEvfevent) {
+                          refreshDiagnosticsFromLocal(instance, evfeventInfo);
                           problemsFetched = true;
-                        } else {
-                          writeEmitter.fire(`*EVENTF not found in command string. Not fetching errors for ${evfeventInfo.library}/${evfeventInfo.object}.` + CompileTools.NEWLINE);
                         }
-                      }
-
-                      if (chosenAction.type === `file` && chosenAction.postDownload?.length) {
-                        if (fromWorkspace) {
-                          const remoteDir = remoteCwd;
-                          const localDir = fromWorkspace.uri;
-
-                          const postDownloads: { type: vscode.FileType, localPath: string, remotePath: string }[] = [];
-                          const downloadDirectories = new Set<vscode.Uri>();
-                          for (const download of chosenAction.postDownload) {
-                            const remotePath = path.posix.join(remoteDir, download);
-                            const localPath = vscode.Uri.joinPath(localDir, download).path;
-
-                            let type: vscode.FileType;
-                            if (await content.isDirectory(remotePath)) {
-                              downloadDirectories.add(vscode.Uri.joinPath(localDir, download));
-                              type = vscode.FileType.Directory;
-                            }
-                            else {
-                              const directory = path.parse(download).dir;
-                              if (directory) {
-                                downloadDirectories.add(vscode.Uri.joinPath(localDir, directory));
-                              }
-                              type = vscode.FileType.File;
-                            }
-
-                            postDownloads.push({ remotePath, localPath, type })
-                          }
-
-                          //Clear and create every local download directories
-                          for (const downloadPath of downloadDirectories) {
-                            try {
-                              const stat = await vscode.workspace.fs.stat(downloadPath); //Check if target exists
-                              if (stat.type !== vscode.FileType.Directory) {
-                                if (await vscode.window.showWarningMessage(`${downloadPath} exists but is a file.`, "Delete and create directory")) {
-                                  await vscode.workspace.fs.delete(downloadPath);
-                                  throw new Error("Create directory");
-                                }
-                              }
-                              else if (stat.type === vscode.FileType.Directory) {
-                                await vscode.workspace.fs.delete(downloadPath, { recursive: true });
-                                throw new Error("Create directory");
-                              }
-                            }
-                            catch (e) {
-                              //Either fs.stat did not find the folder or it wasn't a folder and it's been deleted above
-                              try {
-                                await vscode.workspace.fs.createDirectory(downloadPath)
-                              }
-                              catch (error) {
-                                vscode.window.showWarningMessage(`Failed to create download path ${downloadPath}: ${error}`);
-                                console.log(error);
-                                closeEmitter.fire(1);
-                              }
-                            }
-                          }
-
-                          // Then we download the files that is specified.
-                          const downloads = postDownloads.map(
-                            async (postDownload) => {
-                              const content = connection.getContent();
-                              if (postDownload.type === vscode.FileType.Directory) {
-                                return content.downloadDirectory(postDownload.localPath, postDownload.remotePath, { recursive: true, concurrency: 5 });
-                              } else {
-                                return content.downloadFile(postDownload.localPath, postDownload.remotePath);
-                              }
-                            }
-                          );
-
-                          await Promise.all(downloads)
-                            .then(async result => {
-                              // Done!
-                              writeEmitter.fire(`Downloaded files as part of Action: ${chosenAction.postDownload!.join(`, `)}\n`);
-
-                              // Process locally downloaded evfevent files:
-                              if (useLocalEvfevent) {
-                                refreshDiagnosticsFromLocal(instance, evfeventInfo);
-                                problemsFetched = true;
-                              }
-                            })
-                            .catch(error => {
-                              vscode.window.showErrorMessage(`Failed to download files as part of Action.`);
-                              writeEmitter.fire(`Failed to download a file after Action: ${error.message}\n`);
-                              closeEmitter.fire(1);
-                            });
-                        }
-                      }
-
-                      if (problemsFetched && viewControl === `problems`) {
-                        commands.executeCommand(`workbench.action.problems.focus`);
-                      }
-                    } else {
-                      writeEmitter.fire(`Command did not run.` + CompileTools.NEWLINE);
-                    }
-
-                  } catch (e) {
-                    writeEmitter.fire(`${e}\n`);
-                    vscode.window.showErrorMessage(`Action ${chosenAction} for ${evfeventInfo.library}/${evfeventInfo.object} failed. (internal error).`);
-                    successful = false;
+                      })
+                      .catch(error => {
+                        vscode.window.showErrorMessage(`Failed to download files as part of Action.`);
+                        writeEmitter.fire(`Failed to download a file after Action: ${error.message}\n`);
+                        closeEmitter.fire(1);
+                      });
                   }
-
-                  closeEmitter.fire(successful ? 0 : 1);
-                },
-                close: function (): void { }
-              };
-
-              return term;
-            })
-          })
-        );
-
-        const executionOK = (exitCode === 0);
-        if (hasRun) {
-          if (executionOK && browserItem) {
-            switch (chosenAction.refresh) {
-              case 'browser':
-                if (chosenAction.type === 'streamfile') {
-                  vscode.commands.executeCommand("code-for-ibmi.refreshIFSBrowser");
                 }
-                else if (chosenAction.type !== 'file') {
-                  vscode.commands.executeCommand("code-for-ibmi.refreshObjectBrowser");
+
+                if (problemsFetched && viewControl === `problems`) {
+                  commands.executeCommand(`workbench.action.problems.focus`);
                 }
-                break;
+              } else {
+                writeEmitter.fire(`Command did not run.` + CompileTools.NEWLINE);
+              }
 
-              case 'filter':
-                //Filter is a top level item so it has no parent (like Batman)
-                let filter: BrowserItem = browserItem;
-                while (filter.parent) {
-                  filter = filter.parent;
-                }
-                filter.refresh?.();
-                break;
-
-              case 'parent':
-                browserItem.parent?.refresh?.();
-                break;
-
-              default:
-              //No refresh
+            } catch (e) {
+              writeEmitter.fire(`${e}\n`);
+              vscode.window.showErrorMessage(`Action ${chosenAction} for ${evfeventInfo.library}/${evfeventInfo.object} failed. (internal error).`);
+              successful = false;
             }
+
+            closeEmitter.fire(successful ? 0 : 1);
+          },
+          close: function (): void { }
+        };
+
+        return term;
+      })
+    })
+  );
+
+  const executionOK = (exitCode === 0);
+  if (hasRun) {
+    if (executionOK && browserItem) {
+      switch (chosenAction.refresh) {
+        case 'browser':
+          if (chosenAction.type === 'streamfile') {
+            vscode.commands.executeCommand("code-for-ibmi.refreshIFSBrowser");
           }
+          else if (chosenAction.type !== 'file') {
+            vscode.commands.executeCommand("code-for-ibmi.refreshObjectBrowser");
+          }
+          break;
 
-          const openOutputAction = "Open output"; //TODO: will be translated in the future
-          const uiPromise = executionOK ?
-            vscode.window.showInformationMessage(`Action ${actionName} was successful.`, openOutputAction) :
-            vscode.window.showErrorMessage(`Action ${actionName} was not successful.`, openOutputAction);
+        case 'filter':
+          //Filter is a top level item so it has no parent (like Batman)
+          let filter: BrowserItem = browserItem;
+          while (filter.parent) {
+            filter = filter.parent;
+          }
+          filter.refresh?.();
+          break;
 
-          uiPromise.then(openOutput => {
-            if (openOutput) {
-              const now = new Date();
-              new CustomUI()
-                .addParagraph(`<pre><code>${outputBuffer.join("")}</code></pre>`)
-                .setOptions({ fullWidth: true })
-                .loadPage(`${chosenAction.name} [${now.toLocaleString()}]`);
-            }
-          })
-        }
+        case 'parent':
+          browserItem.parent?.refresh?.();
+          break;
 
-        return executionOK;
+        default:
+        //No refresh
       }
-      else {
-        return false;
-      }
-    } else if (isProtected) {
-      //when a member is protected(read only)
-      vscode.window.showErrorMessage(`Action cannot be applied on a read only member.`);
-      return false;
-    } else {
-      //No compile commands
-      vscode.window.showErrorMessage(`No compile commands found for ${uri.scheme}-${extension}.`);
-      return false;
     }
+
+    const openOutputAction = "Open output"; //TODO: will be translated in the future
+    const uiPromise = executionOK ?
+      vscode.window.showInformationMessage(`Action ${actionName} was successful.`, openOutputAction) :
+      vscode.window.showErrorMessage(`Action ${actionName} was not successful.`, openOutputAction);
+
+    uiPromise.then(openOutput => {
+      if (openOutput) {
+        const now = new Date();
+        new CustomUI()
+          .addParagraph(`<pre><code>${outputBuffer.join("")}</code></pre>`)
+          .setOptions({ fullWidth: true })
+          .loadPage(`${chosenAction.name} [${now.toLocaleString()}]`);
+      }
+    })
   }
-  else {
-    throw new Error("Please connect to an IBM i first")
-  }
+
+  return executionOK;
 }
 
 function getObjectFromCommand(baseCommand?: string): CommandObject | undefined {


### PR DESCRIPTION
### Changes
* This message is now suppressed from commands not starting with CRT
* Complexity of the method was reduced

### How to test this PR
Steps to reproduce the behavior:

*    Create an action or run any CL command that doesn't use *EVENTF in it's CL command string,
*    Run the action.
*    See error: *EVENTF not found in command string. Not fetching errors for LIB/SRCMBR001.
