### PR TITLE
Display connection error message + add detail in output

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -4,7 +4,6 @@ import * as node_ssh from "node-ssh";
 import os from "os";
 import path, { parse as parsePath } from 'path';
 import { EventEmitter } from 'stream';
-import { EditorPath } from './types';
 import { CompileTools } from "./CompileTools";
 import IBMiContent from "./IBMiContent";
 import { Tools } from './Tools';
@@ -16,9 +15,9 @@ import * as configVars from './configVars';
 import { DebugConfiguration } from "./configuration/DebugConfiguration";
 import { ConnectionManager } from './configuration/config/ConnectionManager';
 import { ConnectionConfig, RemoteConfigFile } from './configuration/config/types';
-import { CachedServerSettings, CodeForIStorage } from './configuration/storage/CodeForIStorage';
-import { AspInfo, CommandData, CommandResult, ConnectionData, IBMiMember, RemoteCommand, WrapResult } from './types';
 import { ConfigFile } from './configuration/serverFile';
+import { CachedServerSettings, CodeForIStorage } from './configuration/storage/CodeForIStorage';
+import { AspInfo, CommandData, CommandResult, ConnectionData, EditorPath, IBMiMember, RemoteCommand, WrapResult } from './types';
 
 export interface MemberParts extends IBMiMember {
   basename: string
@@ -28,8 +27,9 @@ export type ConnectionMessageType = 'info' | 'warning' | 'error';
 export type ConnectionErrorCode = `shell_config` | `home_directory_creation` | `QCPTOIMPF_exists` | `QCPFRMIMPF_exists` | `default_not_bash` | `invalid_bashrc` | `invalid_temp_lib` | `no_auto_conv_ebcdic` | `not_loaded_debug_config` | `no_sql_runner` | `ccsid_warning`;
 
 export interface ConnectionResult {
-  success: boolean,
-  errorCodes?: ConnectionErrorCode[],
+  success: boolean
+  error?: string
+  errorCodes?: ConnectionErrorCode[]
 }
 
 const remoteApps = [ // All names MUST also be defined as key in 'remoteFeatures' below!!
@@ -122,7 +122,7 @@ export default class IBMi {
    * the root of the IFS, thus why we store it.
    */
   private iAspInfo: AspInfo[] = [];
-  private currentAsp: string|undefined;
+  private currentAsp: string | undefined;
   private libraryAsps = new Map<string, number>();
 
   /**
@@ -990,16 +990,22 @@ export default class IBMi {
 
       let error = e.message;
       if (e.code === "ENOTFOUND") {
-        error = `Host is unreachable. Check the connection's hostname/IP address.`;
+        error = `host is unreachable. Check the connection's hostname/IP address.`;
       }
       else if (e.code === "ECONNREFUSED") {
-        error = `Port ${connectionObject.port} is unreachable. Check the connection's port number or run command STRTCPSVR SERVER(*SSHD) on the host.`
+        error = `port ${connectionObject.port} is unreachable. Check the connection's port number or run command STRTCPSVR SERVER(*SSHD) on the host.`
       }
       else if (e.level === "client-authentication") {
-        error = `Check your credentials${e.message ? ` (${e.message})` : ''}.`;
+        error = `check your credentials${e.message ? ` (${e.message})` : ''}.`;
+      }
+
+      this.appendOutput(`${JSON.stringify(e)}`);
+      if (typeof e.stack === "string") {
+        this.appendOutput(`\n\n${e.stack}`);
       }
 
       return {
+        error,
         success: false
       };
     }
@@ -1523,7 +1529,7 @@ export default class IBMi {
     return this.remoteFeatures[`startDebugService.sh`] !== undefined;
   }
 
-  private async getUserProfileAsp(): Promise<string|undefined> {
+  private async getUserProfileAsp(): Promise<string | undefined> {
     const [currentRdb] = await this.runSQL(`values current_server`);
 
     if (currentRdb) {
@@ -1541,8 +1547,8 @@ export default class IBMi {
     return this.iAspInfo;
   }
 
-  getIAspDetail(by: string|number) {
-    let asp: AspInfo|undefined;
+  getIAspDetail(by: string | number) {
+    let asp: AspInfo | undefined;
     if (typeof by === 'string') {
       asp = this.iAspInfo.find(asp => asp.name === by);
     } else {
@@ -1554,14 +1560,14 @@ export default class IBMi {
     }
   }
 
-  getIAspName(by: string|number): string|undefined {
+  getIAspName(by: string | number): string | undefined {
     return this.getIAspDetail(by)?.name;
   }
 
   getCurrentIAspName() {
     return this.currentAsp;
   }
-  async lookupLibraryIAsp(library: string): Promise<string|undefined> {
+  async lookupLibraryIAsp(library: string): Promise<string | undefined> {
     library = this.upperCaseName(library);
     let foundNumber = this.libraryAsps.get(library);
 

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -273,7 +273,8 @@ export default class IBMi {
       }
       await this.client.connect({
         ...connectionObject,
-        privateKeyPath: connectionObject.privateKeyPath ? Tools.resolvePath(connectionObject.privateKeyPath) : undefined
+        privateKeyPath: connectionObject.privateKeyPath ? Tools.resolvePath(connectionObject.privateKeyPath) : undefined,
+        debug: connectionObject.sshDebug ? (message: string) => this.appendOutput(`\n[SSH debug] ${message}`) : undefined
       } as node_ssh.Config);
 
       let wasCancelled = false;

--- a/src/api/tests/connection.ts
+++ b/src/api/tests/connection.ts
@@ -102,7 +102,7 @@ export async function newConnection(reloadSettings?: boolean) {
   }
 
   if (!result.success) {
-    throw new Error(`Failed to connect to IBMi`);
+    throw new Error(`Failed to connect to IBMi${result.error ? `: ${result.error}` : '!'}`);
   }
 
   return conn;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -65,6 +65,7 @@ export interface ConnectionData {
   privateKeyPath?: string;
   keepaliveInterval?: number;
   readyTimeout?: number;
+  sshDebug?: boolean;
 }
 
 export interface Server {

--- a/src/commands/connection.ts
+++ b/src/commands/connection.ts
@@ -1,25 +1,26 @@
 import { commands, Disposable, ExtensionContext, window } from "vscode";
-import Instance from "../Instance";
-import { ConnectionData } from "../typings";
-import { safeDisconnect } from "../instantiate";
+import { ConnectionResult } from "../api/IBMi";
 import { setStoredPassword } from "../config/passwords";
+import Instance from "../Instance";
+import { safeDisconnect } from "../instantiate";
+import { ConnectionData } from "../typings";
 
 export function registerConnectionCommands(context: ExtensionContext, instance: Instance): Disposable[] {
 
   return [
     commands.registerCommand(`code-for-ibmi.connectDirect`,
-      async (connectionData: ConnectionData, reloadSettings = false, savePassword = false): Promise<boolean> => {
+      async (connectionData: ConnectionData, reloadSettings = false, savePassword = false): Promise<ConnectionResult | undefined> => {
         const existingConnection = instance.getConnection();
 
         if (existingConnection) {
-          return false;
+          return;
         }
 
         if (savePassword && connectionData.password) {
           await setStoredPassword(context, connectionData.name, connectionData.password);
         }
 
-        return (await instance.connect({data: connectionData, reloadServerSettings: reloadSettings})).success;
+        return (await instance.connect({ data: connectionData, reloadServerSettings: reloadSettings }));
       }
     ),
     commands.registerCommand(`code-for-ibmi.disconnect`, async (silent?: boolean) => {

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -36,8 +36,8 @@ export class Login {
       .addCheckbox(`savePassword`, l10n.t(`Save Password`))
       .addFile(`privateKeyPath`, l10n.t(`Private Key`), l10n.t(`OpenSSH, RFC4716 and PPK formats are supported.`))
       .addHorizontalRule()
-      .addInput(`readyTimeout`, l10n.t(`Connection Timeout (in milliseconds)`), l10n.t(`How long to wait for the SSH handshake to complete.`), { inputType: "number", min: 1, default: "20000" });
-
+      .addInput(`readyTimeout`, l10n.t(`Connection Timeout (in milliseconds)`), l10n.t(`How long to wait for the SSH handshake to complete.`), { inputType: "number", min: 1, default: "20000" })
+      .addCheckbox(`sshDebug`, l10n.t(`Turn on SSH debug output`), l10n.t(`Enable this to output debug traces in the Code for i and help diagnose SSH connection issues.`));
     const tempTab = new Section()
       .addInput(`tempLibrary`, `Temporary library`, `Temporary library. Cannot be QTEMP.`, { default: `ILEDITOR`, minlength: 1, maxlength: 10 })
       .addInput(`tempDir`, `Temporary IFS directory`, `Directory that will be used to write temporary files to. User must be authorized to create new files in this directory.`, { default: '/tmp', minlength: 1 });

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -1,10 +1,10 @@
 import vscode, { l10n, ThemeIcon } from "vscode";
-import { CustomUI, Section } from "../CustomUI";
+import IBMi from "../../api/IBMi";
 import { Tools } from "../../api/Tools";
+import { deleteStoredPassword, getStoredPassword, setStoredPassword } from "../../config/passwords";
 import { instance, safeDisconnect } from "../../instantiate";
 import { ConnectionData } from '../../typings';
-import IBMi from "../../api/IBMi";
-import { deleteStoredPassword, getStoredPassword, setStoredPassword } from "../../config/passwords";
+import { CustomUI, Section } from "../CustomUI";
 
 type NewLoginSettings = ConnectionData & {
   savePassword: boolean
@@ -120,7 +120,7 @@ export class Login {
                     }
 
                   } else {
-                    vscode.window.showErrorMessage(`Not connected to ${data.host}!`);
+                    vscode.window.showErrorMessage(`Not connected to ${data.host}${connected.error ? `: ${connected.error}` : '!'}`);
                   }
                 } catch (e) {
                   vscode.window.showErrorMessage(`Error connecting to ${data.host}! ${e}`);
@@ -180,7 +180,7 @@ export class Login {
         if (connected.success) {
           vscode.window.showInformationMessage(`Connected to ${connectionConfig.host}!`);
         } else {
-          vscode.window.showErrorMessage(`Not connected to ${connectionConfig.host}!`);
+          vscode.window.showErrorMessage(`Not connected to ${connectionConfig.host}${connected.error ? `: ${connected.error}` : '!'}`);
         }
 
         return true;

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -40,7 +40,7 @@ export class SettingsUI {
         const passwordAuthorisedExtensions = instance.getStorage()?.getAuthorisedExtensions() || [];
 
         let config: ConnectionConfig;
-        let serverConfig: RemoteConfigFile|undefined;
+        let serverConfig: RemoteConfigFile | undefined;
 
         if (connectionSettings && server) {
           config = await IBMi.connectionManager.load(server.name);
@@ -68,7 +68,7 @@ export class SettingsUI {
           if (serverConfig && serverConfig.codefori) {
             for (const field of currentSection.fields) {
               if (!field.id) continue;
-                
+
               if (serverConfig.codefori[field.id] !== undefined) {
                 field.readonly = true;
               }
@@ -204,7 +204,7 @@ export class SettingsUI {
             .set("Debug port", config.debugPort);
 
           debugServiceConfig.set("SEP debug port", config.debugSepPort)
-          
+
           debuggerTab.addParagraph(`<ul>${Array.from(debugServiceConfig.entries()).map(([label, value]) => `<li><code>${label}</code>: ${value}</li>`).join("")}</ul>`);
 
           debuggerTab.addCheckbox(`debugUpdateProductionFiles`, `Update production files`, `Determines whether the job being debugged can update objects in production (<code>*PROD</code>) libraries.`, config.debugUpdateProductionFiles)
@@ -395,7 +395,8 @@ export class SettingsUI {
               .addPassword(`password`, `${vscode.l10n.t(`Password`)}${storedPassword ? ` (${vscode.l10n.t(`stored`)})` : ``}`, vscode.l10n.t("Only provide a password if you want to update an existing one or set a new one."))
               .addFile(`privateKeyPath`, `${vscode.l10n.t(`Private Key`)}${privateKeyPath ? ` (${vscode.l10n.t(`Private Key`)}: ${privateKeyPath})` : ``}`, privateKeyWarning + vscode.l10n.t("Only provide a private key if you want to update from the existing one or set one.") + '<br />' + vscode.l10n.t("OpenSSH, RFC4716 and PPK formats are supported."))
               .addHorizontalRule()
-              .addInput(`readyTimeout`, vscode.l10n.t(`Connection Timeout (in milliseconds)`), vscode.l10n.t(`How long to wait for the SSH handshake to complete.`), { inputType: "number", min: 1, default: stored.readyTimeout ? String(stored.readyTimeout) : "20000" })              
+              .addInput(`readyTimeout`, vscode.l10n.t(`Connection Timeout (in milliseconds)`), vscode.l10n.t(`How long to wait for the SSH handshake to complete.`), { inputType: "number", min: 1, default: stored.readyTimeout ? String(stored.readyTimeout) : "20000" })
+              .addCheckbox(`sshDebug`, vscode.l10n.t(`Turn on SSH debug output`), vscode.l10n.t(`Enable this to output debug traces in the Code for i and help diagnose SSH connection issues.`), stored.sshDebug)
               .addButtons(
                 { id: `submitButton`, label: vscode.l10n.t(`Save`), requiresValidation: true },
                 { id: `removeAuth`, label: vscode.l10n.t(`Remove auth methods`) }
@@ -477,9 +478,9 @@ function installComponentsQuickPick(connection: IBMi) {
     placeHolder: `Select component${withS} to install`
   }).then(async result => {
     if (result) {
-      window.withProgress({title: `Component${withS}`, location: vscode.ProgressLocation.Notification}, async (progress) => {
+      window.withProgress({ title: `Component${withS}`, location: vscode.ProgressLocation.Notification }, async (progress) => {
         for (const item of result) {
-          progress.report({message: `Installing ${item.label}...`});
+          progress.report({ message: `Installing ${item.label}...` });
           try {
             await connection.getComponentManager().installComponent(item.id);
           } catch (e) {


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
The cause of a connection failure was never reported after it happened. This PR fixes this and add the error message in the error notification.

<img width="452" height="131" alt="image" src="https://github.com/user-attachments/assets/c2aed6cc-9d17-44c4-a6e4-d1abf719c552" />


It also adds error details (error JSON representation + stack trace) into the output to help diagnose connection issues.
<img width="861" height="186" alt="image" src="https://github.com/user-attachments/assets/7c1686f7-2cba-4947-aadf-39d77dba014f" />


This should help with #2856 and #2840 .

A new `SSH debug output` option has been added in the Login settings:
<img width="569" height="68" alt="image" src="https://github.com/user-attachments/assets/3956e14c-47b2-4ae2-8475-19d8ec16536f" />

When turned on, it will append SSH debug traces to the Code for i output.
<img width="1020" height="229" alt="image" src="https://github.com/user-attachments/assets/7fa87260-c997-4bd2-adb6-3294dd8c5acc" />

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->

1. Connect to a system with the wrong address or credentials. Or shut down the SSH server on the LPAR
2. Check out the error notification to see the cause of the issue
3. Check out the Code for IBM i output for error details

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change