### PR TITLE
Deprecate aspInfo getter in preparation for IBMi.getAllIAsps in v3.0.0

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -107,6 +107,19 @@ export default class IBMi {
   private currentAsp: string|undefined;
   private libraryAsps = new Map<string, number>();
 
+  /**
+   * @deprecated Will be replaced with {@link IBMi.getAllIAsps} in v3.0.0
+   */
+  public get aspInfo(): { [id: number]: string } {
+    const result: { [id: number]: string } = {};
+
+    this.iAspInfo.forEach(asp => {
+      result[asp.id] = asp.name;
+    });
+
+    return result;
+  }
+
   remoteFeatures: { [name: string]: string | undefined };
 
   variantChars: {


### PR DESCRIPTION
### Changes

`aspInfo` was removed and replaced by `iAspInfo`, but of course, `aspInfo` was public and is used in the database extension.

For 2.15.0 compatability, and the time period to allow extensions to change, I have added it back in but marked as deprecated.

### How to test this PR

Examples:

Test editing an SQL job in the database extension under the following versions of vscode-ibmi:

* production release 2.14.5: works
* pre-release/master: error due to `aspInfo` missing
* this branch/PR: works

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)