### PR TITLE
Omit escaping paths when copying IFS objects

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -138,21 +138,21 @@ export default class IBMiContent {
 
   /**
    * Download the content of a source member
-   * 
-   * @param library 
-   * @param sourceFile 
-   * @param member 
-   * @param localPath 
+   *
+   * @param library
+   * @param sourceFile
+   * @param member
+   * @param localPath
    */
   async downloadMemberContent(library: string, sourceFile: string, member: string, localPath?: string): Promise<string>;
   /**
    * @deprecated Will be removed in `v3.0.0`; use {@link IBMiContent.downloadMemberContent()} without the `asp` parameter instead.
-   * 
-   * @param asp 
-   * @param library 
-   * @param sourceFile 
-   * @param member 
-   * @param localPath 
+   *
+   * @param asp
+   * @param library
+   * @param sourceFile
+   * @param member
+   * @param localPath
    */
   async downloadMemberContent(asp: string | undefined, library: string, sourceFile: string, member: string, localPath?: string): Promise<string>;
   async downloadMemberContent(aspOrLibrary: string | undefined, libraryOrSourceFile: string, sourceFileOrMember: string, memberOrLocalPath?: string, localPath?: string): Promise<string> {
@@ -221,21 +221,21 @@ export default class IBMiContent {
 
   /**
    * Upload to a member
-   * 
-   * @param library 
-   * @param sourceFile 
-   * @param member 
-   * @param content 
+   *
+   * @param library
+   * @param sourceFile
+   * @param member
+   * @param content
    */
   async uploadMemberContent(library: string, sourceFile: string, member: string, content: string | Uint8Array): Promise<boolean>;
 
   /**
    * @deprecated Will be removed in `v3.0.0`; use {@link IBMiContent.uploadMemberContent()} without the `asp` parameter instead.
-   * @param asp 
-   * @param library 
-   * @param sourceFile 
-   * @param member 
-   * @param content 
+   * @param asp
+   * @param library
+   * @param sourceFile
+   * @param member
+   * @param content
    */
   async uploadMemberContent(asp: string | undefined, library: string, sourceFile: string, member: string, content: string | Uint8Array): Promise<boolean>;
   async uploadMemberContent(aspOrLibrary: string | undefined, libraryOrFile: string, sourceFileOrMember: string, memberOrContent: string | Uint8Array, content?: string | Uint8Array): Promise<boolean> {
@@ -1153,9 +1153,8 @@ export default class IBMiContent {
    */
   async copy(paths: string | string[], toPath: string): Promise<CommandResult> {
     paths = Array.isArray(paths) ? paths : [paths];
-    toPath = Tools.escapePath(toPath);
-    const toPathIsDir = await this.isDirectory(toPath);
-    for (const path of paths.map(path => Tools.escapePath(path))) {
+    const toPathIsDir = await this.isDirectory(Tools.escapePath(toPath));
+    for (const path of paths) {
       const result = await this.ibmi.runCommand({ command: `COPY OBJ('${path}') ${toPathIsDir ? 'TODIR(' : 'TOOBJ(' }'${toPath}') SUBTREE(*ALL) REPLACE(*YES)`, environment: "ile" });
       if (result.code !== 0) {
         return result;


### PR DESCRIPTION
### Changes
The change to copying IFS objects using the `COPY` command did not take into account, that the paths were being escaped for shell copy. This caused an error when copying files containing blanks:

<img width="513" height="227" alt="image" src="https://github.com/user-attachments/assets/a58f20da-eb80-4122-a155-b956444acb06" />

This PR will fix that by only escaping the path when testing the target for directory - which is still done in shell, by the `cd` command.

<img width="512" height="206" alt="image" src="https://github.com/user-attachments/assets/7a4699bd-29d9-4c8c-9a93-48c09365b663" />


### How to test this PR
Example:
1. Copy a streamfile containing blank(s) in the filename. The copy should succeed.

### Checklist
* [x] have tested my change
