### PR TITLE
Fix/cqsh path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,3 +62,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@janfh](https://github.com/janfh)
 * [@MohitKambli](https://github.com/MohitKambli)
 * [@bspotswood](https://github.com/bspotswood)
+* [@dcmcdoug](https://github.com/dcmcdoug)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ const dist = path.resolve(__dirname, `dist`);
 
 fs.mkdirSync(dist, {recursive: true});
 
-const files = [{relative: `src/components/cqsh/cqsh`, name: `cqsh_1`}];
+const files = [{relative: `src/api/components/cqsh/cqsh`, name: `cqsh_1`}];
 
 for (const file of files) {
   const src = path.resolve(__dirname, file.relative);


### PR DESCRIPTION
The local path used for installing cqsh_1 to an IBM i is missing the api folder.

### Changes
Fixed the path to cqsh by adding the missing api folder.

### How to test this PR
1. Remove the $HOME/.vscode/cqsh_1 binary on an IBM i that you will connect to with code for i if it exists.
2. "Connect and reload server settings" the IBM i through code for i.
3. Start a PASE terminal with code for i. On the IBM i, $HOME/.vscode/cqsh_1 should get created.

### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)