### PR TITLE
Add makeid function export to VscodeTools namespace

### DIFF
--- a/src/ui/Tools.ts
+++ b/src/ui/Tools.ts
@@ -213,4 +213,5 @@ export namespace VscodeTools {
   export const parseAttrDate = Tools.parseAttrDate;
   export const normalizePath = Tools.normalizePath;
   export const resolvePath = Tools.resolvePath;
+  export const makeid = Tools.makeid;
 }


### PR DESCRIPTION
Add missing export from Tools class.

We do this as we don't export the internal Tools namepsace.