### PR TITLE
Refactor component handling and improve user input management

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -766,7 +766,12 @@ export default class IBMiContent {
    */
   getMemberInfo(library: string, sourceFile: string, member: string) {
     const component = this.ibmi.getComponent<GetMemberInfo>(GetMemberInfo.ID)!;
-    return component.getMemberInfo(this.ibmi, library, sourceFile, member);
+
+    if (component) {
+      return component.getMemberInfo(this.ibmi, library, sourceFile, member);
+    } else {
+      return Promise.resolve(undefined);
+    }
   }
 
   /**

--- a/src/api/components/getMemberInfo.ts
+++ b/src/api/components/getMemberInfo.ts
@@ -53,6 +53,24 @@ export class GetMemberInfo implements IBMiComponent {
     });
   }
 
+  private static parseDateString(tsString: string|undefined): Date | undefined {
+    if (!tsString) {
+      return undefined;
+    }
+    
+    const dateParts = tsString.split('-');
+    const timeParts = dateParts[3].split('.');
+
+    const year = parseInt(dateParts[0], 10);
+    const month = parseInt(dateParts[1], 10) - 1; // Months are zero-based in JavaScript
+    const day = parseInt(dateParts[2], 10);
+    const hours = parseInt(timeParts[0], 10);
+    const minutes = parseInt(timeParts[1], 10);
+    const seconds = parseInt(timeParts[2], 10);
+
+    return new Date(year, month, day, hours, minutes, seconds);
+  }
+
   async getMemberInfo(connection: IBMi, library: string, sourceFile: string, member: string): Promise<IBMiMember | undefined> {
     const config = connection.config!;
     const tempLib = config.tempLibrary;
@@ -78,8 +96,8 @@ export class GetMemberInfo implements IBMiComponent {
         name: result.MEMBER,
         extension: result.EXTENSION,
         text: result.DESCRIPTION,
-        created: new Date(result.CREATED ? Number(result.CREATED) : 0),
-        changed: new Date(result.CHANGED ? Number(result.CHANGED) : 0)
+        created: GetMemberInfo.parseDateString(String(result.CREATED)),
+        changed: GetMemberInfo.parseDateString(String(result.CHANGED))
       } as IBMiMember
     }
   }
@@ -110,8 +128,8 @@ export class GetMemberInfo implements IBMiComponent {
         name: result.MEMBER,
         extension: result.EXTENSION,
         text: result.DESCRIPTION,
-        created: new Date(result.CREATED ? Number(result.CREATED) : 0),
-        changed: new Date(result.CHANGED ? Number(result.CHANGED) : 0)
+        created: GetMemberInfo.parseDateString(String(result.CREATED)),
+        changed: GetMemberInfo.parseDateString(String(result.CHANGED))
       } as IBMiMember
     });
   }

--- a/src/api/components/getMemberInfo.ts
+++ b/src/api/components/getMemberInfo.ts
@@ -59,7 +59,7 @@ export class GetMemberInfo implements IBMiComponent {
     const statement = `select * from table(${tempLib}.${this.procedureName}('${library}', '${sourceFile}', '${member}'))`;
 
     let results: Tools.DB2Row[] = [];
-    if (config.enableSQL) {
+    if (connection.enableSQL) {
       try {
         results = await connection.runSQL(statement);
       } catch (e) { } // Ignore errors, will return undefined.
@@ -92,7 +92,7 @@ export class GetMemberInfo implements IBMiComponent {
       .join(' union all ');
 
     let results: Tools.DB2Row[] = [];
-    if (config.enableSQL) {
+    if (connection.enableSQL) {
       try {
         results = await connection.runSQL(statement);
       } catch (e) { }; // Ignore errors, will return undefined.

--- a/src/api/components/manager.ts
+++ b/src/api/components/manager.ts
@@ -65,7 +65,7 @@ export class ComponentManager {
       if (!installed || !sameVersion || installed.state === `NotChecked`) {
         await newComponent.check();
       } else {
-        newComponent.overrideState(installed.state);
+        await newComponent.overrideState(installed.state);
       }
 
       this.registered.set(component.getIdentification().name, newComponent);

--- a/src/api/components/manager.ts
+++ b/src/api/components/manager.ts
@@ -62,7 +62,7 @@ export class ComponentManager {
       const installed = lastInstalled.find(i => i.id.name === component.getIdentification().name);
       const sameVersion = installed && (installed.id.version === component.getIdentification().version);
 
-      if (!installed || !sameVersion) {
+      if (!installed || !sameVersion || installed.state === `NotChecked`) {
         await newComponent.check();
       } else {
         newComponent.overrideState(installed.state);

--- a/src/api/tests/suites/components.test.ts
+++ b/src/api/tests/suites/components.test.ts
@@ -70,8 +70,8 @@ describe('Component Tests', () => {
     expect(memberInfoC?.library).toBe(tempLib);
     expect(memberInfoC?.file).toBe(tempSPF);
     expect(memberInfoC?.name).toBe(tempMbr);
-    expect(memberInfoC?.created).toBeTypeOf('number');
-    expect(memberInfoC?.changed).toBeTypeOf('number');
+    expect(memberInfoC?.created).toBeTypeOf('object');
+    expect(memberInfoC?.changed).toBeTypeOf('object');
 
     // Cleanup...
     await connection!.runCommand({

--- a/src/api/tests/suites/content.test.ts
+++ b/src/api/tests/suites/content.test.ts
@@ -521,7 +521,7 @@ describe('Content Tests', {concurrent: true}, () => {
       expect(error).toBeInstanceOf(Tools.SqlError);
       expect(error.sqlstate).toBe('38501');
     }
-  });
+  }, {timeout: 25000});
 
   it('Test @clCommand + select statement', async () => {
     const content = connection.getContent();

--- a/src/api/tests/suites/encoding.test.ts
+++ b/src/api/tests/suites/encoding.test.ts
@@ -80,7 +80,6 @@ describe('Encoding tests', {concurrent: true} ,() => {
   });
 
   it('Run variants through shells', async () => {
-
     const text = `Hello${connection?.variantChars.local}world`;
     const basicCommandA = `echo "${IBMi.escapeForShell(text)}"`;
     const basicCommandB = `echo '${text}'`;
@@ -110,7 +109,7 @@ describe('Encoding tests', {concurrent: true} ,() => {
     expect(paseTextResultA?.stdout).toBe(text);
     expect(qshTextResultB?.stdout).toBe(text);
     expect(paseTextResultB?.stdout).toBe(text);
-  });
+  }, {timeout: 25000});
 
   it('streamfileResolve with dollar', async () => {
     await connection.withTempDirectory(async tempDir => {

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -341,9 +341,6 @@ export function registerOpenCommands(instance: Instance): Disposable[] {
       });
 
       quickPick.onDidAccept(async () => {
-        quickPick.busy = true;
-        quickPick.enabled = false;
-
         let selection = quickPick.selectedItems.length === 1 ? quickPick.selectedItems[0].label : undefined;
         if (selection && selection !== LOADING_LABEL) {
           if (selection === CLEAR_RECENT) {
@@ -411,9 +408,6 @@ export function registerOpenCommands(instance: Instance): Disposable[] {
             }
           }
         }
-
-        quickPick.busy = false;
-        quickPick.enabled = true;
       });
 
       quickPick.onDidTriggerItemButton((event: QuickPickItemButtonEvent<QuickPickItem>) => {

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -341,6 +341,9 @@ export function registerOpenCommands(instance: Instance): Disposable[] {
       });
 
       quickPick.onDidAccept(async () => {
+        quickPick.busy = true;
+        quickPick.enabled = false;
+
         let selection = quickPick.selectedItems.length === 1 ? quickPick.selectedItems[0].label : undefined;
         if (selection && selection !== LOADING_LABEL) {
           if (selection === CLEAR_RECENT) {
@@ -408,6 +411,9 @@ export function registerOpenCommands(instance: Instance): Disposable[] {
             }
           }
         }
+
+        quickPick.busy = false;
+        quickPick.enabled = true;
       });
 
       quickPick.onDidTriggerItemButton((event: QuickPickItemButtonEvent<QuickPickItem>) => {


### PR DESCRIPTION
* move `enableSQL` to the connection instance.
* enhance component manager checks for `NotChecked` state
    * Add missing away that was setting all cached states to `NotChecked`
* handle potential crashes when the `getMemberInfo` component is unavailable.
* fixed broken test introduced by another PR (where a date should have been returned correctly)

## How to test

1. Ensure Go to File works as expected for opening members:
    * `Try entering QSYSINC/*` to filter
    * `Then try `QSYSINC/H/*` to filter
    * Try opening `MATH`