### PR TITLE
Update SQL query in downloadMemberContentWithDates to handle specific…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,4 +64,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@bspotswood](https://github.com/bspotswood)
 * [@dcmcdoug](https://github.com/dcmcdoug)
 * [@nathaniel-king-navarrete](https://github.com/Nathaniel-King-Navarrete)
-* [@elmais](https://github.com/e1mais)
+* [@e1mais](https://github.com/e1mais)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,3 +64,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@bspotswood](https://github.com/bspotswood)
 * [@dcmcdoug](https://github.com/dcmcdoug)
 * [@nathaniel-king-navarrete](https://github.com/Nathaniel-King-Navarrete)
+* [@elmais](https://github.com/e1mais)

--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -42,7 +42,7 @@ export class ExtendedIBMiContent {
       }
 
       let rows = await connection.runSQL(
-        `select srcdat, srcdta from ${aliasPath}`,
+        `select case when locate('40',hex(srcdat)) > 0 then 0 else srcdat end as srcdat, srcdta from ${aliasPath}`,
         {forceSafe: true}
       );
 


### PR DESCRIPTION
### Changes

Hello everyone,

This Pull Request addresses an issue that occurs when trying to open source members generated by the RTVBNDSRC (Retrieve Binder Source) command using the Code for IBM i extension.

The purpose of RTVBNDSRC is to retrieve the export symbols EXPORT SYMBOL("PROCNAME") from an object of type MODULE or SRVPGM, and write them into a source member. This source is then used as input for the CRTSRVPGM command, allowing the signature of the SRVPGM to be preserved when it is regenerated.

**Problem**

The source member generated by RTVBNDSRC does not contain a valid date in the SRCDAT field. As a result, when the extension tries to open the member using the ALIAS object, it fails, as shown in the image below:

![imagen](https://github.com/user-attachments/assets/cc02a08c-9430-465a-976f-74d5dad36875)


The extension accesses the content of source members using this ALIAS object. However, if the SRCDAT field contains blank spaces (which is invalid for a NUMERIC(6,0) field), an SQL error occurs when attempting to read the data:

- SQL0802 – Data conversion or data mapping error

- SQLSTATE 01004 – Truncation warning

- Error type: 6

**Solution**

To avoid these conversion or mapping errors when opening members with invalid SRCDAT values, I have modified the query used by the extension. It now returns 0 as the value for SRCDAT when blank spaces are detected, and the original value when it's valid, thus preventing the aforementioned failures.

I appreciate any feedback or suggestions you may have regarding this solution.

Steps to reproduce the issue:
1. Create or use an existing module.

2. Create a BND-type member in your own source file:
    ```cl
    ADDPFM FILE(*CURLIB/QSRCBND) MBR(BNDSRC1) TEXT('Example BND source member') SRCTYPE(BND)
    ```
3. Use the RTVBNDSRC command to retrieve the export symbols into the created member:

    ```cl
    RTVBNDSRC MODULE(*CURLIB/MODULE1) SRCFILE(*CURLIB/QSRCBND) SRCMBR(BNDSRC1)
    ```
4. Open the member using Code for IBM i and observe the error.


### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
