### PR TITLE
Add deprecation warnings for outdated methods in IBMi and Instance classes

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -209,6 +209,7 @@ export default class Instance {
    * @deprecated Will be removed in `v3.0.0`; use {@link IBMi.getConfig()} instead
    */
   getConfig() {
+    console.warn("[Code for IBM i] Deprecation warning: you are using Instance::getConfig which is deprecated and will be removed in v3.0.0. Please use IBMi::getConfig instead.");
     return this.connection?.getConfig();
   }
 
@@ -216,6 +217,7 @@ export default class Instance {
    * @deprecated Will be removed in `v3.0.0`; use {@link IBMi.getContent()} instead
    */
   getContent() {
+    console.warn("[Code for IBM i] Deprecation warning: you are using Instance::getContent which is deprecated and will be removed in v3.0.0. Please use IBMi::getContent instead.");
     return this.connection?.getContent();
   }
 

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -112,6 +112,7 @@ export default class IBMi {
    * @deprecated Will be replaced with {@link IBMi.getAllIAsps} in v3.0.0
    */
   public get aspInfo(): { [id: number]: string } {
+    console.warn("[Code for IBM i] Deprecation warning: you are using IBMi::aspInfo which is deprecated and will be removed in v3.0.0. Please use IBMi::getAllIAsps instead.");
     const result: { [id: number]: string } = {};
 
     this.iAspInfo.forEach(asp => {
@@ -1530,6 +1531,7 @@ export default class IBMi {
    * @deprecated Use {@link IBMiContent.uploadFiles} instead.
    */
   uploadFiles(files: { local: EditorPath, remote: string }[], options?: node_ssh.SSHPutFilesOptions) {
+    console.warn(`[Code for IBM i] uploadFiles is deprecated and will be removed by 4.0.0. Use IBMiContent.uploadFiles instead.`);
     return this.content.uploadFiles(files, options);
   }
 
@@ -1537,6 +1539,7 @@ export default class IBMi {
    * @deprecated Use {@link IBMiContent.downloadFiles} instead.
    */
   downloadFile(localFile: EditorPath, remoteFile: string) {
+    console.warn(`[Code for IBM i] downloadFile is deprecated and will be removed by 4.0.0. Use IBMiContent.downloadFile instead.`);
     return this.content.downloadFile(localFile, remoteFile);
   }
 
@@ -1544,6 +1547,7 @@ export default class IBMi {
    * @deprecated Use {@link IBMiContent.uploadDirectory} instead.
    */
   uploadDirectory(localDirectory: EditorPath, remoteDirectory: string, options?: node_ssh.SSHGetPutDirectoryOptions) {
+    console.warn(`[Code for IBM i] uploadDirectory is deprecated and will be removed by 4.0.0. Use IBMiContent.uploadDirectory instead.`);
     return this.content.uploadDirectory(localDirectory, remoteDirectory, options);
   }
 
@@ -1551,6 +1555,7 @@ export default class IBMi {
    * @deprecated Use {@link IBMiContent.downloadDirectory} instead.
    */
   downloadDirectory(localDirectory: EditorPath, remoteDirectory: string, options?: node_ssh.SSHGetPutDirectoryOptions) {
+    console.warn(`[Code for IBM i] downloadDirectory is deprecated and will be removed by 4.0.0. Use IBMiContent.downloadDirectory instead.`);
     return this.content.downloadDirectory(localDirectory, remoteDirectory, options);
   }
 }

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -93,6 +93,7 @@ export default class IBMiContent {
    * @deprecated Use {@link IBMiContent.downloadStreamfileRaw()} instead
    */
   async downloadStreamfile(remotePath: string, localPath?: string) {
+    console.warn(`[Code for IBM i] downloadStreamfile is deprecated and will be removed by 4.0.0. Use downloadStreamfileRaw instead.`);
     const raw = await this.downloadStreamfileRaw(remotePath, localPath);
     return raw.toString(`utf8`);
   }
@@ -130,6 +131,7 @@ export default class IBMiContent {
    * @deprecated Use {@link IBMiContent.writeStreamfileRaw()} instead
    */
   async writeStreamfile(originalPath: string, content: string) {
+    console.warn(`[Code for IBM i] writeStreamfile is deprecated and will be removed by 4.0.0. Use writeStreamfileRaw instead.`);
     const buffer = Buffer.from(content, `utf8`);
     return this.writeStreamfileRaw(originalPath, buffer);
   }
@@ -155,6 +157,11 @@ export default class IBMiContent {
   async downloadMemberContent(asp: string | undefined, library: string, sourceFile: string, member: string, localPath?: string): Promise<string>;
   async downloadMemberContent(aspOrLibrary: string | undefined, libraryOrSourceFile: string, sourceFileOrMember: string, memberOrLocalPath?: string, localPath?: string): Promise<string> {
     const smallSignature = Boolean(aspOrLibrary && libraryOrSourceFile && sourceFileOrMember && ((memberOrLocalPath && !localPath) || !memberOrLocalPath));
+
+    if (!smallSignature) {
+      console.warn(`[Code for IBM i] downloadMemberContent with 5 parameters is deprecated and will be removed by 3.0.0. Use downloadMemberContent with 4 parameters instead (no ASP).`);
+    }
+
     const library = this.ibmi.upperCaseName(smallSignature ? String(aspOrLibrary) : libraryOrSourceFile);
     const sourceFile = this.ibmi.upperCaseName(smallSignature ? libraryOrSourceFile : sourceFileOrMember);
     const member = this.ibmi.upperCaseName(smallSignature ? sourceFileOrMember : String(memberOrLocalPath));
@@ -233,6 +240,11 @@ export default class IBMiContent {
   async uploadMemberContent(asp: string | undefined, library: string, sourceFile: string, member: string, content: string | Uint8Array): Promise<boolean>;
   async uploadMemberContent(aspOrLibrary: string | undefined, libraryOrFile: string, sourceFileOrMember: string, memberOrContent: string | Uint8Array, content?: string | Uint8Array): Promise<boolean> {
     const fullSignature = Boolean(content);
+
+    if (fullSignature) {
+      console.warn(`[Code for IBM i] uploadMemberContent with 5 parameters is deprecated and will be removed by 3.0.0. Use uploadMemberContent with 4 parameters instead (no ASP).`);
+    }
+
     const library = this.ibmi.upperCaseName(fullSignature ? libraryOrFile : String(aspOrLibrary));
     const sourceFile = this.ibmi.upperCaseName(fullSignature ? sourceFileOrMember : libraryOrFile);
     const member = this.ibmi.upperCaseName(fullSignature ? String(memberOrContent) : sourceFileOrMember);
@@ -302,6 +314,8 @@ export default class IBMiContent {
    * @deprecated Use {@linkcode IBMi.runSQL IBMi.runSQL} instead
    */
   runSQL(statements: string) {
+    console.warn(`[Code for IBM i] runSQL is deprecated and will be removed by 4.0.0. Use IBMi.runSQL instead.`);
+    
     return this.ibmi.runSQL(statements);
   }
 


### PR DESCRIPTION
Introduce deprecation warnings for outdated methods to guide users towards updated alternatives before their removal in future versions.