### PR TITLE
Remove unused imports from serverFile.ts

### DIFF
--- a/src/api/configuration/serverFile.ts
+++ b/src/api/configuration/serverFile.ts
@@ -1,6 +1,5 @@
 
 import path from "path";
-import { RelativePattern, workspace, WorkspaceFolder } from "vscode";
 import IBMi from "../IBMi";
 
 const WORKSPACE_ROOT = `.vscode`;


### PR DESCRIPTION
Eliminate unnecessary imports to clean up the code in serverFile.ts.

The import was breaking our API compatability in keeping the `api` directory away from the `vscode` namespace.