### PR TITLE
Add `+uninhibited` to the default 5250 connection string

### DIFF
--- a/package.json
+++ b/package.json
@@ -306,7 +306,7 @@
 							},
 							"connectringStringFor5250": {
 								"type": "string",
-								"default": "localhost",
+								"default": "+uninhibited localhost",
 								"description": "The connectring string for the 5250 emulator. To use the 5250 emulator, tn5250 must be installed on the remote system via yum."
 							},
 							"autoSaveBeforeAction": {

--- a/src/api/configuration/config/ConnectionManager.ts
+++ b/src/api/configuration/config/ConnectionManager.ts
@@ -1,8 +1,8 @@
 
 import os from "os";
-import { Config, VirtualConfig } from "./VirtualConfig";
 import { ConnectionData } from "../../types";
 import { ConnectionConfig } from "./types";
+import { Config, VirtualConfig } from "./VirtualConfig";
 
 function initialize(parameters: Partial<ConnectionConfig>): ConnectionConfig {
   return {
@@ -31,7 +31,7 @@ function initialize(parameters: Partial<ConnectionConfig>): ConnectionConfig {
     encodingFor5250: parameters.encodingFor5250 || `default`,
     terminalFor5250: parameters.terminalFor5250 || `default`,
     setDeviceNameFor5250: (parameters.setDeviceNameFor5250 === true),
-    connectringStringFor5250: parameters.connectringStringFor5250 || `localhost`,
+    connectringStringFor5250: parameters.connectringStringFor5250 || `+uninhibited localhost`,
     autoSaveBeforeAction: (parameters.autoSaveBeforeAction === true),
     showDescInLibList: (parameters.showDescInLibList === true),
     debugPort: (parameters.debugPort || "8005"),

--- a/src/ui/Terminal.ts
+++ b/src/ui/Terminal.ts
@@ -1,9 +1,9 @@
 
 import path from 'path';
 import vscode, { commands } from 'vscode';
-import { instance } from '../instantiate';
 import IBMi from '../api/IBMi';
 import { Tools } from '../api/Tools';
+import { instance } from '../instantiate';
 
 const PASE_INIT_FLAG = '#C4IINIT';
 const PASE_INIT_FLAG_REGEX = /#+C+4+I+I+N+I+T+$/
@@ -207,7 +207,7 @@ export namespace Terminal {
           terminalSettings.encoding ? `map=${terminalSettings.encoding}` : ``,
           terminalSettings.terminal ? `env.TERM=${terminalSettings.terminal}` : ``,
           terminalSettings.name ? `env.DEVNAME=${terminalSettings.name}` : ``,
-          terminalSettings.connectionString || `localhost`,
+          terminalSettings.connectionString || `+uninhibited localhost`,
           `\n`
         ].join(` `));
       } else {

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -155,7 +155,7 @@ export class SettingsUI {
               }))
             ], `The terminal type for the 5250 emulator.`)
             .addCheckbox(`setDeviceNameFor5250`, `Set Device Name for 5250`, `When enabled, the user will be able to enter a device name before the terminal starts.`, config.setDeviceNameFor5250)
-            .addInput(`connectringStringFor5250`, `Connection string for 5250`, `Default is <code>localhost</code>. A common SSL string is <code>ssl:localhost 992</code>`, { default: config.connectringStringFor5250 });
+            .addInput(`connectringStringFor5250`, `Connection string for 5250`, `Default is <code>+uninhibited localhost</code> (<code>+uninhibited</code> lets you get the cursor out of protected areas with any key).<br />A common SSL string is <code>ssl:localhost 992</code>`, { default: config.connectringStringFor5250 });
         } else if (connection) {
           terminalsTab.addParagraph('Enable 5250 emulation to change these settings');
         } else {


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Based on a tip shared by @alanseiden here: https://www.seidengroup.com/2025/05/21/improve-your-tn5250-experience-in-vs-code-for-ibm-i/

This PR changes the default connection string sent to Tn5250 when opening a new 5250 terminal. It adds `+uninhibited` to make it easier to get the cursor out of a protected area using any key.

![image](https://github.com/user-attachments/assets/002f310b-79a2-4b99-b5f0-3dbc71dd35ea)

The description of the connection string setting now also mentions `+uninhibited` so it can be copy/pasted in an existing connection string that would not  contain it already. 

### How to test this PR
1. Create a new connection
2. Check the default connection string under the Terminal tab of the connection settings is `+uninhibited localhost`
3. Open a 5250 terminal in VS Code
4. Enjoy a cursor that doesn't get stuck anymore
<!-- 
Example:
1. Run the test cases
5. Expand view A and right click on the node
6. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
