### PR TITLE
Fixed droping QSYS members into IFS folder

### DIFF
--- a/src/ui/views/objectBrowser.ts
+++ b/src/ui/views/objectBrowser.ts
@@ -9,7 +9,7 @@ import { Search } from "../../api/Search";
 import { Tools } from "../../api/Tools";
 import { getMemberUri } from "../../filesystems/qsys/QSysFs";
 import { instance } from "../../instantiate";
-import { CommandResult, DefaultOpenMode, FilteredItem, FocusOptions, IBMiMember, IBMiObject, MemberItem, ModuleExport, OBJECT_BROWSER_MIMETYPE, ObjectFilters, ObjectItem, ProgramExportImportInfo, WithLibrary } from "../../typings";
+import { CommandResult, DefaultOpenMode, FilteredItem, FocusOptions, IBMiMember, IBMiObject, MemberItem, ModuleExport, ObjectFilters, ObjectItem, ProgramExportImportInfo, WithLibrary } from "../../typings";
 import { editFilter } from "../../webviews/filters";
 import { VscodeTools } from "../Tools";
 import { BrowserItem, BrowserItemParameters } from "../types";
@@ -420,7 +420,7 @@ class ObjectBrowserMemberItemDragAndDrop implements vscode.TreeDragAndDropContro
   readonly dropMimeTypes = [];
 
   handleDrag(source: readonly ObjectBrowserMemberItem[], dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken) {
-    dataTransfer.set(OBJECT_BROWSER_MIMETYPE, new vscode.DataTransferItem(source.map(item => item.path).join(URI_LIST_SEPARATOR)));
+    //A URI list is automatically produced
   }
 }
 

--- a/src/ui/views/objectBrowser.ts
+++ b/src/ui/views/objectBrowser.ts
@@ -416,13 +416,11 @@ class ObjectBrowserMemberItem extends ObjectBrowserItem implements MemberItem {
 }
 
 class ObjectBrowserMemberItemDragAndDrop implements vscode.TreeDragAndDropController<ObjectBrowserMemberItem> {
-  readonly dragMimeTypes = [OBJECT_BROWSER_MIMETYPE];
+  readonly dragMimeTypes = [];
   readonly dropMimeTypes = [];
 
   handleDrag(source: readonly ObjectBrowserMemberItem[], dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken) {
-    dataTransfer.set(OBJECT_BROWSER_MIMETYPE, new vscode.DataTransferItem(source.filter(item => item.resourceUri?.scheme === `member`)
-      .map(item => item.resourceUri)
-      .join(URI_LIST_SEPARATOR)));
+    dataTransfer.set(OBJECT_BROWSER_MIMETYPE, new vscode.DataTransferItem(source.map(item => item.path).join(URI_LIST_SEPARATOR)));
   }
 }
 


### PR DESCRIPTION
### Changes
For some reason, dropping members into the IFS browser now fails with this message.
![image](https://github.com/user-attachments/assets/21bb2f94-c07c-4c7c-9956-6603b6fe3498)

Getting the members items from the `dataTransfer` object doesn't give the expected result (anymore?).
However, a URI list is automatically added to the `dataTransfer` when dragging items, so we now use that to perform the member copy to IFS operation.

### How to test this PR

1. Drag and drop a member from the Object Browser into an IFS folder in the IFS browser
2. The member must be copied to a streamfile in the target folder.

### Checklist
* [x] have tested my change