### PR TITLE
#2344 Increase VS Code scroll back by default

### DIFF
--- a/src/instantiate.ts
+++ b/src/instantiate.ts
@@ -94,6 +94,11 @@ export async function loadAllofExtension(context: vscode.ExtensionContext) {
     })
   );
 
+  const MINIMUM_SCROLLBACK = 10000;
+  if(<number>vscode.workspace.getConfiguration().get('terminal.integrated.scrollback') < MINIMUM_SCROLLBACK){
+    vscode.workspace.getConfiguration().update('terminal.integrated.scrollback', MINIMUM_SCROLLBACK, true);
+  }
+
   // Register git events based on workspace folders
   if (vscode.workspace.workspaceFolders) {
     setupGitEventHandler(context);


### PR DESCRIPTION
If the scrollback is less than a minimum amount, then set it to that minimum amount.

### Changes
During the instantiate process, set the scollback to a minimum amount. This will globally change the terminal.integrated.scrollback value. If the user has a prefered scollback larger than the minimum, then it will not be update.

### How to test this PR
Two test cases:
1. Scollback value is defined as less than minimum
     1.  terminal.integrated.scrollback within settings.json will be updated to 10000.
2. Scrollback value is defined as equal to minimum or more than minimum.
     1. terminal.integrated.scrollback within settings.json will remain unchanged.

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [] have created one or more test cases
* [] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
