### PR TITLE
Server configuration and apply to every client

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,12 @@
 					".vscode/actions.json"
 				],
 				"url": "./schemas/actions.json"
+			},
+			{
+				"fileMatch": [
+					"/etc/vscode/codefori.json"
+				],
+				"url": "./schemas/codefori.json"
 			}
 		],
 		"configuration": {

--- a/schemas/codefori.json
+++ b/schemas/codefori.json
@@ -7,7 +7,8 @@
         "tempLibrary": {
           "type": "string",
           "default": "ILEDITOR",
-          "description": "Temporary library. Cannot be QTEMP."
+          "description": "Temporary library. Cannot be QTEMP.",
+          "maxLength": 10
         },
         "tempDir": {
           "type": "string",

--- a/schemas/codefori.json
+++ b/schemas/codefori.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "CodeForI": {
+      "type": "object",
+      "properties": {
+        "tempLibrary": {
+          "type": "string",
+          "default": "ILEDITOR",
+          "description": "Temporary library. Cannot be QTEMP."
+        },
+        "tempDir": {
+          "type": "string",
+          "default": "/tmp",
+          "description": "Temporary directory."
+        },
+        "autoClearTempData": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically delete temporary objects from the temporary library on startup."
+        },
+        "sourceFileCCSID": {
+          "type": "string",
+          "default": "*FILE",
+          "description": "The CCSID of source files on your system. You should only change this setting from `*FILE` if you have a source file that is 65535 - otherwise use `*FILE`. Note that this config is used to fetch all members. If you have any source files using 65535, you have bigger problems."
+        },
+        "enableSourceDates": {
+          "type": "boolean",
+          "default": false,
+          "description": "When enabled, Code for IBM i will retain/update source dates of members when editing source members. Requires SQL to be enabled for this feature to work. If this config is changed, you must reconnect to the system."
+        },
+        "encodingFor5250": {
+          "type": "string",
+          "default": "default",
+          "enum": [
+            "default",
+            "37",
+            "256",
+            "273",
+            "277",
+            "278",
+            "280",
+            "284",
+            "285",
+            "297",
+            "500",
+            "871",
+            "870",
+            "905",
+            "880",
+            "420",
+            "875",
+            "424",
+            "1026",
+            "290",
+            "win37",
+            "win256",
+            "win273",
+            "win277",
+            "win278",
+            "win280",
+            "win284",
+            "win285",
+            "win297",
+            "win500",
+            "win871",
+            "win870",
+            "win905",
+            "win880",
+            "win420",
+            "win875",
+            "win424",
+            "win1026"
+          ],
+          "description": "The encoding for the 5250 emulator. To use the 5250 emulator, tn5250 must be installed on the remote system via yum."
+        },
+        "terminalFor5250": {
+          "type": "string",
+          "default": "default",
+          "enum": [
+            "default",
+            "IBM-3477-FC",
+            "IBM-3477-FG",
+            "IBM-3180-2 ",
+            "IBM-3179-2 ",
+            "IBM-3196-A1",
+            "IBM-5292-2",
+            "IBM-5291-1",
+            "IBM-5251-11"
+          ],
+          "description": "The terminal type for the 5250 emulator. To use the 5250 emulator, tn5250 must be installed on the remote system via yum."
+        },
+        "connectringStringFor5250": {
+          "type": "string",
+          "default": "+uninhibited localhost",
+          "description": "The connectring string for the 5250 emulator. To use the 5250 emulator, tn5250 must be installed on the remote system via yum."
+        },
+        "debugPort": {
+          "type": "string",
+          "default": "8005",
+          "description": "Port to connect to IBM i Debug Service."
+        },
+        "debugSepPort": {
+          "type": "string",
+          "default": "8008",
+          "description": "Port to connect to IBM i Debug Service for SEP."
+        }
+      }
+    },
+    "TopLevel": {
+      "type": "object",
+      "properties": {
+        "codefori": {
+          "$ref": "#/definitions/CodeForI"
+        }
+      }
+    }
+  },
+  "$ref": "#/definitions/TopLevel"
+}

--- a/src/api/configuration/config/types.ts
+++ b/src/api/configuration/config/types.ts
@@ -36,6 +36,10 @@ export interface ConnectionConfig extends ConnectionProfile {
   [name: string]: any;
 }
 
+export interface RemoteConfigFile {
+  codefori?: Partial<ConnectionConfig>;
+}
+
 export interface ObjectFilters {
   name: string
   filterType: FilterType

--- a/src/api/configuration/serverFile.ts
+++ b/src/api/configuration/serverFile.ts
@@ -1,0 +1,91 @@
+
+import path from "path";
+import { RelativePattern, workspace, WorkspaceFolder } from "vscode";
+import IBMi from "../IBMi";
+
+const WORKSPACE_ROOT = `.vscode`;
+const SERVER_ROOT = path.posix.join(`/`, `etc`, `vscode`);
+
+type ConfigResult = `not_loaded`|`no_exist`|`failed_to_parse`|`invalid`|`ok`;
+
+interface LoadResult {
+  workspace: ConfigResult;
+  server: ConfigResult;
+}
+
+export class ConfigFile<T> {
+  private state: LoadResult = {server: `not_loaded`, workspace: `not_loaded`};
+  private basename: string;
+  private workspaceFile: string;
+  private serverFile: string;
+  private serverData: T|undefined;
+
+  public validateData: ((loadedConfig: any) => T)|undefined;
+
+  constructor(private connection: IBMi, configId: string, readonly fallback: T) {
+    this.basename = configId + `.json`;
+    this.workspaceFile = path.join(WORKSPACE_ROOT, this.basename);
+    this.serverFile = path.posix.join(SERVER_ROOT, this.basename);
+  }
+
+  getPaths() {
+    return {
+      workspace: this.workspaceFile,
+      server: this.serverFile,
+    }
+  }
+
+  async loadFromServer() {
+    let serverConfig: any|undefined;
+
+    this.state.server = `no_exist`;
+
+    const isAvailable = await this.connection.getContent().testStreamFile(this.serverFile, `r`);
+    if (isAvailable) {
+      const content = await this.connection.getContent().downloadStreamfileRaw(this.serverFile);
+      try {
+        serverConfig = JSON.parse(content.toString());
+        this.state.server = `ok`;
+      } catch (e: any) {
+        this.state.server = `failed_to_parse`;
+      }
+
+      if (this.validateData) {
+        // Should throw an error.
+        try {
+          this.serverData = this.validateData(serverConfig);
+        } catch (e) {
+          this.state.server = `invalid`;
+          this.serverData = undefined;
+        }
+      } else {
+        this.serverData = serverConfig;
+      }
+    }
+  }
+
+  async get(): Promise<T> {
+    let resultingConfig = this.serverData;
+
+    if (this.validateData) {
+      // Should throw an error.
+      try {
+        resultingConfig = this.validateData(resultingConfig);
+      } catch (e: any) {
+        resultingConfig = this.fallback;
+        this.state.workspace = `invalid`;
+        console.log(`Error validating config file: ${e.message}`);
+      }
+    }
+
+    return resultingConfig as T;
+  }
+
+  reset() {
+    this.serverData = undefined;
+  }
+
+  getState() {
+    return this.state;
+  }
+}

--- a/src/api/configuration/serverFile.ts
+++ b/src/api/configuration/serverFile.ts
@@ -9,14 +9,12 @@ const SERVER_ROOT = path.posix.join(`/`, `etc`, `vscode`);
 type ConfigResult = `not_loaded`|`no_exist`|`failed_to_parse`|`invalid`|`ok`;
 
 interface LoadResult {
-  workspace: ConfigResult;
   server: ConfigResult;
 }
 
 export class ConfigFile<T> {
-  private state: LoadResult = {server: `not_loaded`, workspace: `not_loaded`};
+  private state: LoadResult = {server: `not_loaded`};
   private basename: string;
-  private workspaceFile: string;
   private serverFile: string;
   private serverData: T|undefined;
 
@@ -24,13 +22,11 @@ export class ConfigFile<T> {
 
   constructor(private connection: IBMi, configId: string, readonly fallback: T) {
     this.basename = configId + `.json`;
-    this.workspaceFile = path.join(WORKSPACE_ROOT, this.basename);
     this.serverFile = path.posix.join(SERVER_ROOT, this.basename);
   }
 
   getPaths() {
     return {
-      workspace: this.workspaceFile,
       server: this.serverFile,
     }
   }
@@ -64,25 +60,13 @@ export class ConfigFile<T> {
     }
   }
 
-  async get(): Promise<T> {
-    let resultingConfig = this.serverData;
-
-    if (this.validateData) {
-      // Should throw an error.
-      try {
-        resultingConfig = this.validateData(resultingConfig);
-      } catch (e: any) {
-        resultingConfig = this.fallback;
-        this.state.workspace = `invalid`;
-        console.log(`Error validating config file: ${e.message}`);
-      }
-    }
-
-    return resultingConfig as T;
+  async get() {
+    return this.serverData;
   }
 
   reset() {
     this.serverData = undefined;
+    this.state.server = `not_loaded`;
   }
 
   getState() {

--- a/src/webviews/CustomUI.ts
+++ b/src/webviews/CustomUI.ts
@@ -582,7 +582,7 @@ export class Field {
       case `checkbox`:
         return /* html */`
           <vscode-form-group variant="settings-group">
-            <vscode-checkbox id="${this.id}" name="${this.id}" ${this.default === `checked` ? `checked` : ``} label="${this.label}"></vscode-checkbox>
+            <vscode-checkbox id="${this.id}" name="${this.id}" ${this.default === `checked` ? `checked` : ``} label="${this.label}" ${this.readonly ? `disabled` : ``}></vscode-checkbox>
             ${this.renderDescription()}
           </vscode-form-group>`;
 
@@ -669,7 +669,7 @@ export class Field {
           <vscode-form-group variant="settings-group">
               ${this.renderLabel()}
               ${this.renderDescription()}
-              <vscode-single-select id="${this.id}" name="${this.id}">
+              <vscode-single-select id="${this.id}" name="${this.id}" ${this.readonly ? `readonly` : ``}>
                   ${this.items?.map(item => /* html */`<vscode-option ${item.selected ? `selected` : ``} value="${item.value}" description="${item.text}">${item.description}</vscode-option>`)}
               </vscode-single-select>
           </vscode-form-group>`;

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -61,6 +61,8 @@ export class SettingsUI {
           }
         }
 
+        const hasServerProperties = serverConfig && serverConfig.codefori && Object.keys(serverConfig.codefori).length > 0;
+
         const setFieldsReadOnly = async (currentSection: Section) => {
           if (serverConfig && serverConfig.codefori) {
             for (const field of currentSection.fields) {
@@ -77,6 +79,13 @@ export class SettingsUI {
         let restart = false;
 
         const featuresTab = new Section();
+
+        if (hasServerProperties) {
+          featuresTab
+            .addParagraph(`Some of these settings have been set on the server and cannot be changed here.`)
+            .addHorizontalRule();
+        }
+
         featuresTab
           .addCheckbox(`quickConnect`, `Quick Connect`, `When enabled, server settings from previous connection will be used, resulting in much quicker connection. If server settings are changed, right-click the connection in Connection Browser and select <code>Connect and Reload Server Settings</code> to refresh the cache.`, config.quickConnect)
           .addCheckbox(`showDescInLibList`, `Show description of libraries in User Library List view`, `When enabled, library text and attribute will be shown in User Library List. It is recommended to also enable SQL for this.`, config.showDescInLibList)


### PR DESCRIPTION
It's been quite clear we need a way to set a default configuration for all users that connect to a specific system. This adds a new config file that will be read on startup, `/etc/vscode/codefori.json`, and will do two things:

* apply the server settings to the user's connection config
* disable those properties from being edited in the UI

<img width="801" alt="image" src="https://github.com/user-attachments/assets/0b646fdc-7647-468e-a468-d41e63f08ffd" />

You will also notice that not all properties were added to the settings schema. I didn't add anything that could come down to personal preference, like _source date gutter_.

### How to test

1. Connect to a system with no system config file
2. Ensure all connection setting fields are editable
3. Create `/etc/vscode/codefori.json` and test that the JSON schema is working as expected
4. Restart the connection and ensure the fields that were configured in the server settings are reflected in the connection settings UI

### To do

* [ ] Documentation