### PR TITLE
Fix invalid dates from GetMbrInfo

### DIFF
--- a/src/api/components/getMemberInfo.ts
+++ b/src/api/components/getMemberInfo.ts
@@ -7,7 +7,7 @@ import { IBMiMember } from "../types";
 export class GetMemberInfo implements IBMiComponent {
   static ID = 'GetMemberInfo';
   private readonly procedureName = 'GETMBRINFO';
-  private readonly currentVersion = 1;
+  private readonly currentVersion = 2;
   private installedVersion = 0;
 
   reset() {
@@ -160,11 +160,15 @@ function getSource(library: string, name: string, version: number) {
     `       , rtrim( substr( Buffer, 39, 10 ) )`,
     `       , rtrim( substr( Buffer, 49, 10 ) )`,
     `       , timestamp_format( case substr( Buffer, 59, 1 )`,
-    `                             when '1' then '20' else '19' end concat `,
-    `                           substr( Buffer, 60, 12 ) , 'YYYYMMDDHH24MISS')`,
+    `                             when '1' then '20' concat substr( Buffer, 60, 12 )`,
+    `                             when '0' then '19' concat substr( Buffer, 60, 12 )`,
+    `                             else '19700101000000'`,
+    `                           end, 'YYYYMMDDHH24MISS')`,
     `       , timestamp_format( case substr( Buffer, 72, 1 )`,
-    `                             when '1' then '20' else '19' end concat `,
-    `                           substr( Buffer, 73, 12 ), 'YYYYMMDDHH24MISS')`,
+    `                             when '1' then '20' concat substr( Buffer, 73, 12 )`,
+    `                             when '0' then '19' concat substr( Buffer, 73, 12 )`,
+    `                             else '19700101000000'`,
+    `                           end, 'YYYYMMDDHH24MISS')`,
     `       , rtrim( substr( Buffer, 85, 50 ) )`,
     `       , case substr( Buffer, 135, 1 ) when '1' then 'Y' else 'N' end`,
     `       );`,

--- a/src/api/tests/suites/components.test.ts
+++ b/src/api/tests/suites/components.test.ts
@@ -53,5 +53,31 @@ describe('Component Tests', () => {
       expect(error).toBeInstanceOf(Tools.SqlError);
       expect(error.sqlstate).toBe("38501");
     }
+
+    // Check getMemberInfo for empty member.
+    const config = connection.getConfig();
+    const tempLib = config!.tempLibrary,
+      tempSPF = `O_ABC`.concat(connection!.variantChars.local),
+      tempMbr = `O_ABC`.concat(connection!.variantChars.local);
+
+    const result = await connection!.runCommand({
+      command: `CRTSRCPF ${tempLib}/${tempSPF} MBR(${tempMbr})`,
+      environment: 'ile'
+    });
+
+    const memberInfoC = await component.getMemberInfo(connection, tempLib, tempSPF, tempMbr);
+    expect(memberInfoC).toBeTruthy();
+    expect(memberInfoC?.library).toBe(tempLib);
+    expect(memberInfoC?.file).toBe(tempSPF);
+    expect(memberInfoC?.name).toBe(tempMbr);
+    expect(memberInfoC?.created).toBeTypeOf('number');
+    expect(memberInfoC?.changed).toBeTypeOf('number');
+
+    // Cleanup...
+    await connection!.runCommand({
+      command: `DLTF ${tempLib}/${tempSPF}`,
+      environment: 'ile'
+    });
+
   });
 });


### PR DESCRIPTION
### Changes

This PR will fix the error reported in issue #2524 by returning the date `1970-01-01 00:00:00` when the source member date is not initialized, i.e. the date does not start with a '1' or '0'. This is the case when a member is created and not yet used: The QUSRMBRD API will return hexadecimal zeroes for the member change date if the member has never been refreshed.

A test for valid dates from GetMbrInfo has also been added.

### How to test this PR

Examples:

1. Run the test cases

### Checklist

* [x] have tested my change
* [x] have created one or more test cases