### PR TITLE
Check for `CPDA08A` in `stderr` instead of `stdout` during member download

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -192,7 +192,7 @@ export default class IBMiContent {
         return await readFileAsync(localPath, `utf8`);
       } else {
         if (!retry) {
-          const messageID = String(copyResult.stdout).substring(0, 7);
+          const messageID = String(copyResult.stderr).substring(0, 7);
           switch (messageID) {
             case "CPDA08A":
               //We need to try again after we delete the temp remote


### PR DESCRIPTION
### Changes

The `CPDA08A` message ID should be parsed from `stderr` instead of `stdout`. I noticed this because the `Test streamfiles with shell character...` tests were failing.

### How to test this PR

Examples:

Ensure the `Test streamfiles with shell character...` tests pass

### Checklist

* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)