### PR TITLE
Fix #2651 variable expansion test is failing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,3 +61,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@Detrytus59](https://github.com/Detrytus59)
 * [@janfh](https://github.com/janfh)
 * [@MohitKambli](https://github.com/MohitKambli)
+* [@bspotswood](https://github.com/bspotswood)

--- a/src/api/tests/suites/variables.test.ts
+++ b/src/api/tests/suites/variables.test.ts
@@ -9,23 +9,26 @@ describe(`variables tests`, { concurrent: true }, () => {
     expect(variables.size).toBe(0);
     variables.set("&FOO", "bar")
       .set("&FOOTWO", "bartwo")
-      .set("&FOOTHREE", "barthree");
-  }, CONNECTION_TIMEOUT),
+      .set("&FOOTHREE", "barthree")
+      .set("{FOOFOUR}", "barfour");
+  }),
 
     it('Variables get', () => {
-      expect(variables.size).toBe(3);
+      expect(variables.size).toBe(4);
       expect(variables.get("&FOO")).toBe("bar");
       expect(variables.get("&FOOTWO")).toBe("bartwo");
       expect(variables.get("&FOOTHREE")).toBe("barthree");
+      expect(variables.get("{FOOFOUR}")).toBe("barfour");
       expect(variables.get("&FOOFIGHTERS")).toBeUndefined();
     }),
 
     it('Variables copy', () => {
       const variablesCopy = new Variables(undefined, variables);
-      expect(variablesCopy.size).toBe(3);
+      expect(variablesCopy.size).toBe(4);
       expect(variablesCopy.get("&FOO")).toBe("bar");
       expect(variablesCopy.get("&FOOTWO")).toBe("bartwo");
       expect(variablesCopy.get("&FOOTHREE")).toBe("barthree");
+      expect(variablesCopy.get("{FOOFOUR}")).toBe("barfour");
       expect(variablesCopy.get("&FOOFIGHTERS")).toBeUndefined();
     }),
 
@@ -41,10 +44,12 @@ describe(`variables tests`, { concurrent: true }, () => {
 
     it('To Pase variables', () => {
       const paseVariables = variables.toPaseVariables();
-      expect(paseVariables["FOO"]).toBe("bar");
-      expect(paseVariables["FOOTWO"]).toBe("bartwo");
-      expect(paseVariables["FOOTHREE"]).toBe("barthree");
-      expect(paseVariables["FOOFIGHTERS"]).toBeUndefined();
+      expect(paseVariables).toEqual({
+        "FOO": "bar",
+        "FOOTWO": "bartwo",
+        "FOOTHREE": "barthree",
+        "{FOOFOUR}": undefined
+      });
     })
 
   it('Connection variables', async () => {
@@ -73,5 +78,5 @@ describe(`variables tests`, { concurrent: true }, () => {
       customVariables.splice(0, customVariables.length);
       disposeConnection(connection);
     }
-  })
+  }, { timeout: CONNECTION_TIMEOUT });
 });

--- a/src/api/variables.ts
+++ b/src/api/variables.ts
@@ -51,7 +51,9 @@ export class Variables extends Map<string, string> {
   toPaseVariables(): Record<string, string> {
     const variables: Record<string, string> = {};
     for (const [key, value] of this.entries()) {
-      variables[key.startsWith('&') ? key.substring(1) : key] = value;
+      if ((/^[A-Za-z\&]/i).test(key)) {
+        variables[key.startsWith('&') ? key.substring(1) : key] = value;
+      }
     }
     return variables;
   }

--- a/src/api/variables.ts
+++ b/src/api/variables.ts
@@ -51,8 +51,9 @@ export class Variables extends Map<string, string> {
   toPaseVariables(): Record<string, string> {
     const variables: Record<string, string> = {};
     for (const [key, value] of this.entries()) {
-      if ((/^[A-Za-z\&]/i).test(key)) {
-        variables[key.startsWith('&') ? key.substring(1) : key] = value;
+      const cleanKey = key.startsWith('&') ? key.substring(1) : key;
+      if ((/^[a-z_]\w*$/i).test(cleanKey)) {
+        variables[cleanKey] = value;
       }
     }
     return variables;

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -77,7 +77,11 @@ export function initialise(context: vscode.ExtensionContext) {
             const testCase = suite.tests.find(testCase => testCase.name === testName);
 
             if (testCase) {
-              runTest(testCase);
+              if(suite.before) {
+                suite.before().then(() => runTest(testCase));
+              } else {
+                runTest(testCase);
+              }
             }
           }
         }


### PR DESCRIPTION
### Changes

1. Resolve issue with variable names by restoring a filter that was in previous code that was recently refactored (98a1b8880084dbea476fad43888a861921d52ecf)
2. Run the `before` function for individual test runs when the test suite has a `before`

This resolves specific problems documented in #2651 when trying to run the ***Variable expansion test***

### How to test this PR

Examples:

1. Build the code using `npm run webpack-dev`
2. Launch an **Extension Tests** instance from the **Run and Debug** section in VSCode
3. Open a workspace in the launched window, if not already open
4. Connect to an IBM i system
5. If running individually: Click on the ***Variable expansion test*** option from the **Test Cases** panel
6. If **not** running individually: The tests will execute after connection

Before changes, the ***Variable expansion test*** test will fail. After the changes, the test will pass.


### Checklist

* [x] have tested my change
* [x] have ~created~ _fixed_ one or more test cases
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)