### PR TITLE
Add STRDLM and STRESCCHR options to CopyToImport component

### DIFF
--- a/src/api/components/copyToImport.ts
+++ b/src/api/components/copyToImport.ts
@@ -71,7 +71,9 @@ export class CopyToImport implements IBMiComponent {
       RMVBLANK: `*TRAILING`,
       ADDCOLNAM: `*SQL`,
       FLDDLM: `','`,
-      DECPNT: `*PERIOD`
+      DECPNT: `*PERIOD`,
+      STRDLM: `*DBLQUOTE`,
+      STRESCCHR: `*STRDLM`
     }).replaceAll(`'`, `''`) + `')`);
 
     return {


### PR DESCRIPTION
Introduce new options for string delimiter and escape character in the CopyToImport component to ensure lines as escaped and can be parsed correctly.

Fixes #2553.

### How to test

1. Open members that have double quotes in the lines (`"`)
2. Run the test cases