### PR TITLE
Fix failed IFS download notification

### DIFF
--- a/src/ui/views/ifsBrowser.ts
+++ b/src/ui/views/ifsBrowser.ts
@@ -895,7 +895,7 @@ Do you want to replace it?`, target))) {
                 .then(open => open ? vscode.commands.executeCommand('revealFileInOS', saveIntoDirectory ? vscode.Uri.joinPath(downloadLocationURI, path.basename(items[0].path)) : downloadLocationURI) : undefined);
             }
             catch (e: any) {
-              vscode.window.showErrorMessage(l10n.t(`Error downloading file(s): {0}`, e));
+              vscode.window.showErrorMessage(l10n.t(`Error downloading file(s): {0}`, String(e)));
             }
           });
         }


### PR DESCRIPTION
### Changes
When the download of an IFS file fails, the error message is not correctly displayed:
![image](https://github.com/user-attachments/assets/7508aa5f-7707-47e0-96fb-f08d9621e735)

This PR fixes the notification to correctly show the error message:
![image](https://github.com/user-attachments/assets/c1ab0ea4-f280-40c5-aafe-24f6ec1fe09c)