### PR TITLE
Fixed "Run action" when invoked with keyboard shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -1713,7 +1713,23 @@
 			{
 				"command": "code-for-ibmi.runAction",
 				"key": "ctrl+e",
-				"mac": "cmd+e"
+				"mac": "cmd+e",
+				"when": "editorFocus",
+				"args": "editor"
+			},
+			{
+				"command": "code-for-ibmi.runAction",
+				"key": "ctrl+e",
+				"mac": "cmd+e",
+				"when": "focusedView == objectBrowser && listHasSelectionOrFocus",
+				"args": "objectBrowser"
+			},
+			{
+				"command": "code-for-ibmi.runAction",
+				"key": "ctrl+e",
+				"mac": "cmd+e",
+				"when": "focusedView === ifsBrowser && listHasSelectionOrFocus",
+				"args": "ifsBrowser"
 			},
 			{
 				"command": "code-for-ibmi.launchDeploy",

--- a/src/commands/actions.ts
+++ b/src/commands/actions.ts
@@ -8,17 +8,40 @@ import { runAction } from "../ui/actions";
 import { refreshDiagnosticsFromServer } from "../ui/diagnostics";
 import { BrowserItem } from "../ui/types";
 
+const CommandOrigins = ["editor", "objectBrowser", "ifsBrowser"] as const;
+type CommandOrigin = typeof CommandOrigins[number];
+
 export function registerActionsCommands(instance: Instance): Disposable[] {
   return [
-    commands.registerCommand(`code-for-ibmi.runAction`, async (item?: (TreeItem | BrowserItem | Uri), items?: (TreeItem | BrowserItem | Uri)[], action?: Action, method?: DeploymentMethod, workspaceFolder?: WorkspaceFolder) => {
+    commands.registerCommand(`code-for-ibmi.runAction`, async (item: (CommandOrigin | TreeItem | BrowserItem | Uri), items?: (TreeItem | BrowserItem | Uri)[], action?: Action, method?: DeploymentMethod, workspaceFolder?: WorkspaceFolder) => {
       const connection = instance.getConnection()!;
       if (connection) {
         const editor = window.activeTextEditor;
         const browserItems: BrowserItem[] = [];
         const uris: Uri[] = [];
-        if (!item) {
-          if (editor?.document.uri) {
-            uris.push(editor?.document.uri);
+        const addTreeItem = (target: TreeItem | BrowserItem) => {
+          if (target.resourceUri) {
+            uris.push(target.resourceUri);
+            if (target instanceof BrowserItem) {
+              browserItems.push(target);
+            }
+          }
+        };
+
+        if (typeof item === "string") {
+          switch (item) {
+            case "objectBrowser":
+              (await commands.executeCommand<BrowserItem[]>("code-for-ibmi.objectBrowser.selection")).forEach(addTreeItem);
+              break;
+
+            case "ifsBrowser":
+              (await commands.executeCommand<BrowserItem[]>("code-for-ibmi.ifsBrowser.selection")).forEach(addTreeItem);
+              break;
+
+            default:
+              if (editor?.document.uri) {
+                uris.push(editor.document.uri);
+              }
           }
         }
         else {
@@ -26,11 +49,8 @@ export function registerActionsCommands(instance: Instance): Disposable[] {
             if (target instanceof Uri) {
               uris.push(target);
             }
-            else if (target.resourceUri) {
-              uris.push(target.resourceUri);
-              if (target instanceof BrowserItem) {
-                browserItems.push(target);
-              }
+            else {
+              addTreeItem(target);
             }
           }
         }
@@ -42,7 +62,7 @@ export function registerActionsCommands(instance: Instance): Disposable[] {
             return false;
           }
 
-          const config = connection.getConfig();          
+          const config = connection.getConfig();
 
           for (const openedEditor of window.visibleTextEditors) {
             const path = openedEditor.document.uri.path;

--- a/src/ui/views/ifsBrowser.ts
+++ b/src/ui/views/ifsBrowser.ts
@@ -942,7 +942,8 @@ Do you want to replace it?`, target))) {
     vscode.commands.registerCommand(`code-for-ibmi.searchIFSBrowser`, async () => {
       vscode.commands.executeCommand('ifsBrowser.focus');
       vscode.commands.executeCommand('list.find');
-    })
+    }),
+    vscode.commands.registerCommand(`code-for-ibmi.ifsBrowser.selection`, getSelectedItems)
   )
 }
 

--- a/src/ui/views/objectBrowser.ts
+++ b/src/ui/views/objectBrowser.ts
@@ -1362,7 +1362,8 @@ Do you want to replace it?`, item.name), { modal: true }, skipAllLabel, overwrit
       else if (node instanceof ObjectBrowserMemberItem) {
         vscode.commands.executeCommand(`code-for-ibmi.renameMember`, node);
       }
-    })
+    }),
+    vscode.commands.registerCommand(`code-for-ibmi.objectBrowser.selection`, getSelectedItems)
   );
 }
 


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Resolves #2866 

When invoked using a keybinding, commands don't get any arguments by default. This PR makes the Run Action command to receive a single string argument, describing where it's been invoked from. Using this information, it can get the selected item from the browser that had the focus when the keyboard shortcut was pressed.

Note: this cannot work when invoked from VS Code file explorer since there is no API/Command to get the explorer's selection.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->

1. Select several items in the object or IFS browser (only files in the IFS browser)
2. Hit ctrl+e (or cmd+e on MacOS)
3. The action should be run on the selection of the focused browser
4. Open an IFS file or member
5. Hit ctrl+e while the editor is in focus
6. The action should be run on the active editor

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change