### PR TITLE
Add logging functionality for command requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1679,6 +1679,13 @@
 				"category": "IBM i",
 				"icon": "$(plus)",
 				"enablement": "code-for-ibmi:connected"
+			},
+			{
+				"command": "code-for-ibmi.logs.show",
+				"title": "Show logs",
+				"category": "IBM i",
+				"icon": "$(output)",
+				"enablement": "code-for-ibmi:connected"
 			}
 		],
 		"keybindings": [

--- a/src/api/requestLogger.ts
+++ b/src/api/requestLogger.ts
@@ -1,0 +1,52 @@
+export interface RequestLog {
+  start: number;
+  end?: number;
+  command: string;
+  cwd?: string;
+  stdin?: string;
+  stdout?: string;
+  stderr?: string;
+}
+
+export class RequestLogger {
+  private collecting = false;
+  private uniqueName: string|undefined;
+  private log: RequestLog[] = [];
+
+  public setId(uniqueName: string) {
+    this.uniqueName = uniqueName;
+    this.log = [];
+  }
+
+  setLoggingState(state: boolean) {
+    this.collecting = state;
+  }
+
+  clear() {
+    this.log = [];
+  }
+
+  public getLogs() {
+    return this.log;
+  }
+
+  public new(command: string, cwd?: string, stdin?: string): RequestLog {
+    const entry: RequestLog = {
+      start: Date.now(),
+      command,
+      cwd,
+      stdin
+    };
+    return entry;
+  }
+
+  end(entry: RequestLog, code: number, stdout?: string, stderr?: string): void {
+    entry.end = Date.now();
+    entry.stdout = stdout;
+    entry.stderr = stderr;
+
+    if (this.collecting) {
+      this.log.push(entry);
+    }
+  }
+}

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -1,0 +1,21 @@
+import { commands, Disposable, ExtensionContext, window, workspace } from "vscode";
+import Instance from "../Instance";
+
+export function registerLoggingCommands(context: ExtensionContext, instance: Instance): Disposable[] {
+  return [
+    commands.registerCommand(`code-for-ibmi.logs.show`, async () => {
+      const logger = instance.getLogger();
+      
+      const content = logger.getLogs();
+
+      if (content.length === 0) {
+        window.showInformationMessage(`No logs available.`);
+        return;
+      }
+
+      workspace.openTextDocument({ content: JSON.stringify(content, null, 2), language: `json` }).then(doc => {
+        window.showTextDocument(doc);
+      })
+    })
+  ]
+}

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -15,6 +15,7 @@ import { QSysFS } from "./filesystems/qsys/QSysFs";
 import { ActionsUI } from './webviews/actions';
 import { VariablesUI } from "./webviews/variables";
 import IBMi from "./api/IBMi";
+import { registerLoggingCommands } from "./commands/logs";
 
 export let instance: Instance;
 
@@ -81,6 +82,8 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
     ...Terminal.registerTerminalCommands(context),
 
     ...registerPasswordCommands(context, instance),
+
+    ...registerLoggingCommands(context, instance),
 
     vscode.commands.registerCommand("code-for-ibmi.updateConnectedBar", updateConnectedBar),
   );


### PR DESCRIPTION
I'd really like a world where it's easy for us to visualise user issues. Right now, we have to ask the user to paste the output channel and we spend a lot of time navigating that.

Ideally, we'd take the output from the output channel and we'd visualise it nicely.

I had some ideas for visualisations, for example:

* Something like the request view in browser
* A simple list and each item can be expanded with what the request was (SQL statement, CL command, etc) in a nicely formatted way

I did a POC with just putting the data into a webview, but didn't commit this:

![telegram-cloud-photo-size-1-5060303861281041832-y](https://github.com/user-attachments/assets/2206229a-95c8-4dc9-82bb-a6d558b53ee9)
