### PR TITLE
Enable drag and drop support in library list view

### DIFF
--- a/package.json
+++ b/package.json
@@ -2616,7 +2616,7 @@
 				},
 				{
 					"command": "code-for-ibmi.setCurrentLibrary",
-					"when": "view == libraryListView && viewItem == library",
+					"when": "view == libraryListView && viewItem == library && !listMultiSelection",
 					"group": "01libraryActions@01"
 				},
 				{

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -156,10 +156,11 @@ export type IBMiMessages = {
   findId(id: string): IBMiMessage | undefined
 }
 
-export const OBJECT_BROWSER_DRAG_MIMETYPE = "application/objectbrowser.drag";
+export const OBJECT_BROWSER_MIMETYPE = "application/vnd.code.tree.objectbrowser";
 export const IFS_BROWSER_MIMETYPE = "application/vnd.code.tree.ifsbrowser";
 export const LIBRARY_LIST_MIMETYPE = "application/vnd.code.tree.libraryListView";
 export const URI_LIST_MIMETYPE = "text/uri-list";
+export const URI_LIST_SEPARATOR = "\r\n";
 
 export type ObjectBrowserDrag = {
   library: string

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -155,8 +155,18 @@ export type IBMiMessages = {
   messages: IBMiMessage[]
   findId(id: string): IBMiMessage | undefined
 }
-export const OBJECT_BROWSER_MIMETYPE = "application/vnd.code.tree.objectbrowser";
+
+export const OBJECT_BROWSER_DRAG_MIMETYPE = "application/objectbrowser.drag";
 export const IFS_BROWSER_MIMETYPE = "application/vnd.code.tree.ifsbrowser";
+export const LIBRARY_LIST_MIMETYPE = "application/vnd.code.tree.libraryListView";
+export const URI_LIST_MIMETYPE = "text/uri-list";
+
+export type ObjectBrowserDrag = {
+  library: string
+  object: string
+  type: string
+  member?: string
+}
 
 export interface WrapResult {
   newStatements: string[];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 // The module 'vscode' contains the VS Code extensibility API
-import { ExtensionContext, commands, languages, window, workspace } from "vscode";
+import { commands, ExtensionContext, languages, window, workspace } from "vscode";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -12,6 +12,7 @@ import { GetMemberInfo } from "./api/components/getMemberInfo";
 import { GetNewLibl } from "./api/components/getNewLibl";
 import { extensionComponentRegistry } from "./api/components/manager";
 import { parseErrors } from "./api/errors/parser";
+import { CustomCLI } from "./api/tests/components/customCli";
 import { onCodeForIBMiConfigurationChange } from "./config/Configuration";
 import * as Debug from './debug';
 import { IFSFS } from "./filesystems/ifsFs";
@@ -24,7 +25,7 @@ import { CodeForIBMi } from "./typings";
 import { VscodeTools } from "./ui/Tools";
 import { registerActionTools } from "./ui/actions";
 import { initializeConnectionBrowser } from "./ui/views/ConnectionBrowser";
-import { LibraryListProvider } from "./ui/views/LibraryListView";
+import { initializeLibraryListView } from "./ui/views/LibraryListView";
 import { ProfilesView } from "./ui/views/ProfilesView";
 import { initializeDebugBrowser } from "./ui/views/debugView";
 import { HelpView } from "./ui/views/helpView";
@@ -36,7 +37,6 @@ import { openURIHandler } from "./uri/handlers/open";
 import { initializeSandbox, sandboxURIHandler } from "./uri/handlers/sandbox";
 import { CustomUI } from "./webviews/CustomUI";
 import { SettingsUI } from "./webviews/settings";
-import { CustomCLI } from "./api/tests/components/customCli";
 
 export async function activate(context: ExtensionContext): Promise<CodeForIBMi> {
   // Use the console to output diagnostic information (console.log) and errors (console.error)
@@ -60,15 +60,12 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
   initializeIFSBrowser(context);
   initializeDebugBrowser(context);
   initializeSearchView(context);
+  initializeLibraryListView(context);
 
   context.subscriptions.push(
     window.registerTreeDataProvider(
       `helpView`,
       new HelpView(context)
-    ),
-    window.registerTreeDataProvider(
-      `libraryListView`,
-      new LibraryListProvider(context)
     ),
     window.registerTreeDataProvider(
       `profilesView`,

--- a/src/ui/views/LibraryListView.ts
+++ b/src/ui/views/LibraryListView.ts
@@ -1,268 +1,305 @@
 import vscode, { commands, l10n } from "vscode";
-import { instance } from "../../instantiate";
-import { ConnectionConfig, IBMiObject, WithLibrary } from "../../typings";
-import { VscodeTools } from "../Tools";
 import IBMi from "../../api/IBMi";
+import { instance } from "../../instantiate";
+import { ConnectionConfig, IBMiObject, LIBRARY_LIST_MIMETYPE, OBJECT_BROWSER_DRAG_MIMETYPE, WithLibrary } from "../../typings";
+import { VscodeTools } from "../Tools";
 
-export class LibraryListProvider implements vscode.TreeDataProvider<LibraryListNode> {
-  private readonly _emitter: vscode.EventEmitter<LibraryListNode | undefined | null | void> = new vscode.EventEmitter();
-  readonly onDidChangeTreeData: vscode.Event<LibraryListNode | undefined | null | void> = this._emitter.event;;
+export function initializeLibraryListView(context: vscode.ExtensionContext) {
+  const libraryListView = new LibraryListView();
+  const libraryListViewViewer = vscode.window.createTreeView(
+    `libraryListView`, {
+    treeDataProvider: libraryListView,
+    showCollapseAll: false,
+    canSelectMany: false,
+    dragAndDropController: new LibraryListDragAndDrop()
+  });
 
-  constructor(context: vscode.ExtensionContext) {
-    context.subscriptions.push(
-      vscode.commands.registerCommand(`code-for-ibmi.userLibraryList.enable`, () => {
-        commands.executeCommand(`setContext`, `code-for-ibmi:libraryListDisabled`, false);
-      }),
+  const updateConfig = async (config: ConnectionConfig) => {
+    await IBMi.connectionManager.update(config);
+    if (IBMi.connectionManager.get(`autoRefresh`)) {
+      libraryListView.refresh();
+    }
+  }
 
-      vscode.commands.registerCommand(`code-for-ibmi.refreshLibraryListView`, async () => {
-        this.refresh();
-      }),
+  context.subscriptions.push(
+    libraryListViewViewer,
+    vscode.commands.registerCommand(`code-for-ibmi.userLibraryList.enable`, () => {
+      commands.executeCommand(`setContext`, `code-for-ibmi:libraryListDisabled`, false);
+    }),
 
-      vscode.commands.registerCommand(`code-for-ibmi.changeCurrentLibrary`, async () => {
-        const connection = instance.getConnection();
-        const storage = instance.getStorage();
-        if (connection && storage) {
-          const config = connection.getConfig();
-          const currentLibrary = connection.upperCaseName(config.currentLibrary);
-          let prevCurLibs = storage.getPreviousCurLibs();
-          let list = [...prevCurLibs];
-          const listHeader = [
-            { label: l10n.t(`Currently active`), kind: vscode.QuickPickItemKind.Separator },
-            { label: currentLibrary },
-            { label: l10n.t(`Recently used`), kind: vscode.QuickPickItemKind.Separator }
-          ];
-          const clearList = l10n.t(`$(trash) Clear list`);
-          const clearListArray = [{ label: ``, kind: vscode.QuickPickItemKind.Separator }, { label: clearList }];
+    vscode.commands.registerCommand(`code-for-ibmi.refreshLibraryListView`, () => libraryListView.refresh()),
 
-          const quickPick = vscode.window.createQuickPick();
-          quickPick.items = listHeader.concat(list.map(lib => ({ label: lib }))).concat(clearListArray);
-          quickPick.placeholder = l10n.t(`Filter or new library to set as current library`);
-          quickPick.title = l10n.t(`Change current library`);
+    vscode.commands.registerCommand(`code-for-ibmi.changeCurrentLibrary`, () => {
+      const connection = instance.getConnection();
+      const storage = instance.getStorage();
+      if (connection && storage) {
+        const config = connection.getConfig();
+        const currentLibrary = connection.upperCaseName(config.currentLibrary);
+        let prevCurLibs = storage.getPreviousCurLibs();
+        let list = [...prevCurLibs];
+        const listHeader = [
+          { label: l10n.t(`Currently active`), kind: vscode.QuickPickItemKind.Separator },
+          { label: currentLibrary },
+          { label: l10n.t(`Recently used`), kind: vscode.QuickPickItemKind.Separator }
+        ];
+        const clearList = l10n.t(`$(trash) Clear list`);
+        const clearListArray = [{ label: ``, kind: vscode.QuickPickItemKind.Separator }, { label: clearList }];
 
-          quickPick.onDidChangeValue(() => {
-            if (quickPick.value === ``) {
-              quickPick.items = listHeader.concat(list.map(lib => ({ label: lib }))).concat(clearListArray);
-            } else if (!list.includes(connection.upperCaseName(quickPick.value))) {
-              quickPick.items = [{ label: connection.upperCaseName(quickPick.value) }].concat(listHeader)
-                .concat(list.map(lib => ({ label: lib })))
-            }
-          })
+        const quickPick = vscode.window.createQuickPick();
+        quickPick.items = listHeader.concat(list.map(lib => ({ label: lib }))).concat(clearListArray);
+        quickPick.placeholder = l10n.t(`Filter or new library to set as current library`);
+        quickPick.title = l10n.t(`Change current library`);
 
-          quickPick.onDidAccept(async () => {
-            const newLibrary = quickPick.selectedItems[0].label;
-            if (newLibrary) {
-              if (newLibrary === clearList) {
-                await storage.setPreviousCurLibs([]);
-                list = [];
-                quickPick.items = list.map(lib => ({ label: lib }));
-                vscode.window.showInformationMessage(l10n.t(`Cleared list.`));
-                quickPick.show();
-              } else {
-                if (newLibrary !== currentLibrary) {
-                  if (await changeCurrentLibrary(newLibrary)) {
-                    this.refresh();
-                    quickPick.hide();
-                  }
-                } else {
+        quickPick.onDidChangeValue(() => {
+          if (quickPick.value === ``) {
+            quickPick.items = listHeader.concat(list.map(lib => ({ label: lib }))).concat(clearListArray);
+          } else if (!list.includes(connection.upperCaseName(quickPick.value))) {
+            quickPick.items = [{ label: connection.upperCaseName(quickPick.value) }].concat(listHeader)
+              .concat(list.map(lib => ({ label: lib })))
+          }
+        })
+
+        quickPick.onDidAccept(async () => {
+          const newLibrary = quickPick.selectedItems[0].label;
+          if (newLibrary) {
+            if (newLibrary === clearList) {
+              await storage.setPreviousCurLibs([]);
+              list = [];
+              quickPick.items = list.map(lib => ({ label: lib }));
+              vscode.window.showInformationMessage(l10n.t(`Cleared list.`));
+              quickPick.show();
+            } else {
+              if (newLibrary !== currentLibrary) {
+                if (await changeCurrentLibrary(newLibrary)) {
+                  libraryListView.refresh();
                   quickPick.hide();
-                  vscode.window.showInformationMessage(l10n.t(`{0} is already current library.`, newLibrary))
                 }
+              } else {
+                quickPick.hide();
+                vscode.window.showInformationMessage(l10n.t(`{0} is already current library.`, newLibrary))
               }
             }
-          });
-          quickPick.onDidHide(() => quickPick.dispose());
-          quickPick.show();
-        }
-      }),
+          }
+        });
+        quickPick.onDidHide(() => quickPick.dispose());
+        quickPick.show();
+      }
+    }),
 
-      vscode.commands.registerCommand(`code-for-ibmi.changeUserLibraryList`, async () => {
+    vscode.commands.registerCommand(`code-for-ibmi.changeUserLibraryList`, async () => {
+      const connection = instance.getConnection();
+      if (connection) {
+        const content = connection.getContent();
+        const config = connection.getConfig();
+        const libraryList = config.libraryList;
+
+        const newLibraryListStr = await vscode.window.showInputBox({
+          prompt: l10n.t(`Changing library list (can use "*reset")`),
+          value: libraryList.map(lib => connection.upperCaseName(lib)).join(`, `)
+        });
+
+        if (newLibraryListStr) {
+
+          let newLibraryList = [];
+
+          if (newLibraryListStr.toUpperCase() === `*RESET`) {
+            newLibraryList = connection.defaultUserLibraries;
+          } else {
+            newLibraryList = newLibraryListStr
+              .replace(/,/g, ` `)
+              .split(` `)
+              .map(lib => connection.upperCaseName(lib))
+              .filter((lib, idx, libl) => lib && libl.indexOf(lib) === idx);
+            const badLibs = await content.validateLibraryList(newLibraryList);
+
+            if (badLibs.length > 0) {
+              newLibraryList = newLibraryList.filter(lib => !badLibs.includes(lib));
+              vscode.window.showWarningMessage(l10n.t(`The following libraries were removed from the updated library list as they are invalid: {0}`, badLibs.join(', ')));
+            }
+          }
+
+          config.libraryList = newLibraryList;
+          await updateConfig(config);
+        }
+      }
+    }),
+
+    vscode.commands.registerCommand(`code-for-ibmi.addToLibraryList.prompt`, async () => {
+      vscode.commands.executeCommand(`code-for-ibmi.addToLibraryList`, { library: await vscode.window.showInputBox({ prompt: l10n.t(`Library to add`) }) });
+    }),
+
+    vscode.commands.registerCommand(`code-for-ibmi.addToLibraryList`, async (newLibrary: WithLibrary) => {
+      const connection = instance.getConnection();
+      if (connection) {
+        const content = connection.getContent();
+        const config = connection.getConfig();
+        const addingLib = connection.upperCaseName(newLibrary.library);
+
+        if (addingLib.length > 10) {
+          vscode.window.showErrorMessage(l10n.t(`Library is too long.`));
+          return;
+        }
+
+        let libraryList = [...config.libraryList];
+
+        if (libraryList.includes(addingLib)) {
+          vscode.window.showWarningMessage(l10n.t(`Library {0} was already in the library list.`, addingLib));
+          return;
+        }
+
+        let badLibs = await content.validateLibraryList([addingLib]);
+
+        if (badLibs.length > 0) {
+          libraryList = libraryList.filter(lib => !badLibs.includes(lib));
+          vscode.window.showWarningMessage(l10n.t(`Library {0} does not exist.`, badLibs.join(', ')));
+        } else {
+          libraryList.push(addingLib);
+          vscode.window.showInformationMessage(l10n.t(`Library {0} was added to the library list.`, addingLib));
+        }
+
+        badLibs = await content.validateLibraryList(libraryList);
+
+        if (badLibs.length > 0) {
+          libraryList = libraryList.filter(lib => !badLibs.includes(lib));
+          vscode.window.showWarningMessage(l10n.t(`The following libraries were removed from the updated library list as they are invalid: {0}`, badLibs.join(', ')));
+        }
+
+        config.libraryList = libraryList;
+        await updateConfig(config);
+      }
+    }),
+
+    vscode.commands.registerCommand(`code-for-ibmi.removeFromLibraryList`, async (node: LibraryListNode) => {
+      if (node) {
+        //Running from right click
         const connection = instance.getConnection();
         if (connection) {
-          const content = connection.getContent();
+          const config = connection.getConfig();
+          let libraryList = config.libraryList;
+
+          let index = libraryList.findIndex(library => connection.upperCaseName(library) === node.library)
+          if (index >= 0) {
+            const removedLib = libraryList[index];
+            libraryList.splice(index, 1);
+
+            config.libraryList = libraryList;
+            await updateConfig(config);
+            vscode.window.showInformationMessage(l10n.t(`Library {0} was removed from the library list.`, removedLib));
+          }
+        }
+      }
+    }),
+
+    vscode.commands.registerCommand(`code-for-ibmi.moveLibraryUp`, async (node: LibraryListNode) => {
+      if (node) {
+        //Running from right click
+        const connection = instance.getConnection();
+        if (connection) {
           const config = connection.getConfig();
           const libraryList = config.libraryList;
 
-          const newLibraryListStr = await vscode.window.showInputBox({
-            prompt: l10n.t(`Changing library list (can use "*reset")`),
-            value: libraryList.map(lib => connection.upperCaseName(lib)).join(`, `)
-          });
+          const index = libraryList.findIndex(library => connection.upperCaseName(library) === node.library);
+          if (index >= 0 && (index - 1) >= 0) {
+            const library = libraryList[index];
+            libraryList.splice(index, 1);
+            libraryList.splice(index - 1, 0, library);
 
-          if (newLibraryListStr) {
-
-            let newLibraryList = [];
-
-            if (newLibraryListStr.toUpperCase() === `*RESET`) {
-              newLibraryList = connection.defaultUserLibraries;
-            } else {
-              newLibraryList = newLibraryListStr
-                .replace(/,/g, ` `)
-                .split(` `)
-                .map(lib => connection.upperCaseName(lib))
-                .filter((lib, idx, libl) => lib && libl.indexOf(lib) === idx);
-              const badLibs = await content.validateLibraryList(newLibraryList);
-
-              if (badLibs.length > 0) {
-                newLibraryList = newLibraryList.filter(lib => !badLibs.includes(lib));
-                vscode.window.showWarningMessage(l10n.t(`The following libraries were removed from the updated library list as they are invalid: {0}`, badLibs.join(', ')));
-              }
-            }
-
-            config.libraryList = newLibraryList;
-            await this.updateConfig(config);
-          }
-        }
-      }),
-
-      vscode.commands.registerCommand(`code-for-ibmi.addToLibraryList.prompt`, async () => {
-        vscode.commands.executeCommand(`code-for-ibmi.addToLibraryList`, { library: await vscode.window.showInputBox({ prompt: l10n.t(`Library to add`) }) });
-      }),
-
-      vscode.commands.registerCommand(`code-for-ibmi.addToLibraryList`, async (newLibrary: WithLibrary) => {
-        const connection = instance.getConnection();
-        if (connection) {
-          const content = connection.getContent();
-          const config = connection.getConfig();
-          const addingLib = connection.upperCaseName(newLibrary.library);
-
-          if (addingLib.length > 10) {
-            vscode.window.showErrorMessage(l10n.t(`Library is too long.`));
-            return;
-          }
-
-          let libraryList = [...config.libraryList];
-
-          if (libraryList.includes(addingLib)) {
-            vscode.window.showWarningMessage(l10n.t(`Library {0} was already in the library list.`, addingLib));
-            return;
-          }
-
-          let badLibs = await content.validateLibraryList([addingLib]);
-
-          if (badLibs.length > 0) {
-            libraryList = libraryList.filter(lib => !badLibs.includes(lib));
-            vscode.window.showWarningMessage(l10n.t(`Library {0} does not exist.`, badLibs.join(', ')));
-          } else {
-            libraryList.push(addingLib);
-            vscode.window.showInformationMessage(l10n.t(`Library {0} was added to the library list.`, addingLib));
-          }
-
-          badLibs = await content.validateLibraryList(libraryList);
-
-          if (badLibs.length > 0) {
-            libraryList = libraryList.filter(lib => !badLibs.includes(lib));
-            vscode.window.showWarningMessage(l10n.t(`The following libraries were removed from the updated library list as they are invalid: {0}`, badLibs.join(', ')));
-          }
-
-          config.libraryList = libraryList;
-          await this.updateConfig(config);
-        }
-      }),
-
-      vscode.commands.registerCommand(`code-for-ibmi.removeFromLibraryList`, async (node: LibraryListNode) => {
-        if (node) {
-          //Running from right click
-          const connection = instance.getConnection();
-          if (connection) {
-            const config = connection.getConfig();
-            let libraryList = config.libraryList;
-
-            let index = libraryList.findIndex(library => connection.upperCaseName(library) === node.library)
-            if (index >= 0) {
-              const removedLib = libraryList[index];
-              libraryList.splice(index, 1);
-
-              config.libraryList = libraryList;
-              await this.updateConfig(config);
-              vscode.window.showInformationMessage(l10n.t(`Library {0} was removed from the library list.`, removedLib));
-            }
-          }
-        }
-      }),
-
-      vscode.commands.registerCommand(`code-for-ibmi.moveLibraryUp`, async (node: LibraryListNode) => {
-        if (node) {
-          //Running from right click
-          const connection = instance.getConnection();
-          if (connection) {
-            const config = connection.getConfig();
-            const libraryList = config.libraryList;
-
-            const index = libraryList.findIndex(library => connection.upperCaseName(library) === node.library);
-            if (index >= 0 && (index - 1) >= 0) {
-              const library = libraryList[index];
-              libraryList.splice(index, 1);
-              libraryList.splice(index - 1, 0, library);
-
-              config.libraryList = libraryList;
-              await this.updateConfig(config);
-            }
-          }
-        }
-      }),
-
-      vscode.commands.registerCommand(`code-for-ibmi.moveLibraryDown`, async (node: LibraryListNode) => {
-        if (node) {
-          //Running from right click
-          const connection = instance.getConnection();
-          if (connection) {
-            const config = connection.getConfig();
-            const libraryList = config.libraryList;
-            const index = libraryList.findIndex(library => connection.upperCaseName(library) === node.library);
-            if (index >= 0 && (index + 1) >= 0) {
-              const library = libraryList[index];
-              libraryList.splice(index, 1);
-              libraryList.splice(index + 1, 0, library);
-
-              config.libraryList = libraryList;
-              await this.updateConfig(config);
-            }
-          }
-        }
-      }),
-
-      vscode.commands.registerCommand(`code-for-ibmi.cleanupLibraryList`, async () => {
-        const connection = instance.getConnection();
-        if (connection) {
-          const content = connection.getContent();
-          const config = connection.getConfig();
-          let libraryList = [...config.libraryList];
-          const badLibs = await content.validateLibraryList(libraryList);
-
-          if (badLibs.length > 0) {
-            libraryList = libraryList.filter(lib => !badLibs.includes(lib));
-            vscode.window.showWarningMessage(l10n.t(`The following libraries were removed from the updated library list as they are invalid: {0}`, badLibs.join(', ')));
             config.libraryList = libraryList;
-            await this.updateConfig(config);
-          } else {
-            vscode.window.showInformationMessage(l10n.t(`Library list were validated without any errors.`));
+            await updateConfig(config);
           }
         }
-      }),
+      }
+    }),
 
-      vscode.commands.registerCommand(`code-for-ibmi.setCurrentLibrary`, async (node: WithLibrary) => {
-        const library = node.library;
-        if (library) {
-          const connection = instance.getConnection()
-          const storage = instance.getStorage();
+    vscode.commands.registerCommand(`code-for-ibmi.moveLibraryDown`, async (node: LibraryListNode) => {
+      if (node) {
+        //Running from right click
+        const connection = instance.getConnection();
+        if (connection) {
+          const config = connection.getConfig();
+          const libraryList = config.libraryList;
+          const index = libraryList.findIndex(library => connection.upperCaseName(library) === node.library);
+          if (index >= 0 && (index + 1) >= 0) {
+            const library = libraryList[index];
+            libraryList.splice(index, 1);
+            libraryList.splice(index + 1, 0, library);
 
-          if (connection && storage) {
-            const content = connection.getContent();
-            if (await content.checkObject({ library: "QSYS", name: library, type: "*LIB" })) {
-              await changeCurrentLibrary(library);
-              this.refresh();
-            }
+            config.libraryList = libraryList;
+            await updateConfig(config);
           }
         }
-      })
-    )
+      }
+    }),
+
+    vscode.commands.registerCommand(`code-for-ibmi.cleanupLibraryList`, async () => {
+      const connection = instance.getConnection();
+      if (connection) {
+        const content = connection.getContent();
+        const config = connection.getConfig();
+        let libraryList = [...config.libraryList];
+        const badLibs = await content.validateLibraryList(libraryList);
+
+        if (badLibs.length > 0) {
+          libraryList = libraryList.filter(lib => !badLibs.includes(lib));
+          vscode.window.showWarningMessage(l10n.t(`The following libraries were removed from the updated library list as they are invalid: {0}`, badLibs.join(', ')));
+          config.libraryList = libraryList;
+          await updateConfig(config);
+        } else {
+          vscode.window.showInformationMessage(l10n.t(`Library list were validated without any errors.`));
+        }
+      }
+    }),
+
+    vscode.commands.registerCommand(`code-for-ibmi.setCurrentLibrary`, async (node: WithLibrary) => {
+      const library = node.library;
+      if (library) {
+        const connection = instance.getConnection()
+        const storage = instance.getStorage();
+
+        if (connection && storage) {
+          const content = connection.getContent();
+          if (await content.checkObject({ library: "QSYS", name: library, type: "*LIB" })) {
+            await changeCurrentLibrary(library);
+            libraryListView.refresh();
+          }
+        }
+      }
+    })
+  );
+}
+
+class LibraryListDragAndDrop implements vscode.TreeDragAndDropController<LibraryListNode> {
+  readonly dragMimeTypes = [];
+  readonly dropMimeTypes = [OBJECT_BROWSER_DRAG_MIMETYPE];
+
+  handleDrag(source: readonly LibraryListNode[], dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken): Thenable<void> | void {
+    dataTransfer.set(LIBRARY_LIST_MIMETYPE, new vscode.DataTransferItem(source));
   }
 
-  private async updateConfig(config: ConnectionConfig) {
-    await IBMi.connectionManager.update(config);
-    if (IBMi.connectionManager.get(`autoRefresh`)) {
-      this.refresh();
+  handleDrop(target: LibraryListNode | undefined, dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken): Thenable<void> | void {
+    const libraryItem = dataTransfer.get(LIBRARY_LIST_MIMETYPE)?.value[0] as LibraryListNode;
+    if (libraryItem && libraryItem !== target) {
+      const currentLibrary = libraryItem.contextValue === 'currentLibrary';
+
+      if (target) {
+        if (target?.contextValue === 'currentLibrary') {
+          //Dropped on current library: become current library
+          vscode.commands.executeCommand(`code-for-ibmi.setCurrentLibrary`, libraryItem);
+        }
+        else {
+          //Dropped on a library: push it down and move to its position
+        }
+      }
+      else {
+        //Dropped at the bottom after the last item: move to the last position
+      }
     }
   }
+}
+
+class LibraryListView implements vscode.TreeDataProvider<LibraryListNode> {
+  private readonly _emitter: vscode.EventEmitter<LibraryListNode | undefined | null | void> = new vscode.EventEmitter();
+  readonly onDidChangeTreeData: vscode.Event<LibraryListNode | undefined | null | void> = this._emitter.event;;
 
   refresh(element?: LibraryListNode) {
     this._emitter.fire(element);
@@ -320,7 +357,7 @@ async function changeCurrentLibrary(library: string) {
       await IBMi.connectionManager.update(config);
       return true;
     } else {
-      vscode.window.showErrorMessage(l10n.t(`Failed to set {0} as current library: {1}`, library,  commandResult.stderr));
+      vscode.window.showErrorMessage(l10n.t(`Failed to set {0} as current library: {1}`, library, commandResult.stderr));
       return false;
     }
   }

--- a/src/ui/views/ifsBrowser.ts
+++ b/src/ui/views/ifsBrowser.ts
@@ -8,11 +8,10 @@ import { SortOptions } from "../../api/IBMiContent";
 import { Search } from "../../api/Search";
 import { Tools } from "../../api/Tools";
 import { instance } from "../../instantiate";
-import { FocusOptions, IFSFile, IFS_BROWSER_MIMETYPE, OBJECT_BROWSER_MIMETYPE, SearchHit, SearchResults, URI_LIST_MIMETYPE, WithPath } from "../../typings";
+import { FocusOptions, IFSFile, IFS_BROWSER_MIMETYPE, OBJECT_BROWSER_MIMETYPE, SearchHit, SearchResults, URI_LIST_MIMETYPE, URI_LIST_SEPARATOR, WithPath } from "../../typings";
 import { VscodeTools } from "../Tools";
 import { BrowserItem, BrowserItemParameters } from "../types";
 
-const URI_LIST_SEPARATOR = "\r\n";
 const PROTECTED_DIRS = /^(\/|\/QOpenSys|\/QSYS\.LIB|\/QDLS|\/QOPT|\/QNTC|\/QFileSvr\.400|\/QIBM|\/QSR|\/QTCPTMM|\/bin|\/dev|\/home|\/tmp|\/usr|\/var)$/i;
 const ALWAYS_SHOW_FILES = /^(\.gitignore|\.vscode|\.deployignore)$/i;
 type DragNDropAction = "move" | "copy";
@@ -209,7 +208,7 @@ class IFSBrowserDragAndDrop implements vscode.TreeDragAndDropController<IFSItem>
       .join(URI_LIST_SEPARATOR)));
   }
 
-  async handleDrop(target: IFSItem | undefined, dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken) {
+  handleDrop(target: IFSItem | undefined, dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken) {
     if (target) {
       const toDirectory = (target.file.type === "streamfile" ? target.parent : target) as IFSDirectoryItem;
       const ifsBrowserItems = dataTransfer.get(IFS_BROWSER_MIMETYPE);
@@ -220,7 +219,7 @@ class IFSBrowserDragAndDrop implements vscode.TreeDragAndDropController<IFSItem>
         const explorerItems = dataTransfer.get(URI_LIST_MIMETYPE);
         if (explorerItems?.value) {
           //URI_LIST_MIMETYPE Mime type is a string with `toString()`ed Uris separated by `\r\n`.
-          const uris = (await explorerItems.asString()).split(URI_LIST_SEPARATOR).map(uri => vscode.Uri.parse(uri));
+          const uris = String(explorerItems.value).split(URI_LIST_SEPARATOR).map(uri => vscode.Uri.parse(uri));
           if (uris.at(0)?.scheme === "member") {
             this.copyMembers(uris, toDirectory)
           }

--- a/src/ui/views/ifsBrowser.ts
+++ b/src/ui/views/ifsBrowser.ts
@@ -8,11 +8,10 @@ import { SortOptions } from "../../api/IBMiContent";
 import { Search } from "../../api/Search";
 import { Tools } from "../../api/Tools";
 import { instance } from "../../instantiate";
-import { FocusOptions, IFSFile, IFS_BROWSER_MIMETYPE, OBJECT_BROWSER_MIMETYPE, SearchHit, SearchResults, WithPath } from "../../typings";
+import { FocusOptions, IFSFile, IFS_BROWSER_MIMETYPE, OBJECT_BROWSER_MIMETYPE, SearchHit, SearchResults, URI_LIST_MIMETYPE, WithPath } from "../../typings";
 import { VscodeTools } from "../Tools";
 import { BrowserItem, BrowserItemParameters } from "../types";
 
-const URI_LIST_MIMETYPE = "text/uri-list";
 const URI_LIST_SEPARATOR = "\r\n";
 const PROTECTED_DIRS = /^(\/|\/QOpenSys|\/QSYS\.LIB|\/QDLS|\/QOPT|\/QNTC|\/QFileSvr\.400|\/QIBM|\/QSR|\/QTCPTMM|\/bin|\/dev|\/home|\/tmp|\/usr|\/var)$/i;
 const ALWAYS_SHOW_FILES = /^(\.gitignore|\.vscode|\.deployignore)$/i;


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Related to https://github.com/orgs/codefori/discussions/2702

This PR enables users to reorganize their library list using drag and drop in the library list view.
![Code_r0X65IarAV](https://github.com/user-attachments/assets/e1135a07-3660-4232-8f3d-4ab3a91b48c1)
- Dropping a library on the current library will make it the current library
- Dropping a library on a library in the list will push the library down in the list and put the dropped library in its place
- Dropping a library at the bottom of the view will put that library in last position

Dragging a library from an object browser's filter is also supported (it must be a single library filter or a *LIB object).
![Code_f209uHLDLv](https://github.com/user-attachments/assets/7c943591-de1d-4a65-a0b6-b9eb9abb62c9)

Multi-selection is also enabled.
![Code_nVrEp9tl8u](https://github.com/user-attachments/assets/5268c8ad-e66d-4d6b-a6dd-e8179a1c2c28)

### How to test this PR
1. Drag and drop a library on another libray in the library list view: it must take its place in the list
2. Drag and drop a library at the bottom the view: it must become the last library in the list
3. Select multiple libraries and drop them on a library: the libraries must take its place in the list
4. Drag and drop a library on the current library: it must become the current library
5. Drag and drop a library from the object browser in the library list view: it must be added to the list
6. 5. Drag and drop a library from the object browser on the current library in the library list view: it must become the current library
<!-- 
Example:
1. Run the test cases
7. Expand view A and right click on the node
8. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change