### PR TITLE
Added Compare with each other command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1071,9 +1071,15 @@
 				"category": "IBM i"
 			},
 			{
-				"command": "code-for-ibmi.compareWithSelected",
+				"command": "code-for-ibmi.compareWithSelected.short",
 				"enablement": "code-for-ibmi:connected",
 				"title": "Selected",
+				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.compareWithSelected",
+				"enablement": "code-for-ibmi:connected",
+				"title": "Compare with selected",
 				"category": "IBM i"
 			},
 			{
@@ -1083,25 +1089,47 @@
 				"category": "IBM i"
 			},
 			{
-				"command": "code-for-ibmi.compareCurrentFileWithMember",
+				"command": "code-for-ibmi.compareCurrentFileWithMember.short",
 				"enablement": "code-for-ibmi:connected",
 				"title": "Member...",
 				"category": "IBM i"
 			},
 			{
-				"command": "code-for-ibmi.compareCurrentFileWithStreamFile",
+				"command": "code-for-ibmi.compareCurrentFileWithMember",
+				"enablement": "code-for-ibmi:connected",
+				"title": "Compare with member...",
+				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.compareCurrentFileWithStreamFile.short",
 				"enablement": "code-for-ibmi:connected",
 				"title": "IFS file...",
 				"category": "IBM i"
 			},
 			{
-				"command": "code-for-ibmi.compareCurrentFileWithLocal",
+				"command": "code-for-ibmi.compareCurrentFileWithStreamFile",
+				"enablement": "code-for-ibmi:connected",
+				"title": "Compare with IFS file...",
+				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.compareCurrentFileWithLocal.short",
 				"title": "Local file...",
 				"category": "IBM i"
 			},
 			{
-				"command": "code-for-ibmi.compareWithActiveFile",
+				"command": "code-for-ibmi.compareCurrentFileWithLocal",
+				"title": "Compare with local file...",
+				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.compareWithActiveFile.short",
 				"title": "Active file",
+				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.compareWithActiveFile",
+				"title": "Compare with active file",
 				"category": "IBM i"
 			},
 			{
@@ -1839,11 +1867,11 @@
 			},
 			{
 				"id": "code-for-ibmi.compareWith",
-				"label": "Compare with..."
+				"label": "Compare with"
 			},
 			{
 				"id": "code-for-ibmi.compareWithLocal",
-				"label": "Compare with..."
+				"label": "Compare with"
 			}
 		],
 		"menus": {
@@ -1892,23 +1920,23 @@
 			],
 			"code-for-ibmi.compareWith": [
 				{
-					"command": "code-for-ibmi.compareWithSelected",
+					"command": "code-for-ibmi.compareWithSelected.short",
 					"when": "!listMultiSelection"
 				},
 				{
-					"command": "code-for-ibmi.compareCurrentFileWithMember",
+					"command": "code-for-ibmi.compareCurrentFileWithMember.short",
 					"when": "!listMultiSelection"		
 				},
 				{
-					"command": "code-for-ibmi.compareCurrentFileWithStreamFile",
+					"command": "code-for-ibmi.compareCurrentFileWithStreamFile.short",
 					"when": "!listMultiSelection"
 				},
 				{
-					"command": "code-for-ibmi.compareCurrentFileWithLocal",
+					"command": "code-for-ibmi.compareCurrentFileWithLocal.short",
 					"when": "!listMultiSelection"
 				},
 				{
-					"command": "code-for-ibmi.compareWithActiveFile",
+					"command": "code-for-ibmi.compareWithActiveFile.short",
 					"when": "!listMultiSelection"
 				},
 				{
@@ -1918,19 +1946,19 @@
 			],
 			"code-for-ibmi.compareWithLocal": [
 				{
-					"command": "code-for-ibmi.compareCurrentFileWithMember",
+					"command": "code-for-ibmi.compareCurrentFileWithMember.short",
 					"when": "code-for-ibmi:connected"
 				},
 				{
-					"command": "code-for-ibmi.compareCurrentFileWithStreamFile",
+					"command": "code-for-ibmi.compareCurrentFileWithStreamFile.short",
 					"when": "code-for-ibmi:connected"
 				},
 				{
-					"command": "code-for-ibmi.compareCurrentFileWithLocal",
+					"command": "code-for-ibmi.compareCurrentFileWithLocal.short",
 					"when": "!explorerResourceIsFolder"
 				},
 				{
-					"command": "code-for-ibmi.compareWithActiveFile",
+					"command": "code-for-ibmi.compareWithActiveFile.short",
 					"when": "!explorerResourceIsFolder"
 				}
 			],
@@ -1998,6 +2026,30 @@
 				{
 					"command": "code-for-ibmi.compareCurrentFileWithMember",
 					"when": "code-for-ibmi:connected"
+				},
+				{
+					"command": "code-for-ibmi.compareWithSelected.short",
+					"when": "never"
+				},
+				{
+					"command": "code-for-ibmi.compareCurrentFileWithMember.short",
+					"when": "never"		
+				},
+				{
+					"command": "code-for-ibmi.compareCurrentFileWithStreamFile.short",
+					"when": "never"
+				},
+				{
+					"command": "code-for-ibmi.compareCurrentFileWithLocal.short",
+					"when": "never"
+				},
+				{
+					"command": "code-for-ibmi.compareWithActiveFile.short",
+					"when": "never"
+				},
+				{
+					"command": "code-for-ibmi.compareWithEachOther",
+					"when": "never"
 				},
 				{
 					"command": "code-for-ibmi.goToFileReadOnly",
@@ -2289,10 +2341,6 @@
 				},
 				{
 					"command": "code-for-ibmi.compareWithActiveFile",
-					"when": "never"
-				},
-				{
-					"command": "code-for-ibmi.compareWithEachOther",
 					"when": "never"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -1073,29 +1073,35 @@
 			{
 				"command": "code-for-ibmi.compareWithSelected",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Compare with selected",
+				"title": "Selected",
+				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.compareWithEachOther",
+				"enablement": "code-for-ibmi:connected",
+				"title": "Each other",
 				"category": "IBM i"
 			},
 			{
 				"command": "code-for-ibmi.compareCurrentFileWithMember",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Compare with member...",
+				"title": "Member...",
 				"category": "IBM i"
 			},
 			{
 				"command": "code-for-ibmi.compareCurrentFileWithStreamFile",
 				"enablement": "code-for-ibmi:connected",
-				"title": "Compare with IFS file...",
+				"title": "IFS file...",
 				"category": "IBM i"
 			},
 			{
 				"command": "code-for-ibmi.compareCurrentFileWithLocal",
-				"title": "Compare with local file...",
+				"title": "Local file...",
 				"category": "IBM i"
 			},
 			{
 				"command": "code-for-ibmi.compareWithActiveFile",
-				"title": "Compare with active file",
+				"title": "Active file",
 				"category": "IBM i"
 			},
 			{
@@ -1887,23 +1893,27 @@
 			"code-for-ibmi.compareWith": [
 				{
 					"command": "code-for-ibmi.compareWithSelected",
-					"when": "view =~ /^(object|ifs)Browser$/ && (viewItem =~ /^member.*$/ || viewItem == streamfile)"
+					"when": "!listMultiSelection"
 				},
 				{
 					"command": "code-for-ibmi.compareCurrentFileWithMember",
-					"when": "view =~ /^(object|ifs)Browser$/ && (viewItem =~ /^member.*$/ || viewItem == streamfile)"
+					"when": "!listMultiSelection"		
 				},
 				{
 					"command": "code-for-ibmi.compareCurrentFileWithStreamFile",
-					"when": "view =~ /^(object|ifs)Browser$/ && (viewItem =~ /^member.*$/ || viewItem == streamfile)"
+					"when": "!listMultiSelection"
 				},
 				{
 					"command": "code-for-ibmi.compareCurrentFileWithLocal",
-					"when": "view =~ /^(object|ifs)Browser$/ && (viewItem =~ /^member.*$/ || viewItem == streamfile)"
+					"when": "!listMultiSelection"
 				},
 				{
 					"command": "code-for-ibmi.compareWithActiveFile",
-					"when": "view =~ /^(object|ifs)Browser$/ && (viewItem =~ /^member.*$/ || viewItem == streamfile)"
+					"when": "!listMultiSelection"
+				},
+				{
+					"command": "code-for-ibmi.compareWithEachOther",
+					"when": "listDoubleSelection"
 				}
 			],
 			"code-for-ibmi.compareWithLocal": [
@@ -2282,6 +2292,10 @@
 					"when": "never"
 				},
 				{
+					"command": "code-for-ibmi.compareWithEachOther",
+					"when": "never"
+				},
+				{
 					"command": "code-for-ibmi.ifs.find",
 					"when": "never"
 				},
@@ -2635,11 +2649,12 @@
 				},
 				{
 					"command": "code-for-ibmi.selectForCompare",
-					"when": "view =~ /^(object|ifs)Browser$/ && (viewItem =~ /^member.*$/ || viewItem == streamfile)",
+					"when": "view =~ /^(object|ifs)Browser$/ && (viewItem =~ /^member.*$/ || viewItem == streamfile) && !listMultiSelection",
 					"group": "7_sourceFileStuff@1"
 				},
 				{
 					"submenu": "code-for-ibmi.compareWith",
+					"when": "view =~ /^(object|ifs)Browser$/ && (viewItem =~ /^member.*$/ || viewItem == streamfile)",
 					"group": "7_sourceFileStuff@2"
 				},
 				{

--- a/src/commands/compare.ts
+++ b/src/commands/compare.ts
@@ -1,20 +1,19 @@
 import { Disposable, Uri, commands, l10n, window } from "vscode";
-import Instance from "../Instance";
 import { BrowserItem } from "../typings";
 
-let selectedForCompare: Uri;
+let selectedForCompare: Uri | undefined;
 
 const VSCODE_DIFF_COMMAND = `vscode.diff`;
 
-export function registerCompareCommands(instance: Instance): Disposable[] {
+export function registerCompareCommands(): Disposable[] {
   return [
-    commands.registerCommand(`code-for-ibmi.selectForCompare`, async (node) => {
-      if (node) {
+    commands.registerCommand(`code-for-ibmi.selectForCompare`, async (node: BrowserItem) => {
+      if (node?.resourceUri) {
         selectedForCompare = node.resourceUri;
-        window.showInformationMessage(`Selected ${node.path} for compare.`);
+        window.showInformationMessage(`Selected ${selectedForCompare.path} for compare.`);
       }
     }),
-    commands.registerCommand(`code-for-ibmi.compareWithSelected`, async (node) => {
+    commands.registerCommand(`code-for-ibmi.compareWithSelected`, async (node: BrowserItem) => {
       if (selectedForCompare) {
         let uri;
         if (node) {
@@ -53,10 +52,10 @@ export function registerCompareCommands(instance: Instance): Disposable[] {
     commands.registerCommand(`code-for-ibmi.compareCurrentFileWithLocal`, async (node) => {
       compareCurrentFile(node, `file`);
     }),
-    commands.registerCommand(`code-for-ibmi.compareWithActiveFile`, async (node) => {
+    commands.registerCommand(`code-for-ibmi.compareWithActiveFile`, async (node: BrowserItem | Uri) => {
       let selectedFile;
       if (node) {
-        if (node.scheme === `streamfile` || node.constructor.name === `IFSFileItem` || node.constructor.name === `ObjectBrowserItem`) {
+        if (node instanceof BrowserItem) {
           selectedFile = node.resourceUri;
         } else if (node.scheme === `file`) {
           selectedFile = node
@@ -96,11 +95,11 @@ export function registerCompareCommands(instance: Instance): Disposable[] {
   ]
 }
 
-async function compareCurrentFile(node: any, scheme: `streamfile` | `file` | `member`) {
+async function compareCurrentFile(node: BrowserItem | Uri, scheme: `streamfile` | `file` | `member`) {
   let currentFile: Uri | undefined;
   // If we are comparing with an already targeted node
   if (node) {
-    if (node.resourceUri) {
+    if (node instanceof BrowserItem) {
       currentFile = node.resourceUri;
     } else if (node.scheme === `file`) {
       currentFile = node

--- a/src/commands/compare.ts
+++ b/src/commands/compare.ts
@@ -1,5 +1,6 @@
-import { commands, window, Uri, l10n, Disposable } from "vscode";
+import { Disposable, Uri, commands, l10n, window } from "vscode";
 import Instance from "../Instance";
+import { BrowserItem } from "../typings";
 
 let selectedForCompare: Uri;
 
@@ -79,6 +80,13 @@ export function registerCompareCommands(instance: Instance): Disposable[] {
         window.showInformationMessage(l10n.t(`No file is open or selected`));
       }
     }),
+    commands.registerCommand("code-for-ibmi.compareWithEachOther", async (node: BrowserItem, nodes: BrowserItem[]) => {
+      const left = nodes.at(0)?.resourceUri;
+      const right = nodes.at(1)?.resourceUri;
+      if (left) {
+        commands.executeCommand(VSCODE_DIFF_COMMAND, left, right);
+      }
+    })
   ]
 }
 

--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -1,20 +1,19 @@
 
 import * as vscode from "vscode";
-import { onCodeForIBMiConfigurationChange } from "./config/Configuration";
-import Instance from "./Instance";
-import { Terminal } from './ui/Terminal';
 import { getDebugServiceDetails } from './api/configuration/DebugConfiguration';
-import { debugPTFInstalled, isDebugEngineRunning } from './debug/server';
-import { setupGitEventHandler } from './filesystems/local/git';
 import { registerActionsCommands } from './commands/actions';
 import { registerCompareCommands } from './commands/compare';
 import { registerConnectionCommands } from './commands/connection';
 import { registerOpenCommands } from './commands/open';
 import { registerPasswordCommands } from './commands/password';
+import { onCodeForIBMiConfigurationChange } from "./config/Configuration";
+import { debugPTFInstalled, isDebugEngineRunning } from './debug/server';
+import { setupGitEventHandler } from './filesystems/local/git';
 import { QSysFS } from "./filesystems/qsys/QSysFs";
+import Instance from "./Instance";
+import { Terminal } from './ui/Terminal';
 import { ActionsUI } from './webviews/actions';
 import { VariablesUI } from "./webviews/variables";
-import IBMi from "./api/IBMi";
 
 export let instance: Instance;
 
@@ -74,7 +73,7 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
 
     ...registerOpenCommands(instance),
 
-    ...registerCompareCommands(instance),
+    ...registerCompareCommands(),
 
     ...registerActionsCommands(instance),
 


### PR DESCRIPTION
### Changes
This PR adds a `Compare with...each other` command that is enabled when exactly two members or streamfiles are selected in there respective browser:
![image](https://github.com/user-attachments/assets/4fc46536-6846-4720-a976-0ba2209f5a44)

The `Compare with...` submenu items have been renamed too, to avoid redundancy.
![image](https://github.com/user-attachments/assets/4c4df58c-4a4e-4652-8bb0-fa69ce661991)

### How to test this PR
1. Select exactly two members or streamfiles
2. Select the `Each other` command in the `Compare with...` menu
3. Select just one member or streamfile: the menu must show 6 commands
4. Select more than two members/streamfiles: the menu must not be shown

### Checklist
* [x] have tested my change