### PR TITLE
Fix error copying IFS objects

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -1146,16 +1146,17 @@ export default class IBMiContent {
   }
 
   /**
-   * Copy one or more folders or files into a directory. Uses QSH's `cp` to keep all the attributes of the original file into its copy.
+   * Copy one or more folders or files into a directory or file. Uses ILE `CPY` to keep all the attributes of the original file into its copy.
    * @param paths one or more files/folders to copy
-   * @param toDirectory the directory where the files/folders will be copied into
-   * @returns the {@link CommandResult} of the `cp` command execution
+   * @param toPath the directory or file where the files/folders will be copied into
+   * @returns the {@link CommandResult} of the `CPY` command execution
    */
-  async copy(paths: string | string[], toDirectory: string): Promise<CommandResult> {
+  async copy(paths: string | string[], toPath: string): Promise<CommandResult> {
     paths = Array.isArray(paths) ? paths : [paths];
-    toDirectory = Tools.escapePath(toDirectory);
+    toPath = Tools.escapePath(toPath);
+    const toPathIsDir = await this.isDirectory(toPath);
     for (const path of paths.map(path => Tools.escapePath(path))) {
-      const result = await this.ibmi.runCommand({ command: `COPY OBJ('${path}') TODIR('${toDirectory}') SUBTREE(*ALL) REPLACE(*YES)`, environment: "ile" });
+      const result = await this.ibmi.runCommand({ command: `COPY OBJ('${path}') ${toPathIsDir ? 'TODIR(' : 'TOOBJ(' }'${toPath}') SUBTREE(*ALL) REPLACE(*YES)`, environment: "ile" });
       if (result.code !== 0) {
         return result;
       }


### PR DESCRIPTION
### Changes
This PR will fix issue #2779 by changing the use of `COPY` ILE command when copying IFS objects.

The `COPY`command has two target keywords: `TODIR` and `TOOBJ`. The keyword will be chosen based on whether the target is a directory or not.

### How to test this PR
<!-- 
Example:
1. Copy a streamfile into new streamfile
2. Copy a streamfile into existing directory
3. Copy a directory to existing directory
4. Copy a directory to new directory
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
