### PR TITLE
Fixed download of members with variant characters

### DIFF
--- a/src/ui/views/objectBrowser.ts
+++ b/src/ui/views/objectBrowser.ts
@@ -943,8 +943,8 @@ Do you want to replace it?`, item.name), { modal: true }, skipAllLabel, overwrit
                 .filter(item => item.copy)
                 .map(item =>
                   [
-                    `@QSYS/CPYF FROMFILE(${item.member.library}/${item.member.file}) TOFILE(QTEMP/QTEMPSRC) FROMMBR(${item.member.name}) TOMBR(${item.member.name}) MBROPT(*ADD) CRTFILE(*YES);`,
-                    `@QSYS/CPYTOSTMF FROMMBR('${Tools.qualifyPath("QTEMP", "QTEMPSRC", item.member.name, undefined)}') TOSTMF('${directory}/${item.name.toLocaleLowerCase()}') STMFOPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${config.sourceFileCCSID});`
+                    `@QSYS/CPYF FROMFILE(${item.member.library}/${item.member.file}) TOFILE(QTEMP/QTEMPSRC) FROMMBR(${item.member.name}) TOMBR(TEMPMBR) MBROPT(*REPLACE) CRTFILE(*YES);`,
+                    `@QSYS/CPYTOSTMF FROMMBR('${Tools.qualifyPath("QTEMP", "QTEMPSRC", "TEMPMBR")}') TOSTMF('${directory}/${item.name.toLocaleLowerCase()}') STMFOPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${config.sourceFileCCSID});`
                   ].join("\n"))
                 .join("\n");
               await connection.runSQL(copyToStreamFiles);


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Fixes #2728 

Downloading a member with the `$` or `à` variant characters would fail because:
- `$` was escaped by `Tools.qualifyPath`
- `à` would be uppercased when `CPYTOSTMF` was run (don't know exactly why...it is sent lowercased by us)

Using a dummy member name while transferring the member to a stream file fixes both issues.

### How to test this PR
1. Create a member with `$` (CSSID 37 or 297) or `à` (CSSID 297) in its name
2. Right click and download it
<!-- 
Example:
1. Run the test cases
3. Expand view A and right click on the node
4. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change