### PR TITLE
Add warnings when copying members/streamfiles with unsaved changes

### DIFF
--- a/src/ui/views/ifsBrowser.ts
+++ b/src/ui/views/ifsBrowser.ts
@@ -1,6 +1,6 @@
 import os from "os";
 import path, { dirname, extname } from "path";
-import vscode, { FileType, l10n, window } from "vscode";
+import vscode, { FileType, l10n, Uri, window } from "vscode";
 
 import { existsSync, mkdirSync, rmdirSync } from "fs";
 import IBMi from "../../api/IBMi";
@@ -690,6 +690,17 @@ Please type "{0}" to confirm deletion.`, dirName);
     }),
     vscode.commands.registerCommand(`code-for-ibmi.copyIFS`, async (node: IFSItem) => {
       const connection = instance.getConnection();
+
+      const oldFile = node.file;
+      const oldUri = node.resourceUri as Uri;
+
+      const oldIfsTabs = VscodeTools.findUriTabs(oldUri);
+      if (oldIfsTabs.find(tab => tab.isDirty)) {
+        const result = await vscode.window.showWarningMessage(vscode.l10n.t(`The stream file {0} has unsaved changes. The copied stream file will not include these changes. Do you want to continue?`, oldFile.name), { modal: true }, vscode.l10n.t("Yes"), vscode.l10n.t("No"));
+        if (result === vscode.l10n.t("No")) {
+          return;
+        }
+      }
 
       if (connection) {
         const config = connection.getConfig();


### PR DESCRIPTION
### Changes

Fixes https://github.com/codefori/vscode-ibmi/issues/2897

Warning when copying members with unsaved changes:

<img width="1436" height="369" alt="image" src="https://github.com/user-attachments/assets/3d9805aa-3a30-4733-b7e3-43008a1d2621" />

Warning when copying stream file with unsaved changes:

<img width="1435" height="385" alt="image" src="https://github.com/user-attachments/assets/eed89106-ea8b-4761-b7c1-d9d899b0efd0" />



### How to test this PR
1. Create member or stream and make some change without saving.
2. Attempt to copy it and check the warning appears.

### Checklist
* [x] have tested my change
