### PR TITLE
Changed debug service submission to have default library configuration

### DIFF
--- a/src/debug/server.ts
+++ b/src/debug/server.ts
@@ -63,7 +63,7 @@ export async function startService(connection: IBMi) {
       // Change the permissions to 777
       await connection.sendCommand({ command: `chmod 777 ${debugConfig.getRemoteServiceWorkspace()}` });
 
-      const command = `QSYS/SBMJOB JOB(QDBGSRV) ${submitOptions} CMD(QSH CMD('export JAVA_HOME=${javaHome};${debugConfig.getRemoteServiceBin()}/startDebugService.sh > ${debugConfig.getNavigatorLogFile()} 2>&1'))`
+      const command = `QSYS/SBMJOB JOB(QDBGSRV) SYSLIBL(*SYSVAL) CURLIB(*USRPRF) INLLIBL(*JOBD) ${submitOptions} CMD(QSH CMD('export JAVA_HOME=${javaHome};${debugConfig.getRemoteServiceBin()}/startDebugService.sh > ${debugConfig.getNavigatorLogFile()} 2>&1'))`
       const submitResult = await connection.runCommand({ command, noLibList: true });
       if (submitResult.code === 0) {
         const submitMessage = Tools.parseMessages(submitResult.stderr || submitResult.stdout).findId("CPC1221")?.text;


### PR DESCRIPTION
### Changes
Changed **Debugger Service** submission command

Now, all parameters in the SBMJOB command are using default parameters: SYSLIBL(*SYSVAL) CURLIB(*USRPRF) INLLIBL(*JOBD)

<img width="1093" height="54" alt="image" src="https://github.com/user-attachments/assets/6bc03d53-8edd-407a-b89d-e80e5976548f" />

Closes #2785 