### PR TITLE
Convert input handling based on CCSID scenarios

### DIFF
--- a/src/api/CompileTools.ts
+++ b/src/api/CompileTools.ts
@@ -147,7 +147,7 @@ export namespace CompileTools {
               command: [
                 ...options.noLibList? [] : buildLiblistCommands(connection, ileSetup),
                 ...commands.map(command =>
-                  `${`system "${IBMi.escapeForShell(command)}"`}`,
+                  `${`system "${IBMi.escapeForShell(connection.sysNameInAmerican(command, connection.systemCommandRequiresTranslation))}"`}`,
                 )
               ].join(` && `),
               directory: cwd,

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -19,6 +19,12 @@ import { EventEmitter } from 'stream';
 import { ConnectionConfig } from './configuration/config/types';
 import { EditorPath } from '../typings';
 
+export interface VariantInfo {
+  american: string,
+  local: string,
+  qsysNameRegex?: RegExp
+};
+
 export interface MemberParts extends IBMiMember {
   basename: string
 }
@@ -124,11 +130,7 @@ export default class IBMi {
 
   remoteFeatures: { [name: string]: string | undefined };
 
-  variantChars: {
-    american: string,
-    local: string,
-    qsysNameRegex?: RegExp
-  };
+  variantChars: VariantInfo;
 
   shell?: string;
 

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -160,16 +160,37 @@ export default class IBMi {
   }
 
   /**
-   * Determines if the client should do variant translation.
-   * False when cqsh should be used.
-   * True when cqsh is not available and the job CCSID is not the same as the SSHD CCSID.
+   * Determines if the client should do variant translation for SQL statements.
+   * The SQL runner (ZDFMDB2) translation is always based on QCCSID, and never on the user's CCSID.
    */
-  get requiresTranslation() {
+  private get sqlRunnerRequiresTranslation() {
+    if (this.canUseCqsh && this.qccsid === this.sshdCcsid) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Determine if QSYS paths need to be translated to use system variants
+   */
+  get qsysPosixPathsRequireTranslation() {
+    if (this.canUseCqsh && this.getCcsid() === this.sshdCcsid) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Determine if the system command requires translation
+   */
+  get systemCommandRequiresTranslation() {
     if (this.canUseCqsh) {
       return false;
-    } else {
-      return this.getCcsid() !== this.sshdCcsid;
     }
+    
+    return true;
   }
 
   get dangerousVariants() {
@@ -851,17 +872,18 @@ export default class IBMi {
           }
         }
 
-        else {
-          // If cqsh is not available, then we need to check the SSHD CCSID
-          this.sshdCcsid = await this.content.getSshCcsid();
-          if (this.sshdCcsid === this.getCcsid()) {
-            // If the SSHD CCSID matches the job CCSID (not the user profile!), then we're good.
-            // This means we can use regular qsh without worrying about translation because the SSHD and job CCSID match.
-            userCcsidNeedsFixing = false;
-          } else {
-            // If the SSHD CCSID does not match the job CCSID, then we need to warn the user
-            sshdCcsidMismatch = true;
-          }
+        callbacks.progress({
+          message: `Checking SSHD CCSID.`
+        });
+
+        this.sshdCcsid = await this.content.getSshCcsid();
+        if (this.sshdCcsid === this.getCcsid()) {
+          // If the SSHD CCSID matches the job CCSID (not the user profile!), then we're good.
+          // This means we can use regular qsh without worrying about translation because the SSHD and job CCSID match.
+          userCcsidNeedsFixing = false;
+        } else {
+          // If the SSHD CCSID does not match the job CCSID, then we need to warn the user
+          sshdCcsidMismatch = true;
         }
 
         if (userCcsidNeedsFixing) {
@@ -1069,11 +1091,6 @@ export default class IBMi {
       qshExecutable = this.getComponent<CustomQSh>(CustomQSh.ID)!.installPath;
     }
 
-    if (this.requiresTranslation) {
-      options.stdin = this.sysNameInAmerican(options.stdin);
-      options.directory = options.directory ? this.sysNameInAmerican(options.directory) : undefined;
-    }
-
     return this.sendCommand({
       ...options,
       command: `${IBMi.locale} ${qshExecutable}`
@@ -1240,17 +1257,21 @@ export default class IBMi {
    * @param {string} string
    * @returns {string} result
    */
-  sysNameInAmerican(string: string) {
-    const fromChars = this.variantChars.local;
-    const toChars = this.variantChars.american;
+  sysNameInAmerican(string: string, enabled: boolean = true) {
+    if (enabled) {
+      const fromChars = this.variantChars.local;
+      const toChars = this.variantChars.american;
 
-    let result = string;
+      let result = string;
 
-    for (let i = 0; i < fromChars.length; i++) {
-      result = result.replace(new RegExp(`[${fromChars[i]}]`, `g`), toChars[i]);
-    };
+      for (let i = 0; i < fromChars.length; i++) {
+        result = result.replace(new RegExp(`[${fromChars[i]}]`, `g`), toChars[i]);
+      };
 
-    return result
+      return result;
+    }
+
+    return string;
   }
 
   getLastDownloadLocation() {
@@ -1346,7 +1367,7 @@ export default class IBMi {
         command = `${IBMi.locale} ${customQsh.installPath} -c "system \\"call QSYS/QZDFMDB2 PARM('-d' '-i' '-t')\\""`;
       }
 
-      if (this.requiresTranslation) {
+      if (this.sqlRunnerRequiresTranslation) {
         // If we can't fix the input, then we can attempt to convert ourselves and then use the CSV.
         input = this.sysNameInAmerican(input);
         useCsv = true;

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -175,7 +175,7 @@ export default class IBMi {
    * Determine if QSYS paths need to be translated to use system variants
    */
   get qsysPosixPathsRequireTranslation() {
-    if (this.canUseCqsh && this.getCcsid() === this.sshdCcsid) {
+    if (this.canUseCqsh && this.getCcsid() === this.qccsid && this.qccsid !== IBMi.CCSID_NOCONVERSION) {
       return false;
     }
 

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -1072,13 +1072,17 @@ export default class IBMiContent {
 
   async countMembers(path: QsysPath) {
     return this.countFiles(this.ibmi.sysNameInAmerican(
-      Tools.qualifyPath(path.library, path.name, undefined, path.asp, undefined, this.ibmi.variantChars),
+      Tools.qualifyPath(path.library, path.name, undefined, path.asp),
       this.ibmi.qsysPosixPathsRequireTranslation
-    ));
+    ), true);
   }
 
-  async countFiles(directory: string) {
-    return Number((await this.ibmi.sendCommand({ command: `cd "${directory}" && (ls | wc -l)` })).stdout.trim());
+  async countFiles(directory: string, isQsys?: boolean) {
+    if (isQsys) {
+      return Number((await this.ibmi.sendQsh({ command: `cd "${directory}" && (ls | wc -l)` })).stdout.trim());
+    } else {
+      return Number((await this.ibmi.sendCommand({ command: `cd "${directory}" && (ls | wc -l)` })).stdout.trim());
+    }
   }
 
 

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -1035,11 +1035,11 @@ export default class IBMiContent {
 
     if (assumeMember) {
       // If it's an object, we assume it's a member, therefore let's let qsh handle it (better for variants)
-      localPath.asp = localPath.asp ? this.ibmi.sysNameInAmerican(localPath.asp) : undefined;
-      localPath.library = this.ibmi.sysNameInAmerican(localPath.library);
-      localPath.name = this.ibmi.sysNameInAmerican(localPath.name);
-      localPath.member = localPath.member ? this.ibmi.sysNameInAmerican(localPath.member) : undefined;
       target = Tools.qualifyPath(localPath.library, localPath.name, localPath.member || '', localPath.asp || '', true);
+
+      if (this.ibmi.qsysPosixPathsRequireTranslation) {
+        target = this.ibmi.sysNameInAmerican(target);
+      }
     } else {
       target = localPath;
     }

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -1035,7 +1035,7 @@ export default class IBMiContent {
 
     if (assumeMember) {
       // If it's an object, we assume it's a member, therefore let's let qsh handle it (better for variants)
-      target = Tools.qualifyPath(localPath.library, localPath.name, localPath.member || '', localPath.asp || '', true);
+      target = Tools.qualifyPath(localPath.library, localPath.name, localPath.member || '', localPath.asp || '', true, this.ibmi.variantChars.local);
 
       if (this.ibmi.qsysPosixPathsRequireTranslation) {
         target = this.ibmi.sysNameInAmerican(target);

--- a/src/api/Search.ts
+++ b/src/api/Search.ts
@@ -14,7 +14,7 @@ export namespace Search {
       let memberFilter: string|undefined;
 
       if (typeof members === `string`) {
-        memberFilter = connection.sysNameInAmerican(`${members}.MBR`);
+        memberFilter = connection.sysNameInAmerican(`${members}.MBR`, connection.qsysPosixPathsRequireTranslation);
       } else
       if (Array.isArray(members)) {
         if (members.length > connection.maximumArgsLength) {
@@ -31,7 +31,7 @@ export namespace Search {
       // Then search the members
       const result = await connection.sendQsh({
         command: `/usr/bin/grep -inHR -F "${sanitizeSearchTerm(searchTerm)}" ${memberFilter}`,
-        directory: connection.sysNameInAmerican(`${asp ? `/${asp}` : ``}/QSYS.LIB/${library}.LIB/${sourceFile}.FILE`)
+        directory: connection.sysNameInAmerican(`${asp ? `/${asp}` : ``}/QSYS.LIB/${library}.LIB/${sourceFile}.FILE`, connection.qsysPosixPathsRequireTranslation)
       });
 
       if (!result.stderr) {

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -3,6 +3,7 @@ import os from "os";
 import path from "path";
 import { IBMiMessage, IBMiMessages, QsysPath } from './types';
 import { EditorPath } from "../typings";
+import { VariantInfo } from "./IBMi";
 
 export namespace Tools {
   export class SqlError extends Error {
@@ -176,7 +177,7 @@ export namespace Tools {
    * @param member Optional
    * @param iasp Optional: an iASP name
    */
-  export function qualifyPath(library: string, object: string, member?: string, iasp?: string, noEscape?: boolean, localVariants?: string) {
+  export function qualifyPath(library: string, object: string, member?: string, iasp?: string, noEscape?: boolean, localVariants?: VariantInfo) {
     [library, object] = Tools.sanitizeObjNamesForPase([library, object], localVariants);
     member = member ? Tools.sanitizeObjNamesForPase([member], localVariants)[0] : undefined;
     iasp = iasp ? Tools.sanitizeObjNamesForPase([iasp], localVariants)[0] : undefined;
@@ -236,11 +237,12 @@ export namespace Tools {
     return text.charAt(0).toUpperCase() + text.slice(1);
   }
 
-  export function sanitizeObjNamesForPase(libraries: string[], localVariants = `"`): string[] {
+  export function sanitizeObjNamesForPase(libraries: string[], localVariants?: VariantInfo): string[] {
+    const checkChar = localVariants ? localVariants.local[0] : `"`;
     return libraries
       .map(library => {
         const first = library[0];
-        return localVariants.includes(first) ? `"${library}"` : library;
+        return first === checkChar ? `"${library}"` : library;
       });
   }
 

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -176,10 +176,10 @@ export namespace Tools {
    * @param member Optional
    * @param iasp Optional: an iASP name
    */
-  export function qualifyPath(library: string, object: string, member?: string, iasp?: string, noEscape?: boolean) {
-    [library, object] = Tools.sanitizeObjNamesForPase([library, object]);
-    member = member ? Tools.sanitizeObjNamesForPase([member])[0] : undefined;
-    iasp = iasp ? Tools.sanitizeObjNamesForPase([iasp])[0] : undefined;
+  export function qualifyPath(library: string, object: string, member?: string, iasp?: string, noEscape?: boolean, localVariants?: string) {
+    [library, object] = Tools.sanitizeObjNamesForPase([library, object], localVariants);
+    member = member ? Tools.sanitizeObjNamesForPase([member], localVariants)[0] : undefined;
+    iasp = iasp ? Tools.sanitizeObjNamesForPase([iasp], localVariants)[0] : undefined;
 
     const libraryPath = library === `QSYS` ? `QSYS.LIB` : `QSYS.LIB/${library}.LIB`;
     const filePath = object ? `${object}.FILE` : '';
@@ -236,11 +236,11 @@ export namespace Tools {
     return text.charAt(0).toUpperCase() + text.slice(1);
   }
 
-  export function sanitizeObjNamesForPase(libraries: string[]): string[] {
+  export function sanitizeObjNamesForPase(libraries: string[], localVariants = `"`): string[] {
     return libraries
       .map(library => {
-        // Quote libraries starting with #
-        return library.startsWith(`#`) ? `"${library}"` : library;
+        const first = library[0];
+        return localVariants.includes(first) ? `"${library}"` : library;
       });
   }
 

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -177,7 +177,7 @@ export namespace Tools {
    * @param member Optional
    * @param iasp Optional: an iASP name
    */
-  export function qualifyPath(library: string, object: string, member?: string, iasp?: string, noEscape?: boolean, localVariants?: VariantInfo) {
+  export function qualifyPath(library: string, object: string, member?: string, iasp?: string, localVariants?: VariantInfo) {
     [library, object] = Tools.sanitizeObjNamesForPase([library, object], localVariants);
     member = member ? Tools.sanitizeObjNamesForPase([member], localVariants)[0] : undefined;
     iasp = iasp ? Tools.sanitizeObjNamesForPase([iasp], localVariants)[0] : undefined;
@@ -187,7 +187,7 @@ export namespace Tools {
     const memberPath = member ? `/${member}.MBR` : '';
     const fullPath = `${libraryPath}/${filePath}${memberPath}`;
 
-    const result = (iasp && iasp.length > 0 ? `/${iasp}` : ``) + `/${noEscape ? fullPath : Tools.escapePath(fullPath)}`;
+    const result = (iasp && iasp.length > 0 ? `/${iasp}` : ``) + `/${fullPath}`;
     return result;
   }
 
@@ -242,6 +242,7 @@ export namespace Tools {
     return libraries
       .map(library => {
         const first = library[0];
+
         return first === checkChar ? `"${library}"` : library;
       });
   }

--- a/src/api/tests/setup.ts
+++ b/src/api/tests/setup.ts
@@ -10,9 +10,20 @@ export async function setup(project: TestProject) {
     console.log(`Testing connection before tests run since configs do not exist.`);
 
     const conn = await newConnection();
-    disposeConnection(conn);
 
     console.log(`Testing connection complete. Configs written.`);
     console.log(``);
+
+    console.table({
+      "QCCSID": conn.getCcsids().qccsid,
+      "runtimeCcsid": conn.getCcsids().runtimeCcsid,
+      "userDefaultCCSID": conn.getCcsids().userDefaultCCSID,
+      "sshdCcsid": conn.getCcsids().sshdCcsid,
+      "canUseCqsh": conn.canUseCqsh
+    });
+
+    console.log(``);
+
+    disposeConnection(conn);
   }
 }

--- a/src/api/tests/setup.ts
+++ b/src/api/tests/setup.ts
@@ -19,7 +19,9 @@ export async function setup(project: TestProject) {
       "runtimeCcsid": conn.getCcsids().runtimeCcsid,
       "userDefaultCCSID": conn.getCcsids().userDefaultCCSID,
       "sshdCcsid": conn.getCcsids().sshdCcsid,
-      "canUseCqsh": conn.canUseCqsh
+      "canUseCqsh": conn.canUseCqsh,
+      "americanVariants": conn.variantChars.american,
+      "localVariants": conn.variantChars.local,
     });
 
     console.log(``);

--- a/src/api/tests/suites/encoding.test.ts
+++ b/src/api/tests/suites/encoding.test.ts
@@ -179,7 +179,7 @@ describe('Encoding tests', { concurrent: true }, () => {
     });
   });
 
-  it('Listing objects with variants', { timeout: 15000 }, async () => {
+  it('Listing objects with variants', { timeout: 30000 }, async () => {
     const content = connection.getContent();
     if (connection && content) {
       const tempLib = connection.config?.tempLibrary!;

--- a/src/api/tests/suites/encoding.test.ts
+++ b/src/api/tests/suites/encoding.test.ts
@@ -176,10 +176,13 @@ describe('Encoding tests', { concurrent: true }, () => {
 
       const memberContentA = await content?.downloadMemberContent(tempLib, tempSPF, tempMbr);
       expect(memberContentA).toBe(baseContent);
+
+      const resolved = await content?.memberResolve(tempMbr, [{name: tempSPF, library: `QSYS`}, {name: tempSPF, library: `QSY2`}, {name: tempSPF, library: tempLib}]);
+      expect(resolved).toBeTruthy();
     });
   });
 
-  it('Listing objects with variants', { timeout: 30000 }, async () => {
+  it('Listing objects with variants', { timeout: 40000 }, async () => {
     const content = connection.getContent();
     if (connection && content) {
       const tempLib = connection.config?.tempLibrary!;
@@ -188,7 +191,7 @@ describe('Encoding tests', { concurrent: true }, () => {
       let library = `TESTLIB${connection.variantChars.local}`;
       let skipLibrary = false;
       const sourceFile = `${connection.variantChars.local}TESTFIL`;
-      const dataArea = `TSTDTA${connection.variantChars.local}`;
+      const dataArea = `${connection.variantChars.local}TSTDTA`;
       const members: string[] = [];
 
       for (let i = 0; i < 5; i++) {
@@ -236,7 +239,7 @@ describe('Encoding tests', { concurrent: true }, () => {
       };
 
       const nameFilter = await content.getObjectList({ library, types: ["*ALL"], object: `${connection.variantChars.local[0]}*` });
-      expect(nameFilter.length).toBe(1);
+      expect(nameFilter.length).toBe(2);
       expect(nameFilter.some(obj => obj.library === library && obj.type === `*FILE` && obj.name === sourceFile)).toBeTruthy();
 
       const objectList = await content.getObjectList({ library, types: ["*ALL"] });
@@ -258,6 +261,9 @@ describe('Encoding tests', { concurrent: true }, () => {
 
       const [expectedSourceFile] = await content.getObjectList({ library, object: sourceFile, types: ["*SRCPF"] });
       checkFile(expectedSourceFile);
+
+      const resolvedObject = await content.objectResolve(dataArea, [`QSYS`, `QSYS2`, library]);
+      expect(resolvedObject).toBeTruthy();
     }
   });
 

--- a/src/api/tests/suites/encoding.test.ts
+++ b/src/api/tests/suites/encoding.test.ts
@@ -343,6 +343,9 @@ describe('Encoding tests', { concurrent: true }, () => {
       expect(files.some(f => f.name === connection.sysNameInAmerican(variantMember) + `.MBR`)).toBeTruthy();
       expect(files.some(f => f.name === connection.sysNameInAmerican(testMember) + `.MBR`)).toBeTruthy();
 
+      const count = await connection.getContent().countMembers({library: tempLib, name: testFile});
+      expect(count).toBe(2);
+
       const eol = `\r\n`;
       const memberContents = [`**free`, `dsply 'Hello world';`, ``, ``, `return;`].join(eol);
       await connection.getContent().uploadMemberContent(tempLib, testFile, testMember, memberContents);


### PR DESCRIPTION
Enhance input conversion logic to account for CCSID in various contexts, ensuring proper translation for system commands and SQL statements. Adjustments made to improve path handling and user feedback during checks.

Fixes #2519

### How to test

1. List members/objects in the Object Browser with variant chats
2. Open source members up
3. Compile source members
4. Run the test cases