### PR TITLE
Throw an error and abort build when file to copy is not found

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,9 @@ for (const file of files) {
     // Overwrites by default
     fs.copyFileSync(src, dest);
   }
+  else{
+    throw `File ${src} not found for copy!`
+  }
 }
 
 console.log(``);


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Webpack build will now throw an error if the files that must be copied during the build are not found.

### How to test this PR
1. Add a file that doesn't exist or change the path of cqsh in the root `webpack.config.js` file:
![image](https://github.com/user-attachments/assets/c9222e9d-f8d0-43a5-9218-7f27ed8e56f6)
2. Run `npm run webpack`: it must fail
3. Revert change made in 1.
4. Run `npm run webpack`: it must succeed

<!-- 
Example:
1. Run the test cases
5. Expand view A and right click on the node
6. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change