### PR TITLE
Add additional check for SIGABRT

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -1115,6 +1115,7 @@ export default class IBMi {
 
     // Some simplification
     if (result.code === null) result.code = 0;
+    if (result.signal === `SIGABRT`) result.code = 127;
 
     this.appendOutput(JSON.stringify(result, null, 4) + `\n\n`);
 

--- a/src/api/tests/suites/content.test.ts
+++ b/src/api/tests/suites/content.test.ts
@@ -236,7 +236,7 @@ describe('Content Tests', { concurrent: true }, () => {
       await connection.runSQL('select from qiws.qcustcdt');
       expect.fail('Should have thrown an error');
     } catch (e: any) {
-      expect(e.message).toBe('Token . was not valid. Valid tokens: , FROM INTO. (42601)');
+      expect(e.message.endsWith(': , FROM INTO. (42601)')).toBeTruthy();
       expect(e.sqlstate).toBe('42601');
     }
   });
@@ -622,7 +622,7 @@ describe('Content Tests', { concurrent: true }, () => {
     const shortName = Tools.makeid(8);
     const createLib = await connection.runCommand({ command: `RUNSQL 'create schema "${longName}" for ${shortName}' commit(*none)`, noLibList: true });
     if (createLib.code === 0) {
-      await connection.runCommand({ command: `CRTSRCPF FILE(${shortName}/SFILE) MBR(MBR) TEXT('Test long library name')` });
+      const result = await connection.runCommand({ command: `CRTSRCPF FILE(${shortName}/SFILE) MBR(MBR) TEXT('Test long library name')` });
 
       const libraries = await content.getLibraries({ library: `${shortName}` });
       expect(libraries?.length).toBe(1);

--- a/src/api/tests/suites/content.test.ts
+++ b/src/api/tests/suites/content.test.ts
@@ -622,23 +622,26 @@ describe('Content Tests', { concurrent: true }, () => {
     const shortName = Tools.makeid(8);
     const createLib = await connection.runCommand({ command: `RUNSQL 'create schema "${longName}" for ${shortName}' commit(*none)`, noLibList: true });
     if (createLib.code === 0) {
-      const result = await connection.runCommand({ command: `CRTSRCPF FILE(${shortName}/SFILE) MBR(MBR) TEXT('Test long library name')` });
+      try {
+        await connection.runCommand({ command: `CRTSRCPF FILE(${shortName}/SFILE) MBR(MBR) TEXT('Test long library name')` });
 
-      const libraries = await content.getLibraries({ library: `${shortName}` });
-      expect(libraries?.length).toBe(1);
+        const libraries = await content.getLibraries({ library: `${shortName}` });
+        expect(libraries?.length).toBe(1);
 
-      const objects = await content.getObjectList({ library: `${shortName}`, types: [`*SRCPF`], object: `SFILE` });
-      expect(objects?.length).toBe(1);
-      expect(objects[0].type).toBe(`*FILE`);
-      expect(objects[0].text).toBe(`Test long library name`);
+        const objects = await content.getObjectList({ library: `${shortName}`, types: [`*SRCPF`], object: `SFILE` });
+        expect(objects?.length).toBe(1);
+        expect(objects[0].type).toBe(`*FILE`);
+        expect(objects[0].text).toBe(`Test long library name`);
 
-      const memberCount = await content.countMembers({ library: `${shortName}`, name: `SFILE` });
-      expect(memberCount).toBe(1);
-      const members = await content.getMemberList({ library: `${shortName}`, sourceFile: `SFILE` });
+        const memberCount = await content.countMembers({ library: `${shortName}`, name: `SFILE` });
+        expect(memberCount).toBe(1);
+        const members = await content.getMemberList({ library: `${shortName}`, sourceFile: `SFILE` });
 
-      expect(members?.length).toBe(1);
-
-      await connection.runCommand({ command: `RUNSQL 'drop schema "${longName}"' commit(*none)`, noLibList: true });
+        expect(members?.length).toBe(1);
+      }
+      finally {
+        await connection.runCommand({ command: `RUNSQL 'drop schema "${longName}"' commit(*none)`, noLibList: true });
+      }
     } else {
       throw new Error(`Failed to create schema "${longName}"`);
     }
@@ -737,7 +740,7 @@ describe('Content Tests', { concurrent: true }, () => {
       await connection.sendCommand({ command: `${connection.remoteFeatures.attr} ${directory}/${ccsid37File} CCSID=37` });
       await checkFile(`${directory}/${ccsid37File}`, 37);
       const files = [`${directory}/${unicodeFile}`, `${directory}/${ccsid37File}`];
-      
+
       expect((await connection.sendCommand({ command: `mkdir ${directory}/copy` })).code).toBe(0);
       expect((await content.copy(files, `${directory}/copy`)).code).toBe(0);
       expect(await content.testStreamFile(`${directory}/${unicodeFile}`, "f")).toBe(true);

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -37,6 +37,7 @@ export interface CommandData extends StandardIO {
 
 export interface CommandResult {
   code: number;
+  signal?: string|null;
   stdout: string;
   stderr: string;
   command?: string;


### PR DESCRIPTION
Looks like there is a bug with our node library. We have an instance when an IBM i system is not setup correctly, then SIGABRT is thrown, but the `code` is still `0` - which in most of the extension, indicates success.

```
/home/OLVERA: /home/OLVERA/.vscode/cqsh_1
echo "Hello world"
{
    "code": 0,
    "signal": "SIGABRT",
    "stdout": "",
    "stderr": ""
}
```

I've added some logic to our statement executor to set the code to `127` when `SIGABRT` is thrown.

I have also added a page in the docs to track this issue (which we've now seen a couple of times in the wild, but we are still unsure of the cause): https://codefori.github.io/docs/tips/setup/#qsh--cqsh-returning-sigabrt