### PR TITLE
Ensure unique connection storage per session

### DIFF
--- a/src/api/configuration/storage/BaseStorage.ts
+++ b/src/api/configuration/storage/BaseStorage.ts
@@ -1,13 +1,18 @@
 export abstract class BaseStorage {
   protected readonly globalState: any;
 
+  private uniqueKeyPrefix: string|undefined;
   constructor(globalState: any) {  
-    this.globalState = globalState;  
+    this.globalState = globalState;
   }  
 
 
   keys(): readonly string[] {
     return Array.from(this.globalState.keys());
+  }
+
+  setUniqueKeyPrefix(prefix: string) {
+    this.uniqueKeyPrefix = prefix;
   }
 
   get<T>(key: string): T | undefined {
@@ -19,7 +24,7 @@ export abstract class BaseStorage {
   }
 
   getStorageKey(key: string): string {
-    return key;
+    return `${this.uniqueKeyPrefix ? this.uniqueKeyPrefix + '.' : ''}${key}`;
   }
 }
 

--- a/src/api/configuration/storage/CodeForIStorage.ts
+++ b/src/api/configuration/storage/CodeForIStorage.ts
@@ -34,10 +34,6 @@ export type CachedServerSettings = {
 export class CodeForIStorage {
   constructor(private internalStorage: BaseStorage) {}
 
-  protected getStorageKey(key: string): string {
-    return key;
-  }
-
   getLastConnections() {
     return this.internalStorage.get<LastConnection[]>("lastConnections");
   }

--- a/src/api/configuration/storage/ConnectionStorage.ts
+++ b/src/api/configuration/storage/ConnectionStorage.ts
@@ -20,7 +20,8 @@ type AuthorisedExtension = {
 
 export class ConnectionStorage {
   private connectionName: string = "";
-  constructor(private internalStorage: BaseStorage) {}
+  constructor(private internalStorage: BaseStorage) {
+  }
 
   get ready(): boolean {
     if (this.connectionName) {
@@ -33,10 +34,7 @@ export class ConnectionStorage {
 
   setConnectionName(connectionName: string) {
     this.connectionName = connectionName;
-  }
-
-  protected getStorageKey(key: string): string {
-    return `${this.connectionName}.${key}`;
+    this.internalStorage.setUniqueKeyPrefix(`settings-${connectionName}`);
   }
 
   getSourceList() {


### PR DESCRIPTION
Implement a mechanism to set a unique key prefix for connection storage, ensuring that each connection maintains its own distinct storage context. This change enhances the organization and retrieval of connection-specific data.