### PR TITLE
Fixed multiple download/delete of IFS directories starting with the same name

### DIFF
--- a/src/api/tests/suites/content.test.ts
+++ b/src/api/tests/suites/content.test.ts
@@ -236,7 +236,7 @@ describe('Content Tests', { concurrent: true }, () => {
       await connection.runSQL('select from qiws.qcustcdt');
       expect.fail('Should have thrown an error');
     } catch (e: any) {
-      expect(e.message).toBe('Token . was not valid. Valid tokens: , FROM INTO. (42601)');
+      expect(e.message.endsWith(': , FROM INTO. (42601)')).toBeTruthy();
       expect(e.sqlstate).toBe('42601');
     }
   });
@@ -622,7 +622,7 @@ describe('Content Tests', { concurrent: true }, () => {
     const shortName = Tools.makeid(8);
     const createLib = await connection.runCommand({ command: `RUNSQL 'create schema "${longName}" for ${shortName}' commit(*none)`, noLibList: true });
     if (createLib.code === 0) {
-      await connection.runCommand({ command: `CRTSRCPF FILE(${shortName}/SFILE) MBR(MBR) TEXT('Test long library name')` });
+      const result = await connection.runCommand({ command: `CRTSRCPF FILE(${shortName}/SFILE) MBR(MBR) TEXT('Test long library name')` });
 
       const libraries = await content.getLibraries({ library: `${shortName}` });
       expect(libraries?.length).toBe(1);

--- a/src/api/tests/suites/content.test.ts
+++ b/src/api/tests/suites/content.test.ts
@@ -622,23 +622,26 @@ describe('Content Tests', { concurrent: true }, () => {
     const shortName = Tools.makeid(8);
     const createLib = await connection.runCommand({ command: `RUNSQL 'create schema "${longName}" for ${shortName}' commit(*none)`, noLibList: true });
     if (createLib.code === 0) {
-      const result = await connection.runCommand({ command: `CRTSRCPF FILE(${shortName}/SFILE) MBR(MBR) TEXT('Test long library name')` });
+      try {
+        await connection.runCommand({ command: `CRTSRCPF FILE(${shortName}/SFILE) MBR(MBR) TEXT('Test long library name')` });
 
-      const libraries = await content.getLibraries({ library: `${shortName}` });
-      expect(libraries?.length).toBe(1);
+        const libraries = await content.getLibraries({ library: `${shortName}` });
+        expect(libraries?.length).toBe(1);
 
-      const objects = await content.getObjectList({ library: `${shortName}`, types: [`*SRCPF`], object: `SFILE` });
-      expect(objects?.length).toBe(1);
-      expect(objects[0].type).toBe(`*FILE`);
-      expect(objects[0].text).toBe(`Test long library name`);
+        const objects = await content.getObjectList({ library: `${shortName}`, types: [`*SRCPF`], object: `SFILE` });
+        expect(objects?.length).toBe(1);
+        expect(objects[0].type).toBe(`*FILE`);
+        expect(objects[0].text).toBe(`Test long library name`);
 
-      const memberCount = await content.countMembers({ library: `${shortName}`, name: `SFILE` });
-      expect(memberCount).toBe(1);
-      const members = await content.getMemberList({ library: `${shortName}`, sourceFile: `SFILE` });
+        const memberCount = await content.countMembers({ library: `${shortName}`, name: `SFILE` });
+        expect(memberCount).toBe(1);
+        const members = await content.getMemberList({ library: `${shortName}`, sourceFile: `SFILE` });
 
-      expect(members?.length).toBe(1);
-
-      await connection.runCommand({ command: `RUNSQL 'drop schema "${longName}"' commit(*none)`, noLibList: true });
+        expect(members?.length).toBe(1);
+      }
+      finally {
+        await connection.runCommand({ command: `RUNSQL 'drop schema "${longName}"' commit(*none)`, noLibList: true });
+      }
     } else {
       throw new Error(`Failed to create schema "${longName}"`);
     }
@@ -737,7 +740,7 @@ describe('Content Tests', { concurrent: true }, () => {
       await connection.sendCommand({ command: `${connection.remoteFeatures.attr} ${directory}/${ccsid37File} CCSID=37` });
       await checkFile(`${directory}/${ccsid37File}`, 37);
       const files = [`${directory}/${unicodeFile}`, `${directory}/${ccsid37File}`];
-      
+
       expect((await connection.sendCommand({ command: `mkdir ${directory}/copy` })).code).toBe(0);
       expect((await content.copy(files, `${directory}/copy`)).code).toBe(0);
       expect(await content.testStreamFile(`${directory}/${unicodeFile}`, "f")).toBe(true);

--- a/src/ui/views/ifsBrowser.ts
+++ b/src/ui/views/ifsBrowser.ts
@@ -1064,5 +1064,5 @@ async function showOpenDialog() {
  * Filters the content of an IFSItem array to keep only items whose parent are not in the array
  */
 function reduceIFSPath(item: IFSItem, index: number, array: IFSItem[]) {
-  return !array.filter(i => i.file.type === "directory" && i !== item).some(folder => item.file.path.startsWith(folder.file.path));
+  return !array.filter(i => i.file.type === "directory" && i !== item).some(folder => item.file.path.startsWith(`${folder.file.path}/`));
 }


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Fixes #2725

The `reduceIFSPath` that is supposed to filter out IFS elements from an array whose parent folder is in that same array.
There was a bug that made the function filter out elements that started with a folder name present in the array.

For example, when selecting these three folders, only one would be picked up for deletion:
![image](https://github.com/user-attachments/assets/07b6bc23-8729-4a9d-b107-2b3d10e56cf2)
![image](https://github.com/user-attachments/assets/d74868e4-6e82-4775-bd3a-45fca2cc9286)

After the PR is applied, the three folders are correctly picked up:
![image](https://github.com/user-attachments/assets/899bdee0-7813-4de3-a8cd-f4d0d7ca8043)

And the method still filters out elements with a common parent item (e.g. selecting a folder and its files):
![image](https://github.com/user-attachments/assets/9a660fb9-590d-494a-abcd-d27472345682)


### How to test this PR
1. Create two or more folders starting with the same name
2. Select them all and run the `Delete` action
3. All folders should be picked up for deletion
<!-- 
Example:
1. Run the test cases
4. Expand view A and right click on the node
5. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change