### PR TITLE
Escape IFS path with &

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -4,13 +4,12 @@ import * as node_ssh from "node-ssh";
 import path from 'path';
 import tmp from 'tmp';
 import util from 'util';
-import { EditorPath } from './types';
 import { FilterType, parseFilter, singleGenericName } from './Filter';
 import { default as IBMi } from './IBMi';
 import { Tools } from './Tools';
 import { GetMemberInfo } from './components/getMemberInfo';
 import { ObjectTypes } from './import/Objects';
-import { AttrOperands, CommandResult, IBMiError, IBMiMember, IBMiObject, IFSFile, ModuleExport, ProgramExportImportInfo, QsysPath, SpecialAuthorities } from './types';
+import { AttrOperands, CommandResult, EditorPath, IBMiError, IBMiMember, IBMiObject, IFSFile, ModuleExport, ProgramExportImportInfo, QsysPath, SpecialAuthorities } from './types';
 const tmpFile = util.promisify(tmp.file);
 const readFileAsync = util.promisify(fs.readFile);
 const writeFileAsync = util.promisify(fs.writeFile);
@@ -1155,7 +1154,7 @@ export default class IBMiContent {
     paths = Array.isArray(paths) ? paths : [paths];
     const toPathIsDir = await this.isDirectory(Tools.escapePath(toPath));
     for (const path of paths) {
-      const result = await this.ibmi.runCommand({ command: `COPY OBJ('${path}') ${toPathIsDir ? 'TODIR(' : 'TOOBJ(' }'${toPath}') SUBTREE(*ALL) REPLACE(*YES)`, environment: "ile" });
+      const result = await this.ibmi.runCommand({ command: `COPY OBJ('${path}') ${toPathIsDir ? 'TODIR(' : 'TOOBJ('}'${toPath}') SUBTREE(*ALL) REPLACE(*YES)`, environment: "ile" });
       if (result.code !== 0) {
         return result;
       }

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -1,8 +1,7 @@
 
 import os from "os";
 import path from "path";
-import { IBMiMessage, IBMiMessages, QsysPath } from './types';
-import { EditorPath } from "./types";
+import { EditorPath, IBMiMessage, IBMiMessages, QsysPath } from './types';
 
 export namespace Tools {
   export class SqlError extends Error {
@@ -224,7 +223,7 @@ export namespace Tools {
     if (alreadyQuoted) {
       return Path.replace(/"|\$|\\/g, matched => `\\`.concat(matched));
     } else {
-      return Path.replace(/'|"|\$|\\| /g, matched => `\\`.concat(matched));
+      return Path.replace(/'|"|\$|&|\\| /g, matched => `\\`.concat(matched));
     }
   }
 


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Fixes #2886 .
IFS path with `&` in it were not correctly escaped. This PR fixes this.

### How to test this PR
1. Create an IFS file with a `&` in its name
2. Run actions from the IFS browser
3. Open it
4. Save it

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
