### PR TITLE
Render sequence numbers in the editor

### DIFF
--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -42,7 +42,7 @@ export class ExtendedIBMiContent {
       }
 
       let rows = await connection.runSQL(
-        `select case when locate('40',hex(srcdat)) > 0 then 0 else srcdat end as srcdat, srcdta from ${aliasPath}`,
+        `select case when locate('40',hex(srcdat)) > 0 then 0 else srcdat end as srcdat, srcseq, srcdta from ${aliasPath}`,
         {forceSafe: true}
       );
 
@@ -50,6 +50,7 @@ export class ExtendedIBMiContent {
         rows.push({
           SRCDAT: 0,
           SRCDTA: ``,
+          SRCSEQ: 0
         });
       }
 
@@ -57,10 +58,11 @@ export class ExtendedIBMiContent {
       const body = rows
         .map(row => row.SRCDTA)
         .join(`\n`);
+      const sequences = rows.map(row => String(row.SRCSEQ).padStart(6, `0`));
 
       this.sourceDateHandler.baseDates.set(alias, sourceDates);
-
       this.sourceDateHandler.baseSource.set(alias, body);
+      this.sourceDateHandler.baseSequences.set(alias, sequences);
 
       return body;
     }
@@ -182,6 +184,7 @@ export class ExtendedIBMiContent {
 
         this.sourceDateHandler.baseSource.set(alias, body);
         this.sourceDateHandler.baseDates.set(alias, sourceDates);
+        this.sourceDateHandler.baseSequences.delete(alias);
       }
     }
   }

--- a/src/filesystems/qsys/sourceDateHandler.ts
+++ b/src/filesystems/qsys/sourceDateHandler.ts
@@ -41,8 +41,9 @@ const lengthDiagnostics = vscode.languages.createDiagnosticCollection(`Record Le
 
 export class SourceDateHandler {
   readonly baseDates: Map<string, string[]> = new Map;
-  readonly baseSource: Map<string, string> = new Map
-  readonly recordLengths: Map<string, number> = new Map
+  readonly baseSource: Map<string, string> = new Map;
+  readonly recordLengths: Map<string, number> = new Map;
+  readonly baseSequences: Map<string, string[]> = new Map;
 
   private enabled: boolean = false;
 
@@ -52,6 +53,7 @@ export class SourceDateHandler {
   private highlightSince?: number;
   private highlightBefore?: number;
   private lineEditedBefore?: number;
+  private sequenceNumbersShowing: boolean = false;
   private readonly sourceDateSearchBarItem: vscode.StatusBarItem;
 
   constructor(context: vscode.ExtensionContext) {
@@ -70,6 +72,7 @@ export class SourceDateHandler {
       vscode.commands.registerCommand(`code-for-ibmi.toggleSourceDateGutter`, () => this.toggleSourceDateGutter()),
       vscode.commands.registerCommand(`code-for-ibmi.member.clearDateSearch`, () => this.clearDateSearch()),
       vscode.commands.registerCommand(`code-for-ibmi.member.newDateSearch`, () => this.newDateSearch()),
+      vscode.commands.registerCommand(`code-for-ibmi.toggleSequenceNumbers`, () => this.toggleSequenceNumbers()),
       this.sourceDateSearchBarItem
     );
   }
@@ -183,15 +186,48 @@ export class SourceDateHandler {
     const connection = instance.getConnection();
     if (connection && document.uri.scheme === `member`) {
       const config = connection.getConfig();
+      const alias = getAliasName(document.uri);
+
+      let lineGutters: vscode.DecorationOptions[] = [];
 
       if (config && config.sourceDateGutter) {
-        const alias = getAliasName(document.uri);
-
         const sourceDates = this.baseDates.get(alias);
-        if (sourceDates) {
+        const sequenceNumbers = this.baseSequences.get(alias);
+        const sequenceNumbersAvailable = !document.isDirty && sequenceNumbers && sequenceNumbers.length === document.lineCount;
+        const shouldShowSequences = this.sequenceNumbersShowing && sequenceNumbersAvailable;
+
+        if (shouldShowSequences) {
+          const markdownString = [
+            `[Show source dates](command:code-for-ibmi.toggleSequenceNumbers)`,
+          ].join(`\n\n---\n\n`);
+
+          const hoverMessage = new vscode.MarkdownString(markdownString);
+          hoverMessage.isTrusted = true;
+
+          for (let cLine = 0; cLine < sequenceNumbers.length && cLine < document.lineCount; cLine++) {
+            const sequenceNumber = sequenceNumbers[cLine];
+            lineGutters.push({
+              range: new vscode.Range(
+                new vscode.Position(cLine, 0),
+                new vscode.Position(cLine, 0)
+              ),
+              hoverMessage,
+              renderOptions: {
+                before: {
+                  contentText: sequenceNumber,
+                },
+              },
+            });
+          }
+
+          const activeEditor = vscode.window.activeTextEditor;
+          if (activeEditor && activeEditor.document.uri.fsPath === document.uri.fsPath) {
+            activeEditor.setDecorations(annotationDecoration, lineGutters);
+          }
+
+        } else if (sourceDates) {
           const dates = document.isDirty ? this.calcNewSourceDates(alias, document.getText()) : sourceDates;
 
-          let lineGutters: vscode.DecorationOptions[] = [];
           let changedLined: vscode.DecorationOptions[] = [];
 
           const currentDate = currentStamp();
@@ -199,13 +235,13 @@ export class SourceDateHandler {
 
           const markdownString = [
             `[Show changes since last local save](command:workbench.files.action.compareWithSaved)`,
-            `---`,
-            `${this.highlightSince ? `[Clear date search](command:code-for-ibmi.member.clearDateSearch) | ` : ``}[New date search](command:code-for-ibmi.member.newDateSearch)`
-          ];
+            `${this.highlightSince ? `[Clear date search](command:code-for-ibmi.member.clearDateSearch) | ` : ``}[New date search](command:code-for-ibmi.member.newDateSearch)`,
+            sequenceNumbersAvailable ? `[Show sequence numbers](command:code-for-ibmi.toggleSequenceNumbers)` : undefined
+          ].filter(i => i !== undefined) as string[];
 
-          if (this.highlightSince) markdownString.push(`---`, `Changes from ${String(this.highlightSince) == currentDate ? `today` : this.highlightSince} highlighted`)
+          if (this.highlightSince) markdownString.push(`Changes from ${String(this.highlightSince) == currentDate ? `today` : this.highlightSince} highlighted`)
 
-          const hoverMessage = new vscode.MarkdownString(markdownString.join(`\n\n`));
+          const hoverMessage = new vscode.MarkdownString(markdownString.join(`\n\n---\n\n`));
           hoverMessage.isTrusted = true;
 
           // Due to the way source dates are stored, we're doing some magic.
@@ -323,6 +359,14 @@ export class SourceDateHandler {
       if (editor) {
         this._diffRefreshGutter(editor.document);
       }
+    }
+  }
+
+  private toggleSequenceNumbers() {
+    this.sequenceNumbersShowing = !this.sequenceNumbersShowing;
+    const editor = vscode.window.activeTextEditor;
+    if (editor) {
+      this._diffRefreshGutter(editor.document);
     }
   }
 


### PR DESCRIPTION
Implement functionality to display sequence numbers, replacing source dates in the editor temporarily, allowing users to switch between the two.

**note:** sequence numbers are rendered one time only. Once the user makes a change to the document, it will switch the gutter back to the source dates. This PR does not change how sequencing works when the member is saved.

## How to test

1. Enable source dates and source gutter in the connection settings
2. Connect to a system and open a source member
3. See the source date gutter appear, and hover over the gutter to switch to source sequences
4. Make a change and see the gutter switch back to source dates
5. The option to switch back to sequences will dissapear after a) editing the file, and b) saving the file

