### PR TITLE
Fix quoted name and variant character support

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -133,7 +133,7 @@ export namespace CompileTools {
             commandResult = await connection.sendQsh({
               command: [
                 ...options.noLibList? [] : buildLiblistCommands(connection, ileSetup),
-                ...commands,
+                ...commands.map(command => IBMi.escapeForShell((command)))
               ].join(` && `),
               directory: cwd,
               ...callbacks

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -453,17 +453,11 @@ export default class IBMiContent {
 
     newLibl = newLibl
       .filter(lib => {
-        if (lib.match(/^\d/)) {
+        const isValid = this.ibmi.validQsysName(lib);
+        if(!isValid) {
           badLibs.push(lib);
-          return false;
         }
-
-        if (lib.length > 10) {
-          badLibs.push(lib);
-          return false;
-        }
-
-        return true;
+        return isValid;
       });
 
     const sanitized = Tools.sanitizeObjNamesForPase(newLibl);

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -176,17 +176,11 @@ export namespace Tools {
    * @param member Optional
    * @param iasp Optional: an iASP name
    */
-  export function qualifyPath(library: string, object: string, member?: string, iasp?: string, noEscape?: boolean) {
-    [library, object] = Tools.sanitizeObjNamesForPase([library, object]);
-    member = member ? Tools.sanitizeObjNamesForPase([member])[0] : undefined;
-    iasp = iasp ? Tools.sanitizeObjNamesForPase([iasp])[0] : undefined;
-
+  export function qualifyPath(library: string, object: string, member?: string, iasp?: string) {
     const libraryPath = library === `QSYS` ? `QSYS.LIB` : `QSYS.LIB/${library}.LIB`;
     const filePath = object ? `${object}.FILE` : '';
-    const memberPath = member ? `/${member}.MBR` : '';
-    const fullPath = `${libraryPath}/${filePath}${memberPath}`;
-
-    const result = (iasp && iasp.length > 0 ? `/${iasp}` : ``) + `/${noEscape ? fullPath : Tools.escapePath(fullPath)}`;
+    const memberPath = member ? `${member}.MBR` : '';
+    const result = (iasp && iasp.length > 0 ? `/${iasp}` : ``) + `/${libraryPath}/${filePath}/${memberPath}`;
     return result;
   }
 

--- a/src/api/tests/suites/content.test.ts
+++ b/src/api/tests/suites/content.test.ts
@@ -268,11 +268,13 @@ describe('Content Tests', {concurrent: true}, () => {
   it('Test validateLibraryList', async () => {
     const content = connection.getContent();
 
-    const badLibs = await content.validateLibraryList(['SCOOBY', 'QSYSINC', 'BEEPBOOP']);
+    const badLibs = await content.validateLibraryList(['SCOOBY', 'QSYSINC', 'BEEPBOOP', '"QUOTES', '"YOYOYO"']);
 
     expect(badLibs?.includes('BEEPBOOP')).toBe(true);
     expect(badLibs?.includes('QSYSINC')).toBe(false);
     expect(badLibs?.includes('SCOOBY')).toBe(true);
+    expect(badLibs?.includes('"QUOTES')).toBe(true);
+    expect(badLibs?.includes('"YOYOYO"')).toBe(false);
   });
 
   it('Test getFileList', async () => {


### PR DESCRIPTION
### Changes

- [x] Fixes #2366
- [x] Potentially fixes #2264
- [x] Prevent endless recursive retries to read member if it exists but fails to be read
- [x] Quoted names:
  - [x] You can now properly create, open, and edit members with quoted names
  - [x] Reworked QSYS path validation to include validating quoted names
- [x] Variant characters:
  - [x] Should be able to now download members with variants (which failed in some cases, refer to examples [here](https://github.com/codefori/vscode-ibmi/issues/2264#issuecomment-2702067189)

TODO:
- [ ] Add some new tests!
- [ ] Review for other spots where triple quotes is needed
- [ ] Review use of `escapePath` vs `escapeForShell`
- [ ] Review what to do in the case `runSQL` is used
- [ ] Improve quoted name regex

### How to test this PR

### Checklist

* [ ] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)