### PR TITLE
Move EditorPath type to api directory

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -4,7 +4,7 @@ import * as node_ssh from "node-ssh";
 import os from "os";
 import path, { parse as parsePath } from 'path';
 import { EventEmitter } from 'stream';
-import { EditorPath } from '../typings';
+import { EditorPath } from './types';
 import { CompileTools } from "./CompileTools";
 import IBMiContent from "./IBMiContent";
 import { Tools } from './Tools';

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -4,7 +4,7 @@ import * as node_ssh from "node-ssh";
 import path from 'path';
 import tmp from 'tmp';
 import util from 'util';
-import { EditorPath } from '../typings';
+import { EditorPath } from './types';
 import { FilterType, parseFilter, singleGenericName } from './Filter';
 import { default as IBMi } from './IBMi';
 import { Tools } from './Tools';

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -2,7 +2,7 @@
 import os from "os";
 import path from "path";
 import { IBMiMessage, IBMiMessages, QsysPath } from './types';
-import { EditorPath } from "../typings";
+import { EditorPath } from "./types";
 
 export namespace Tools {
   export class SqlError extends Error {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -221,5 +221,7 @@ export interface ModuleExport {
   argumentOptimization: string,
 }
 
+export type EditorPath = string | { fsPath: string };
+
 export * from "./configuration/config/types";
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -23,7 +23,5 @@ export interface DeploymentParameters {
   ignoreRules?: Ignore
 }
 
-export type EditorPath = string | { fsPath: string };
-
 export * from "./api/types";
 export * from "./ui/types";


### PR DESCRIPTION
Relocate the `EditorPath` type definition from the `typings` directory to the `api` directory for better organization and accessibility.

This is to correctly singularise the `api` directory so it doesn't depend on the `vscode` namespace.