### PR TITLE
Add read only mode to server settings file

### DIFF
--- a/package.json
+++ b/package.json
@@ -368,7 +368,12 @@
 								"type": "boolean",
 								"default": false,
 								"description": "Tells the debug service to send more data to the client. Only useful for debugging issues in the service."
-							}
+							},
+              "readOnlyMode": {
+								"type": "boolean",
+								"default": false,
+								"description": "Always open source members and IFS files in read-only mode."
+              }
 						}
 					}
 				},

--- a/schemas/settings.json
+++ b/schemas/settings.json
@@ -4,6 +4,11 @@
     "CodeForI": {
       "type": "object",
       "properties": {
+        "readOnlyMode": {
+          "type": "boolean",
+          "default": false,
+          "description": "Always open source members and IFS files in read-only mode."
+        },
         "tempLibrary": {
           "type": "string",
           "default": "ILEDITOR",


### PR DESCRIPTION
### Changes
This PR will add the Readonly Mode setting to the server settings file, allowing the system admin to set the connection to read only:

![image](https://github.com/user-attachments/assets/86987fcb-a511-4885-94c2-cf417e9fd404)


### How to test this PR
<!-- 
Example:
1. Add the setting to file `/etc/vscode/settings.json` on the server and reconnect. All members and files opened will be read only.
2. Remove the setting again and reconnect. Members and files can now be edited.
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
