### PR TITLE
Complete actions schema

### DIFF
--- a/schemas/actions.json
+++ b/schemas/actions.json
@@ -1,80 +1,79 @@
 {
-  "$id": "#/actions",
   "type": "array",
   "title": "Actions",
   "description": "List of Actions that apply to this Workspace. Actions may be used to run commands on the remote system.",
-  "default": [],
-  "additionalItems": true,
   "items": {
-    "$id": "#/actions/items",
-    "anyOf": [
-      {
-        "$id": "#/actions/items/anyOf/0",
+    "$ref": "#/$defs/code4iAction"
+  },
+  "$defs": {
+    "code4iAction": {
+      "type": "object",
+      "properties": {
         "type": "object",
         "title": "Action",
         "description": "A single Action.",
-        "default": {},
         "required": [
           "name",
           "command",
           "environment",
           "extensions"
         ],
-        "properties": {
-          "name": {
-            "$id": "#/actions/items/anyOf/0/properties/name",
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the Action. Used when running the Action."
+        },
+        "command": {
+          "type": "string",
+          "title": "Command",
+          "description": "The command that will be run when executing this Action.",
+          "default": ""
+        },
+        "environment": {
+          "type": "string",
+          "title": "Command Environment",
+          "description": "Which environment the command will run in.",
+          "default": "ile",
+          "enum": [
+            "ile",
+            "qsh",
+            "pase"
+          ]
+        },
+        "extensions": {
+          "type": "array",
+          "title": "Extensions",
+          "description": "Extensions which support this Action.",
+          "default": [
+            "GLOBAL"
+          ],
+          "items": {
             "type": "string",
-            "title": "Name",
-            "description": "The name of the Action. Used when running the Action."
-          },
-          "command": {
-            "$id": "#/actions/items/anyOf/0/properties/command",
-            "type": "string",
-            "title": "Command",
-            "description": "The command that will be run when executing this Action.",
-            "default": ""
-          },
-          "environment": {
-            "$id": "#/actions/items/anyOf/0/properties/commandEnvironment",
-            "type": "string",
-            "title": "Command Environment",
-            "description": "Which environment the command will run in.",
-            "default": "ile",
-            "enum": [
-              "ile",
-              "qsh",
-              "pase"
-            ]
-          },
-          "extensions": {
-            "$id": "#/actions/items/anyOf/0/properties/extensions",
-            "type": "array",
-            "title": "Extensions",
-            "description": "Extensions which support this Action.",
-            "default": ["GLOBAL"],
-            "items": {
-              "type": "string",
-              "title": "Extension."
-            }
-          },
-          "deployFirst": {
-            "type": "boolean",
-            "description": "The deployment process should run before the Action."
-          },
-          "postDownload": {
-            "$id": "#/actions/items/anyOf/0/properties/postDownload",
-            "type": "array",
-            "title": "Post Download",
-            "description": "Remote files/folders to download when the Action is complete. Using `.evfevent` in combination with a build tool will populate the Problems view.",
-            "default": [""],
-            "items": {
-              "type": "string",
-              "title": "Relative path."
-            }
+            "title": "Extension."
           }
         },
-        "additionalProperties": true
-      }
-    ]
+        "deployFirst": {
+          "type": "boolean",
+          "description": "The deployment process should run before the Action."
+        },
+        "postDownload": {
+          "type": "array",
+          "title": "Post Download",
+          "description": "Remote files/folders to download when the Action is complete. Using `.evfevent` in combination with a build tool will populate the Problems view.",
+          "default": [
+            ""
+          ],
+          "items": {
+            "type": "string",
+            "title": "Relative path."
+          }
+        },
+        "outputToFile": {
+          "type": "string",
+          "description": "Copy the action output to a file. Variables can be used to define the file's path; use &i to compute file index.\nExample: ~/outputs/&CURLIB_&OPENMBR&i.txt"
+        }
+      },
+      "additionalProperties": true
+    }
   }
 }

--- a/src/languages/actions/completion.ts
+++ b/src/languages/actions/completion.ts
@@ -26,8 +26,8 @@ const ITEMS = {
 export class LocalActionCompletionItemProvider implements vscode.CompletionItemProvider {
   provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext) {
         const text = document.lineAt(position.line).text?.trim();
-    //Only provide items if the cursor is on a "command" line
-    if (/^\s*"command"\s*:/.test(text)) {
+    //Only provide items if the cursor is on a "command" or "outputToFile" line
+    if (/^\s*"(command||outputToFile)"\s*:/.test(text)) {
       return Object.entries(ITEMS).map(([variable, label]) => ({
         label: variable,
         detail: label.replaceAll(/<code>|<\/code>|&amp;/g, ""),

--- a/src/languages/actions/completion.ts
+++ b/src/languages/actions/completion.ts
@@ -25,7 +25,7 @@ const ITEMS = {
 
 export class LocalActionCompletionItemProvider implements vscode.CompletionItemProvider {
   provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext) {
-        const text = document.lineAt(position.line).text?.trim();
+    const text = document.lineAt(position.line).text?.trim();
     //Only provide items if the cursor is on a "command" or "outputToFile" line
     if (/^\s*"(command|outputToFile)"\s*:/.test(text)) {
       return Object.entries(ITEMS).map(([variable, label]) => ({

--- a/src/languages/actions/completion.ts
+++ b/src/languages/actions/completion.ts
@@ -1,4 +1,4 @@
-import vscode from "vscode";
+import vscode, { l10n } from "vscode";
 
 const ITEMS = {
   "BASENAME": vscode.l10n.t("Name of the file, including the extension"),
@@ -25,8 +25,9 @@ const ITEMS = {
 
 export class LocalActionCompletionItemProvider implements vscode.CompletionItemProvider {
   provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext) {
+        const text = document.lineAt(position.line).text?.trim();
     //Only provide items if the cursor is on a "command" line
-    if (/^\s*"command"\s*:/.test(document.lineAt(position.line).text)) {
+    if (/^\s*"command"\s*:/.test(text)) {
       return Object.entries(ITEMS).map(([variable, label]) => ({
         label: variable,
         detail: label.replaceAll(/<code>|<\/code>|&amp;/g, ""),
@@ -34,8 +35,12 @@ export class LocalActionCompletionItemProvider implements vscode.CompletionItemP
         kind: vscode.CompletionItemKind.Variable
       } as vscode.CompletionItem));
     }
-    else {
-      return [];
+    else if (!text || text === "},") {
+      const snippet = new vscode.CompletionItem("action");
+      snippet.insertText = new vscode.SnippetString('{\n  "name": "$1",\n  "command": "$2",\n  "environment": "ile",\n  "extensions": [\n      "$3GLOBAL"\n    ]\n}');
+      snippet.documentation = new vscode.MarkdownString(l10n.t("Code for IBM i action"));
+      return [snippet];
     }
+
   }
 }

--- a/src/languages/actions/completion.ts
+++ b/src/languages/actions/completion.ts
@@ -27,7 +27,7 @@ export class LocalActionCompletionItemProvider implements vscode.CompletionItemP
   provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext) {
         const text = document.lineAt(position.line).text?.trim();
     //Only provide items if the cursor is on a "command" or "outputToFile" line
-    if (/^\s*"(command||outputToFile)"\s*:/.test(text)) {
+    if (/^\s*"(command|outputToFile)"\s*:/.test(text)) {
       return Object.entries(ITEMS).map(([variable, label]) => ({
         label: variable,
         detail: label.replaceAll(/<code>|<\/code>|&amp;/g, ""),

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -423,6 +423,10 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
                             }
                           }
 
+                          if (chosenAction.outputToFile) {
+                            await outputToFile(connection, chosenAction.outputToFile, variables, target.output);
+                          }
+
                           if (chosenAction.type === `file` && chosenAction.postDownload?.length) {
                             if (fromWorkspace) {
                               const remoteDir = remoteCwd;
@@ -511,10 +515,6 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
 
                           if (problemsFetched && viewControl === `problems`) {
                             commands.executeCommand(`workbench.action.problems.focus`);
-                          }
-
-                          if (chosenAction.outputToFile) {
-                            await outputToFile(connection, chosenAction.outputToFile, variables, target.output);
                           }
                         } else {
                           writeEmitter.fire(`Command did not run.` + CompileTools.NEWLINE);


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
- Added the recently added `outputToFile` attribute to the local actions' schema and cleans it up.
- Added a snippet to easily define new actions.
![image](https://github.com/user-attachments/assets/ad1d8240-34e3-4d88-99e7-2db975f4b8d4)
![image](https://github.com/user-attachments/assets/2cdb3714-a173-41dd-9037-2e164bbf3a60)
- Added content assist to show variables on the `outputToFile` field since its supports variables replacement
- Moved the call to the `outputToFile` method before post download gets executed, so the output can be downloaded locally if needed

### How to test this PR
1. Open a local `.vscode/actions.json` file
2. Use content assist to check `outputToFile` is suggested as a field when defining an action
3. Use content assist when defining the `outputToFile` value to see the available variables
4. Define a value for an action's `outputToFile` and add the output file's parent folder path in `postDownload` then check the output file is downloaded. 
<!-- 
Example:
1. Run the test cases
5. Expand view A and right click on the node
6. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change