### PR TITLE
Added F2 shortcut for Rename actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1770,6 +1770,21 @@
 				"command": "code-for-ibmi.objectBrowser.delete",
 				"key": "delete",
 				"when": "focusedView === objectBrowser && listHasSelectionOrFocus"
+			},
+			{
+				"command": "code-for-ibmi.moveIFS",
+				"key": "f2",
+				"when": "focusedView === ifsBrowser && listHasSelectionOrFocus && !listMultiSelection && !(viewItem =~ /^.*_protected$/)"
+			},
+			{
+				"command": "code-for-ibmi.renameMember",
+				"key": "f2",
+				"when": "focusedView === objectBrowser && listHasSelectionOrFocus && !listMultiSelection && !(viewItem =~ /^.*_protected$/)"
+			},
+			{
+				"command": "code-for-ibmi.renameObject",
+				"key": "f2",
+				"when": "focusedView === objectBrowser && listHasSelectionOrFocus && !listMultiSelection && !(viewItem =~ /^.*_protected$/)"
 			}
 		],
 		"viewsContainers": {


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
This PR binds the F2 key to the rename actions in the IFS and Object browser:
![image](https://github.com/user-attachments/assets/0a0ba290-b000-4045-ba07-328f99c842f0)

### How to test this PR
1. Select an IFS item and press F2
2. Select an Object browser item and press F2
3. Check it doesn't work when multiple objects are selected
<!-- 
Example:
1. Run the test cases
4. Expand view A and right click on the node
5. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [ ] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
