### PR TITLE
Do not modify `workbench.editor.enablePreview` status on startup

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -60,7 +60,6 @@ export async function safeDisconnect(): Promise<boolean> {
 export async function loadAllofExtension(context: vscode.ExtensionContext) {
   // No connection when the extension is first activated
   vscode.commands.executeCommand(`setContext`, `code-for-ibmi:connected`, false);
-  vscode.workspace.getConfiguration().update(`workbench.editor.enablePreview`, false, true);
 
   instance = new Instance(context);
   context.subscriptions.push(


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Resolves #2062.
Revert the change made to fix this https://github.com/codefori/vscode-ibmi/issues/928#issuecomment-1295444916

Assuming this was due to QSYS FS `stat()` method not being fully implemented back then, it should be fine now it returns the actual member modification date.

### How to test this PR
1. Turn on Preview Mode in the settings
2. Open members
3. Check the output doesn't fill up with QSYS FS trying to load the member over and over
<!-- 
Example:
1. Run the test cases
4. Expand view A and right click on the node
5. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
