### PR TITLE
Change LIBRARY_LIST table functionto to significantly reduce SRCPF load time.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,3 +66,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@nathaniel-king-navarrete](https://github.com/Nathaniel-King-Navarrete)
 * [@buzzia2001](https://github.com/buzzia2001)
 * [@e1mais](https://github.com/e1mais)
+* [@jman116](https://github.com/jman116)

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -1565,7 +1565,7 @@ export default class IBMi {
     let foundNumber = this.libraryAsps.get(library);
 
     if (!foundNumber) {
-      const [row] = await this.runSQL(`SELECT IASP_NUMBER FROM TABLE(QSYS2.LIBRARY_INFO('${this.sysNameInAmerican(library)}'))`);
+      const [row] = await this.runSQL(`SELECT IASP_NUMBER FROM TABLE(QSYS2.LIBRARY_INFO('${this.sysNameInAmerican(library)}', DETAILED_INFO=>'NO'))`);
       const iaspNumber = Number(row?.IASP_NUMBER);
       if (iaspNumber >= 0) {
         this.libraryAsps.set(library, iaspNumber);


### PR DESCRIPTION

### Changes
I found that when opening objects in our SRCPFs, it's wildly unpredictable with how long it takes to open, ranging from nearly instantly to minutes.
The Code for i log shows that the last command sent before it seems to get stuck loading is:
https://github.com/codefori/vscode-ibmi/blob/351048536ec7014ff7b758a47a7ed3b9bf75d5e4/src/api/IBMi.ts#L1568

[IBM documentation](https://www.ibm.com/docs/en/i/7.4.0?topic=services-library-info-table-function#:~:text=.%20For%20a%20library%20with%20a%20large%20number%20of%20objects%2C%20LIBRARY_SIZE%20can%20be%20a%20time%20consuming%20calculation) states that calculating library_size can take a long time which our 20k+ object library seems to agree with:

<img width="890" height="84" alt="Image" src="https://github.com/user-attachments/assets/3686b86d-166c-47fe-8216-5596d072c37b" />

By swapping to DETAILED_INFO=>'NO', the fetch time becomes nearly instantaneously, and it still provides IASP_NUMBER:

<img width="539" height="157" alt="Image" src="https://github.com/user-attachments/assets/dc92c631-ea23-42a3-afd4-c6f7f7ff7096" />

<img width="895" height="149" alt="Image" src="https://github.com/user-attachments/assets/cc2ba477-295e-44c1-9c45-5219c26cb718" />

Made the necessary change and have been running it all day, with great success.

This is my first pull request, if I messed something up please let me know!

### How to test this PR
<!-- 
Connect to a system and open a source physical file member.
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
