### PR TITLE
Add search item tooltip

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -787,6 +787,59 @@ export default class IBMiContent {
     return items;
   }
 
+  /**
+   * Get path info
+   * @param path
+   * @return IFSFile
+   */
+  async getFileInfo(path: string): Promise<IFSFile> {
+    const { 'stat': STAT } = this.ibmi.remoteFeatures;
+
+    let item: IFSFile = { type: 'streamfile', name: '', path: '' };
+    let fileInfoResult: CommandResult;
+
+    if (STAT) {
+      fileInfoResult = (await this.ibmi.sendCommand({
+        command: `${STAT} --dereference --printf="%A\t%h\t%U\t%G\t%s\t%Y\t%n\n" ${Tools.escapePath(path)}`
+      }));
+
+      if (fileInfoResult.stdout !== '') {
+        const fileInfo = fileInfoResult.stdout;
+
+        let auth: string, hardLinks: string, owner: string, group: string, size: string, modified: string, name: string;
+        [auth, hardLinks, owner, group, size, modified, name] = fileInfo.split(`\t`);
+
+        if (name !== `..` && name !== `.`) {
+          const type = (auth.startsWith(`d`) ? `directory` : `streamfile`);
+          item = {
+            type: type,
+            name: name,
+            path: path,
+            size: Number(size),
+            modified: new Date(Number(modified) * 1000),
+            owner: owner
+          };
+        };
+      }
+    } else {
+      fileInfoResult = (await this.ibmi.sendCommand({
+        command: `${this.ibmi.remoteFeatures.ls} -a -p -L ${Tools.escapePath(path)}`
+      }));
+
+      if (fileInfoResult.stdout !== '') {
+        const fileInfo = fileInfoResult.stdout;
+        const type = (fileInfo.endsWith(`/`) ? `directory` : `streamfile`);
+        item = {
+          type: type,
+          name: (type === `directory` ? fileInfo.substring(0, fileInfo.length - 1) : fileInfo),
+          path: path
+        };
+      }
+    }
+
+    return item;
+  }
+
   async memberResolve(member: string, files: QsysPath[]): Promise<IBMiMember | undefined> {
     const inAmerican = (s: string) => { return this.ibmi.sysNameInAmerican(s) };
     const inLocal = (s: string) => { return this.ibmi.sysNameInLocal(s) };

--- a/src/api/Search.ts
+++ b/src/api/Search.ts
@@ -121,9 +121,13 @@ export namespace Search {
         });
 
         if (grepRes.code == 0) {
+          const hits = parseGrepOutput(grepRes.stdout);
+          for (var i = 0; i < hits.length; i++) {
+            hits[i].file = await connection.content.getFileInfo(hits[i].path)
+          };
           return {
             term: searchTerm,
-            hits: parseGrepOutput(grepRes.stdout)
+            hits: hits
           }
         }
       } else {

--- a/src/api/Search.ts
+++ b/src/api/Search.ts
@@ -156,9 +156,13 @@ export namespace Search {
         });
 
         if (findRes.code == 0 && findRes.stdout) {
+          const hits = parseFindOutput(findRes.stdout);
+          for (var i = 0; i < hits.length; i++) {
+            hits[i].file = await connection.content.getFileInfo(hits[i].path)
+          };
           return {
             term: findTerm,
-            hits: parseFindOutput(findRes.stdout)
+            hits: hits
           }
         }
       } else {

--- a/src/api/components/getMemberInfo.ts
+++ b/src/api/components/getMemberInfo.ts
@@ -56,7 +56,11 @@ export class GetMemberInfo implements IBMiComponent {
   async getMemberInfo(connection: IBMi, library: string, sourceFile: string, member: string): Promise<IBMiMember | undefined> {
     const config = connection.config!;
     const tempLib = config.tempLibrary;
-    const statement = `select * from table(${tempLib}.${this.procedureName}('${library}', '${sourceFile}', '${member}'))`;
+    const statement = ``.concat(`select Library, File, Member, Attr, Extension`,
+                                `     , extract(epoch from (CREATED))*1000 as CREATED`,
+                                `     , extract(epoch from (CHANGED))*1000 as CHANGED`,
+                                `     , Description, isSource`,
+                                `  from table(${tempLib}.${this.procedureName}('${library}', '${sourceFile}', '${member}'))`);
 
     let results: Tools.DB2Row[] = [];
     if (config.enableSQL) {
@@ -88,7 +92,11 @@ export class GetMemberInfo implements IBMiComponent {
     const config = connection.config!;
     const tempLib = config.tempLibrary;
     const statement = members
-      .map(member => `select * from table(${tempLib}.${this.procedureName}('${member.library}', '${member.file}', '${member.name}'))`)
+      .map(member => ``.concat(`select Library, File, Member, Attr, Extension`,
+                               `     , extract(epoch from (CREATED))*1000 as CREATED`,
+                               `     , extract(epoch from (CHANGED))*1000 as CHANGED`,
+                               `     , Description, isSource`,
+                               `  from table(${tempLib}.${this.procedureName}('${member.library}', '${member.file}', '${member.name}'))`))
       .join(' union all ');
 
     let results: Tools.DB2Row[] = [];

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -92,7 +92,7 @@ export interface IBMiObject extends QsysPath {
   owner?: string
 }
 
-export interface IBMiMember {
+export type IBMiMember = {
   library: string
   file: string
   name: string
@@ -176,6 +176,7 @@ export type SearchHit = {
   readonly?: boolean
   label?: string
   file?: IFSFile
+  member?: IBMiMember
 }
 
 export type SearchHitLine = {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -105,7 +105,7 @@ export interface IBMiMember {
   changed?: Date
 }
 
-export interface IFSFile {
+export type IFSFile = {
   type: "directory" | "streamfile"
   name: string
   path: string
@@ -175,6 +175,7 @@ export type SearchHit = {
   lines: SearchHitLine[]
   readonly?: boolean
   label?: string
+  file?: IFSFile
 }
 
 export type SearchHitLine = {

--- a/src/ui/views/searchView.ts
+++ b/src/ui/views/searchView.ts
@@ -79,7 +79,9 @@ class HitSource extends vscode.TreeItem implements WithPath {
     this.iconPath = vscode.ThemeIcon.File;
     this.path = result.path;
     this._readonly = result.readonly;
-    this.tooltip = result.file ? VscodeTools.ifsFileToToolTip(this.path, result.file) : result.path;
+    this.tooltip = result.file ? VscodeTools.ifsFileToToolTip(this.path, result.file) :
+                   result.member? VscodeTools.memberToToolTip(this.path, result.member) :
+                   result.path;
 
     if (hits) {
       this.description = `${hits} hit${hits === 1 ? `` : `s`}`;

--- a/src/ui/views/searchView.ts
+++ b/src/ui/views/searchView.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import vscode from "vscode";
+import { VscodeTools } from "../Tools";
 import { DefaultOpenMode, SearchHit, SearchHitLine, SearchResults, WithPath } from "../../typings";
 
 export function initializeSearchView(context: vscode.ExtensionContext) {
@@ -78,7 +79,7 @@ class HitSource extends vscode.TreeItem implements WithPath {
     this.iconPath = vscode.ThemeIcon.File;
     this.path = result.path;
     this._readonly = result.readonly;
-    this.tooltip = result.path;
+    this.tooltip = result.file ? VscodeTools.ifsFileToToolTip(this.path, result.file) : result.path;
 
     if (hits) {
       this.description = `${hits} hit${hits === 1 ? `` : `s`}`;


### PR DESCRIPTION
### Changes

This PR will add tooltips to the items in the search result view:

Members:
![billede](https://github.com/user-attachments/assets/436acda4-db4e-480b-b9da-72dab59ac5e1)

Streamfiles:
![billede](https://github.com/user-attachments/assets/d78c2917-9f00-4786-a505-4e3c74d0c29c)

Streamfiles - find:
![billede](https://github.com/user-attachments/assets/c0a6664e-837d-4e2d-8e2b-00e3222da55a)

Included in the PR is a fix for invalid dates from the `getMemberInfo` and `getMultipleMemberInfo` functions...

### How to test this PR

Examples:

1. Run the test cases
2. Search for some text in members and streamfile and check for tooltips in the result view.
3. Find some streamfiles and check for tooltips in the result view.

### Checklist

* [x] have tested my change
