### PR TITLE
Update IBMiContent.ts to use validQsysName

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -453,17 +453,12 @@ export default class IBMiContent {
 
     newLibl = newLibl
       .filter(lib => {
-        if (lib.match(/^\d/)) {
-          badLibs.push(lib);
-          return false;
+        const isValid = this.ibmi.validQsysName(lib);        
+        if(!isValid){
+          badLibs.push(lib);          
         }
-
-        if (lib.length > 10) {
-          badLibs.push(lib);
-          return false;
-        }
-
-        return true;
+        
+        return isValid;
       });
 
     const sanitized = Tools.sanitizeObjNamesForPase(newLibl);


### PR DESCRIPTION
Use validQsysName rather than individual checks. #2366 

### Changes
Removed individual checks within `validateLibraryList` method and changed it to `IBMI.validQsysName` method.

### How to test this PR
I tested this change by using the `Add to Library List` command. I tested adding a library name of '!@#$%'.

I wasn't able to test the length > 10 case, because there is a check in `code-for-ibmi.addToLibraryList` for that case, before the call to `validateLibraryList`.

 I noticed that there was some test suites that tested `validateLibraryList`, but I wasn't sure how to run them. Is there a way for me to call these test suites? Thanks.

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
