### PR TITLE
Add setting to write Actions output to an IFS file

### DIFF
--- a/package.json
+++ b/package.json
@@ -606,6 +606,10 @@
 							"runOnProtected": {
 								"type": "boolean",
 								"description": "If enabled, this Action will be allowed to run on protected/read only targets."
+							},
+							"outputToFile": {
+								"type": "string",
+								"description": "If defined, a copy of the output will be put in the defined location; supports variable replacement."
 							}
 						}
 					},

--- a/src/api/tests/suites/variables.test.ts
+++ b/src/api/tests/suites/variables.test.ts
@@ -1,0 +1,77 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { Variables } from '../../variables';
+import { CONNECTION_TIMEOUT, disposeConnection, newConnection } from '../connection';
+
+describe(`variables tests`, { concurrent: true }, () => {
+  const variables = new Variables();
+
+  beforeAll(async () => {
+    expect(variables.size).toBe(0);
+    variables.set("&FOO", "bar")
+      .set("&FOOTWO", "bartwo")
+      .set("&FOOTHREE", "barthree");
+  }, CONNECTION_TIMEOUT),
+
+    it('Variables get', () => {
+      expect(variables.size).toBe(3);
+      expect(variables.get("&FOO")).toBe("bar");
+      expect(variables.get("&FOOTWO")).toBe("bartwo");
+      expect(variables.get("&FOOTHREE")).toBe("barthree");
+      expect(variables.get("&FOOFIGHTERS")).toBeUndefined();
+    }),
+
+    it('Variables copy', () => {
+      const variablesCopy = new Variables(undefined, variables);
+      expect(variablesCopy.size).toBe(3);
+      expect(variablesCopy.get("&FOO")).toBe("bar");
+      expect(variablesCopy.get("&FOOTWO")).toBe("bartwo");
+      expect(variablesCopy.get("&FOOTHREE")).toBe("barthree");
+      expect(variablesCopy.get("&FOOFIGHTERS")).toBeUndefined();
+    }),
+
+    it('Variables expansion', () => {
+      const vars = new Variables();
+      vars.set("&PARAMETER", "TYPE(&TYPE)");
+      vars.set("&TYPE", "*PGM");
+
+      const input = "CRTSOMETHING &PARAMETER";
+      expect(vars.expand(input)).toBe("CRTSOMETHING TYPE(*PGM)");
+
+    }),
+
+    it('To Pase variables', () => {
+      const paseVariables = variables.toPaseVariables();
+      expect(paseVariables["FOO"]).toBe("bar");
+      expect(paseVariables["FOOTWO"]).toBe("bartwo");
+      expect(paseVariables["FOOTHREE"]).toBe("barthree");
+      expect(paseVariables["FOOFIGHTERS"]).toBeUndefined();
+    })
+
+  it('Connection variables', async () => {
+    const connection = await newConnection();
+    const config = connection.getConfig();
+    const customVariables = config.customVariables
+    try {
+      customVariables.push(
+        { name: "CUSTOM", value: "value" },
+        { name: "WARCRY", value: "Fus Roh Dah!" },
+        { name: "EXPANDED", value: `I am &USERNAME!` }
+      );
+      const connectionVariables = new Variables(connection);
+      expect(connectionVariables.get("&USERNAME")).toBe(connection.currentUser);
+      expect(connectionVariables.get("{usrprf}")).toBe(connectionVariables.get("&USERNAME"));
+      expect(connectionVariables.get("&HOST")).toBe(connection.currentHost);
+      expect(connectionVariables.get("{host}")).toBe(connectionVariables.get("&HOST"));
+      expect(connectionVariables.get("&HOME")).toBe(config.homeDirectory);
+      expect(connectionVariables.get("&WORKDIR")).toBe(connectionVariables.get("&HOME"));
+
+      expect(connectionVariables.get("&CUSTOM")).toBe("value");
+      expect(connectionVariables.get("&WARCRY")).toBe("Fus Roh Dah!");
+      expect(connectionVariables.get("&EXPANDED")).toBe(`I am ${connectionVariables.get("&USERNAME")}!`);
+    }
+    finally {
+      customVariables.splice(0, customVariables.length);
+      disposeConnection(connection);
+    }
+  })
+});

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -43,15 +43,16 @@ export interface CommandResult {
 }
 
 export interface Action {
-  name: string;
-  command: string;
-  type?: ActionType;
-  environment: ActionEnvironment;
-  extensions?: string[];
-  deployFirst?: boolean;
-  postDownload?: string[];
-  refresh?: ActionRefresh;
-  runOnProtected?: boolean;
+  name: string
+  command: string
+  type?: ActionType
+  environment: ActionEnvironment
+  extensions?: string[]
+  deployFirst?: boolean
+  postDownload?: string[]
+  refresh?: ActionRefresh
+  runOnProtected?: boolean
+  outputToFile?: string
 }
 
 export interface ConnectionData {
@@ -190,22 +191,23 @@ export interface AspInfo {
 }
 
 export interface ProgramExportImportInfo {
-    programLibrary: string,
-    programName: string,
-    objectType: string,
-    symbolName: string,
-    symbolUsage: string,
-    argumentOptimization: string,
-    dataItemSize: number
+  programLibrary: string,
+  programName: string,
+  objectType: string,
+  symbolName: string,
+  symbolUsage: string,
+  argumentOptimization: string,
+  dataItemSize: number
 }
 
 export interface ModuleExport {
-    moduleLibrary: string,
-    moduleName: string,
-    moduleAttr: string,
-    symbolName: string,
-    symbolType: string,
-    argumentOptimization: string,
+  moduleLibrary: string,
+  moduleName: string,
+  moduleAttr: string,
+  symbolName: string,
+  symbolType: string,
+  argumentOptimization: string,
 }
 
 export * from "./configuration/config/types";
+

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,3 +1,4 @@
+import { Variables } from "./variables";
 
 export type DeploymentMethod = "all" | "staged" | "unstaged" | "changed" | "compare";
 
@@ -13,7 +14,6 @@ export interface StandardIO {
 export type ActionType = "member" | "streamfile" | "object" | "file";
 export type ActionRefresh = "no" | "parent" | "filter" | "browser";
 export type ActionEnvironment = "ile" | "qsh" | "pase";
-export type Variable = Record<string, string>;
 
 export enum CcsidOrigin {
   User = "user",
@@ -25,7 +25,7 @@ export interface RemoteCommand {
   command: string;
   environment?: ActionEnvironment;
   cwd?: string;
-  env?: Record<string, string>;
+  env?: Record<string, string> | Variables;
   noLibList?: boolean
 }
 

--- a/src/api/variables.ts
+++ b/src/api/variables.ts
@@ -1,0 +1,58 @@
+import IBMi from "./IBMi";
+
+export class Variables extends Map<string, string> {
+  constructor(connection?: IBMi, variables?: Record<string, string> | Map<string, string>) {
+    super(variables instanceof Map ? variables : variables ? Object.entries(variables) : new Map);
+
+    if (connection) {
+      const config = connection.getConfig();
+      //Add default variables
+      this.set(`&BUILDLIB`, this.get(`CURLIB`) || config.currentLibrary);
+      if (!this.has(`&CURLIB`)) {
+        this.set(`&CURLIB`, config.currentLibrary);
+      }
+      if (!this.has(`\\*CURLIB`)) {
+        this.set(`\\*CURLIB`, config.currentLibrary);
+      }
+      this.set(`&USERNAME`, connection.currentUser)
+        .set(`{usrprf}`, connection.currentUser)
+        .set(`&HOST`, connection.currentHost)
+        .set(`{host}`, connection.currentHost)
+        .set(`&HOME`, config.homeDirectory)
+        .set(`&WORKDIR`, config.homeDirectory);
+
+      for (const variable of config.customVariables) {
+        this.set(`&${variable.name.toUpperCase()}`, variable.value);
+      }
+    }
+  }
+
+  set(key: string, value: string): this {
+    super.set(key, value);
+    this.expandVariables();
+    return this;
+  }
+
+  private expandVariables() {
+    for (const [key, value] of this.entries()) {
+      super.set(key, this.expand(value, [key]));
+    }
+  }
+
+  public expand(input: string, keysToOmit: string[] = []) {
+    for (const [key, value] of this.entries()) {
+      if (!keysToOmit.includes(key)) {
+        input = input.replace(new RegExp(key, `g`), value);
+      }
+    }
+    return input;
+  }
+
+  toPaseVariables(): Record<string, string> {
+    const variables: Record<string, string> = {};
+    for (const [key, value] of this.entries()) {
+      variables[key.startsWith('&') ? key.substring(1) : key] = value;
+    }
+    return variables;
+  }
+}

--- a/src/webviews/actions/index.ts
+++ b/src/webviews/actions/index.ts
@@ -2,11 +2,11 @@ import vscode from "vscode";
 
 import { CustomUI, Tab } from "../CustomUI";
 
+import IBMi from "../../api/IBMi";
 import { Tools } from "../../api/Tools";
 import { instance } from "../../instantiate";
 import { Action, ActionEnvironment, ActionRefresh, ActionType } from "../../typings";
 import { getVariablesInfo } from "./varinfo";
-import IBMi from "../../api/IBMi";
 
 type MainMenuPage = {
   buttons?: 'newAction' | 'duplicateAction'
@@ -21,6 +21,7 @@ type ActionPage = {
   environment: ActionEnvironment
   refresh: ActionRefresh
   runOnProtected: boolean
+  outputToFile: string
   buttons: "saveAction" | "deleteAction" | "cancelAction"
 }
 
@@ -237,8 +238,9 @@ export namespace ActionsUI {
             description: vscode.l10n.t(`Browser`),
             text: vscode.l10n.t(`The entire browser is refreshed`)
           }], vscode.l10n.t(`The browser level to refresh after the action is done`)
-        )        
+        )
         .addCheckbox("runOnProtected", vscode.l10n.t(`Run on protected/read only`), vscode.l10n.t(`Allows the execution of this Action on protected or read-only targets`), currentAction.runOnProtected)
+        .addInput(`outputToFile`, vscode.l10n.t(`Copy output to file`), vscode.l10n.t(`Copy the action output to a file. Variables can be used to define the file's path; use <code>&i</code> to compute file index.<br/>Example: <code>~/outputs/&CURLIB_&OPENMBR_&i.txt</code>.`), { default: currentAction.outputToFile })
         .addHorizontalRule()
         .addButtons(
           { id: `saveAction`, label: vscode.l10n.t(`Save`) },
@@ -269,14 +271,15 @@ export namespace ActionsUI {
               // We don't want \r (Windows line endings)
               data.command = data.command.replace(new RegExp(`\\\r`, `g`), ``);
 
-              const newAction : Action = {
+              const newAction: Action = {
                 type: data.type,
                 extensions: data.extensions.split(`,`).map(item => item.trim().toUpperCase()),
                 environment: data.environment,
                 name: data.name,
                 command: data.command,
                 refresh: data.refresh,
-                runOnProtected: data.runOnProtected
+                runOnProtected: data.runOnProtected,
+                outputToFile: data.outputToFile
               };
 
               if (id >= 0) {

--- a/src/webviews/actions/index.ts
+++ b/src/webviews/actions/index.ts
@@ -240,7 +240,7 @@ export namespace ActionsUI {
           }], vscode.l10n.t(`The browser level to refresh after the action is done`)
         )
         .addCheckbox("runOnProtected", vscode.l10n.t(`Run on protected/read only`), vscode.l10n.t(`Allows the execution of this Action on protected or read-only targets`), currentAction.runOnProtected)
-        .addInput(`outputToFile`, vscode.l10n.t(`Copy output to file`), vscode.l10n.t(`Copy the action output to a file. Variables can be used to define the file's path; use <code>&i</code> to compute file index.<br/>Example: <code>~/outputs/&CURLIB_&OPENMBR_&i.txt</code>.`), { default: currentAction.outputToFile })
+        .addInput(`outputToFile`, vscode.l10n.t(`Copy output to file`), vscode.l10n.t(`Copy the action output to a file. Variables can be used to define the file's path; use <code>&i</code> to compute file index.<br/>Example: <code>~/outputs/&CURLIB_&OPENMBR&i.txt</code>.`), { default: currentAction.outputToFile })
         .addHorizontalRule()
         .addButtons(
           { id: `saveAction`, label: vscode.l10n.t(`Save`) },


### PR DESCRIPTION
### Changes
As discussed in https://github.com/orgs/codefori/discussions/2630

This PR adds a new setting to the Action definition - namely `outputFile`:
![image](https://github.com/user-attachments/assets/319499ec-80dc-4c12-ab58-d80c28295af1)

This field expects an IFS path and supports variables replacement as well as the special `&i` placeholder that, if present in the path, will act as an index that gets computed when the output is written (to avoid overwriting the previous output).

`~` is also supported and will be replaced by the user actual home directory.

For example, this pattern `~/outputs/&CURLIB_&OPENMBR&i.txt` will create these files if the action is run three time:
![image](https://github.com/user-attachments/assets/b7a7b905-7dc8-45ab-8efc-5ebeeac85a95)

If the pattern is `~/outputs/&CURLIB_&OPENMBR&i.txt`, then a single file get written over and over again:
![image](https://github.com/user-attachments/assets/78a7c3e3-2b55-4d27-8145-ab0d29c7486f)

A new `Variables` object has been created to isolate the variables management (see src/api/variables.ts).

### How to test this PR

Examples:
1. Define an output file path in an action
2. Run the action
4. Check the file was created with the expected name in the IFS

### Checklist
* [x] have tested my change
* [x] have created one or more test cases