### PR TITLE
Fix custom variable editor

### DIFF
--- a/src/webviews/CustomUI.ts
+++ b/src/webviews/CustomUI.ts
@@ -619,6 +619,7 @@ export class Field {
           <vscode-form-group variant="settings-group">
               ${this.renderLabel()}
               ${this.renderDescription()}
+              <br />
               <vscode-tree id="${this.id}"></vscode-tree>
           </vscode-form-group>`;
 

--- a/src/webviews/variables/index.ts
+++ b/src/webviews/variables/index.ts
@@ -23,7 +23,7 @@ export namespace VariablesUI {
   }
 
   async function openVariablesList() {
-    const config = instance.getConfig();
+    const config = instance.getConnection()?.getConfig();
     if (config) {
       const variables = config.customVariables;
 
@@ -54,7 +54,7 @@ export namespace VariablesUI {
   }
 
   async function editVariable(id?: number) {
-    const config = instance.getConfig();
+    const config = instance.getConnection()?.getConfig();
     if (config) {
       const allVariables = config.customVariables;
       const currentVariable: CustomVariable = id !== undefined ? allVariables[id] : { name: ``, value: `` };

--- a/src/webviews/variables/index.ts
+++ b/src/webviews/variables/index.ts
@@ -22,7 +22,7 @@ export namespace VariablesUI {
     )
   }
 
-  export async function openVariablesList() {
+  async function openVariablesList() {
     const config = instance.getConfig();
     if (config) {
       const variables = config.customVariables;

--- a/src/webviews/variables/index.ts
+++ b/src/webviews/variables/index.ts
@@ -1,103 +1,91 @@
 import vscode from "vscode";
-import { CustomUI } from "../CustomUI";
-import { instance } from "../../instantiate";
 import IBMi from "../../api/IBMi";
+import { instance } from "../../instantiate";
+import { CustomVariable } from "../../typings";
+import { CustomUI } from "../CustomUI";
 
-export class VariablesUI {
+type VariablesListPage = {
+  value?: string
+  buttons?: "newVariable"
+}
 
-  /**
-   * Called to log in to an IBM i
-   * @param {vscode.ExtensionContext} context
-   */
-  static initialize(context: vscode.ExtensionContext) {
+type EditVariablePage = {
+  name: string
+  value: string
+  buttons?: "save" | "delete"
+}
+
+export namespace VariablesUI {
+  export function initialize(context: vscode.ExtensionContext) {
     context.subscriptions.push(
-      vscode.commands.registerCommand(`code-for-ibmi.showVariableMaintenance`, async () => {
-        this.MainMenu();
-      })
+      vscode.commands.registerCommand(`code-for-ibmi.showVariableMaintenance`, openVariablesList)
     )
   }
 
-  static async MainMenu() {
+  export async function openVariablesList() {
     const config = instance.getConfig();
     if (config) {
-      let variables = config.customVariables;
+      const variables = config.customVariables;
 
       const ui = new CustomUI()
         .addTree(`variable`, `Work with Variables`, [
           ...variables.map((variable, index) => ({
-            label: `&${variable.name}: \`${variable.value}\``,
+            label: `&${variable.name}: '${variable.value}'`,
             value: String(index)
           })).sort((a, b) => a.label.localeCompare(b.label))
         ], `Create or maintain custom variables. Custom variables can be used in any Action in this connection.`)
         .addButtons({ id: `newVariable`, label: `New Variable` });
 
-      const page = await ui.loadPage<any>(`Work with Variables`);
+      const page = await ui.loadPage<VariablesListPage>(`Work with Variables`);
       if (page && page.data) {
         page.panel.dispose();
 
         const data = page.data;
         switch (data.buttons) {
           case `newVariable`:
-            this.WorkVariable(-1);
+            editVariable();
             break;
           default:
-            this.WorkVariable(Number(data.variable));
+            editVariable(Number(data.value));
             break;
         }
       }
     }
   }
 
-  /**
-   * Edit an existing action
-   * @param {number} id Existing action index, or -1 for a brand new index
-   */
-  static async WorkVariable(id: number) {
+  async function editVariable(id?: number) {
     const config = instance.getConfig();
     if (config) {
-      let allVariables = config.customVariables;
-      let currentVariable;
-
-      if (id >= 0) {
-        //Fetch existing variable
-        currentVariable = allVariables[id];
-
-      } else {
-        //Otherwise.. prefill with defaults
-        currentVariable = {
-          name: ``,
-          value: ``
-        }
-      }
+      const allVariables = config.customVariables;
+      const currentVariable: CustomVariable = id !== undefined ? allVariables[id] : { name: ``, value: `` };
 
       const ui = new CustomUI()
         .addInput(`name`, `Variable name`, `<code>&</code> not required. Will be forced uppercase.`, { default: currentVariable.name })
         .addInput(`value`, `Variable value`, ``, { default: currentVariable.value })
         .addButtons({ id: `save`, label: `Save` }, { id: `delete`, label: `Delete` });
 
-      const page = await ui.loadPage<any>(`Work with Variable`);
+      const page = await ui.loadPage<EditVariablePage>(`Work with Variable`);
       if (page && page.data) {
         page.panel.dispose();
 
         const data = page.data;
         switch (data.buttons) {
           case `delete`:
-            if (id >= 0) {
+            if (id !== undefined) {
               allVariables.splice(id, 1);
               config.customVariables = allVariables;
               await IBMi.connectionManager.update(config);
             }
             break;
 
-          default: //save
-            data.name = data.name.replace(new RegExp(` `, `g`), `_`).toUpperCase();
+          case "save":
+          default:
+            data.name = data.name.replace(/ /g, '_')
+              .replace(/&/g, '')
+              .toUpperCase();
 
-            const newAction = {
-              name: data.name,
-              value: data.value
-            };
-
-            if (id >= 0) {
+            const newAction = { ...data };
+            if (id !== undefined) {
               allVariables[id] = newAction;
             } else {
               allVariables.push(newAction);
@@ -107,10 +95,9 @@ export class VariablesUI {
             await IBMi.connectionManager.update(config);
             break;
         }
-
       }
 
-      this.MainMenu();
+      openVariablesList();
     }
   }
 


### PR DESCRIPTION
### Changes
Fixes #2590 

- Fixed variable edition (variable id was not retrieved correctly
- Added types for Custom Variables pages (list and editor)
- Removes any `&` in variable name
- Turn static class into namespace and refactored the code a bit

### How to test this PR
1. Open the custom variables list
2. Create a new variable: it must appear in the list
  - Try to start the name with `&` : it must be removed
4. Edit the variable: save and the changes should appear in the list
5. Delete the variable: it must be removed from the list


### Checklist
* [x] have tested my change