### PR TITLE
Run `cp` and `mv` in QSH to keep CCSID attribute

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -103,7 +103,7 @@ export default class IBMiContent {
    * @param content Raw content
    * @param encoding Optional encoding to write.
    */
-  async writeStreamfileRaw(originalPath: string, content: string|Uint8Array, encoding?: string) {
+  async writeStreamfileRaw(originalPath: string, content: string | Uint8Array, encoding?: string) {
     const client = this.ibmi.client!;
     const features = this.ibmi.remoteFeatures;
     const tmpobj = await tmpFile();
@@ -228,7 +228,7 @@ export default class IBMiContent {
    * @param content 
    */
   async uploadMemberContent(library: string, sourceFile: string, member: string, content: string | Uint8Array): Promise<boolean>;
-  
+
   /**
    * @deprecated Will be removed in `v3.0.0`; use {@link IBMiContent.uploadMemberContent()} without the `asp` parameter instead.
    * @param asp 
@@ -315,7 +315,7 @@ export default class IBMiContent {
    */
   runSQL(statements: string) {
     console.warn(`[Code for IBM i] runSQL is deprecated and will be removed by 4.0.0. Use IBMi.runSQL instead.`);
-    
+
     return this.ibmi.runSQL(statements);
   }
 
@@ -1148,5 +1148,27 @@ export default class IBMiContent {
 
   downloadDirectory(localDirectory: EditorPath, remoteDirectory: string, options?: node_ssh.SSHGetPutDirectoryOptions) {
     return this.ibmi.client!.getDirectory(Tools.fileToPath(localDirectory), remoteDirectory, options);
+  }
+
+  /**
+   * Copy one or more folders or files into a directory. Uses QSH's `cp` to keep all the attributes of the original file into its copy.
+   * @param paths one or more files/folders to copy
+   * @param toDirectory the directory where the files/folders will be copied into
+   * @returns the {@link CommandResult} of the `cp` command execution
+   */
+  async copy(paths: string | string[], toDirectory: string) {
+    paths = Array.isArray(paths) ? paths : [paths];
+    return this.ibmi.runCommand({ command: `cp -r ${paths.map(path => Tools.escapePath(path)).join(" ")} ${Tools.escapePath(toDirectory)}`, environment: "qsh" });
+  }
+
+  /**
+   * Move one or more folders or files into a directory. Uses QSH's `mv` to ensures attributes are not altered during the opration.
+   * @param paths one or more files/folders to copy
+   * @param toDirectory the directory where the files/folders will be copied into
+   * @returns the {@link CommandResult} of the `mv` command execution
+   */
+  async move(paths: string | string[], toDirectory: string) {
+    paths = Array.isArray(paths) ? paths : [paths];
+    return await this.ibmi.runCommand({ command: `mv ${paths.map(path => Tools.escapePath(path)).join(" ")} ${Tools.escapePath(toDirectory)}`, environment: "qsh" });
   }
 }

--- a/src/ui/views/ifsBrowser.ts
+++ b/src/ui/views/ifsBrowser.ts
@@ -255,11 +255,11 @@ class IFSBrowserDragAndDrop implements vscode.TreeDragAndDropController<IFSItem>
         let result;
         switch (action) {
           case "copy":
-            result = await connection.sendCommand({ command: `cp -r ${ifsBrowserItems.map(item => Tools.escapePath(item.path)).join(" ")} ${Tools.escapePath(toDirectory.path)}` });
+            result = await connection.runCommand({ command: `cp -r ${ifsBrowserItems.map(item => Tools.escapePath(item.path)).join(" ")} ${Tools.escapePath(toDirectory.path)}`, environment: "qsh" });
             break;
 
           case "move":
-            result = await connection.sendCommand({ command: `mv ${ifsBrowserItems.map(item => Tools.escapePath(item.path)).join(" ")} ${Tools.escapePath(toDirectory.path)}` });
+            result = await connection.runCommand({ command: `mv ${ifsBrowserItems.map(item => Tools.escapePath(item.path)).join(" ")} ${Tools.escapePath(toDirectory.path)}`, environment: "qsh" });
             ifsBrowserItems.map(item => item.parent)
               .filter(Tools.distinct)
               .forEach(folder => folder?.refresh?.());
@@ -654,7 +654,7 @@ Please type "{0}" to confirm deletion.`, dirName);
         if (target) {
           const targetPath = path.posix.isAbsolute(target) ? target : path.posix.join(homeDirectory, target);
           try {
-            const moveResult = await connection.sendCommand({ command: `mv ${Tools.escapePath(node.path)} ${Tools.escapePath(targetPath)}` });
+            const moveResult = await connection.runCommand({ command: `mv ${Tools.escapePath(node.path)} ${Tools.escapePath(targetPath)}`, environment: "qsh" });
             if (moveResult.code !== 0) {
               throw moveResult.stderr;
             }
@@ -704,7 +704,7 @@ Please type "{0}" to confirm deletion.`, dirName);
         if (target) {
           const targetPath = target.startsWith(`/`) ? target : homeDirectory + `/` + target;
           try {
-            await connection.sendCommand({ command: `cp -r ${Tools.escapePath(node.path)} ${Tools.escapePath(targetPath)}` });
+            await connection.runCommand({ command: `cp -r ${Tools.escapePath(node.path)} ${Tools.escapePath(targetPath)}`, environment: "qsh" });
             if (IBMi.connectionManager.get(`autoRefresh`)) {
               ifsBrowser.refresh();
             }


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Fixes #2696 

As explained by @kadler in the IBM i OSS chat, QSH version of `cp` retain the CCSID of the original file into the copy.
Running the copy and move operations in QSH fixes the issue reported in #2696.

### How to test this PR
- Run the new  test case
- Check from the UI
  1. Create a streamfile with CCSID != 1208 or 819: `touch -C 37 testfile`
  2. Copy this streamfile using drag and drop in the IFS browser
  3. Copy it also using the right-click `Copy` action
  4. Check the CCSID of the copied file is 37: `attr copyOfTestFile CCSID`
<!-- 
Example:
1. Run the test cases
5. Expand view A and right click on the node
6. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change