### PR TITLE
Added missing `postDownload` and `deployFirst` fields in action editor

### DIFF
--- a/src/editors/actionEditor.ts
+++ b/src/editors/actionEditor.ts
@@ -149,7 +149,7 @@ async function save(targetAction: Action, actionData: ActionData, workspace?: vs
   Object.assign(targetAction, actionData,
     //Fields that needs to be tranformed before saving
     {
-      command: targetAction.command.replace(new RegExp(`\\\r`, `g`), ``), // We don't want \r (Windows line endings)
+      command: actionData.command.replace(new RegExp(`\\\r`, `g`), ``), // We don't want \r (Windows line endings)
       extensions: extensions.length ? extensions : undefined,
       outputToFile: actionData.outputToFile || undefined,
       postDownload: postDownload.length ? postDownload : undefined

--- a/src/editors/actionEditor.ts
+++ b/src/editors/actionEditor.ts
@@ -53,7 +53,7 @@ export function editAction(targetAction: Action, doAfterSave?: () => Thenable<vo
         } as Tab)), getDefaultTabIndex(targetAction.type)
     )
     .addHorizontalRule()
-    .addInput(`extensions`, vscode.l10n.t(`Extensions`), vscode.l10n.t(`A comma delimited list of extensions for this action. This can be a member extension, a streamfile extension, an object type or an object attribute`), { default: targetAction.extensions?.join(`, `) })
+    .addInput(`extensions`, vscode.l10n.t(`Extensions`), vscode.l10n.t(`A comma separated list of extensions for this action. This can be a member extension, a streamfile extension, an object type or an object attribute`), { default: targetAction.extensions?.join(`, `) })
     .addSelect(`type`, vscode.l10n.t(`Type`), workspace ? [{
       selected: targetAction.type === `file`,
       value: `file`,
@@ -130,7 +130,7 @@ export function editAction(targetAction: Action, doAfterSave?: () => Thenable<vo
       }], vscode.l10n.t(`The browser level to refresh after the action is done`)
     )
     .addCheckbox("runOnProtected", vscode.l10n.t(`Run on protected/read only`), vscode.l10n.t(`Allows the execution of this Action on protected or read only targets`), targetAction.runOnProtected)
-    .addInput(`postDownload`, vscode.l10n.t(`Post execution downloads`), vscode.l10n.t("Remote files/folders to download when the Action is complete. Using `.evfevent` in combination with a build tool will populate the Problems view."), { default: targetAction.postDownload?.join(', ') })
+    .addInput(`postDownload`, vscode.l10n.t(`Post execution downloads`), vscode.l10n.t("A comma separated list of remote files/folders to download when the Action is complete. Using `.evfevent` in combination with a build tool will populate the Problems view."), { default: targetAction.postDownload?.join(', ') })
     .addInput(`outputToFile`, vscode.l10n.t(`Copy output to file`), vscode.l10n.t(`Copy the action output to a file. Variables can be used to define the file's path; use <code>&i</code> to compute file index.<br/>Example: <code>~/outputs/&CURLIB_&OPENMBR&i.txt</code>.`), { default: targetAction.outputToFile })
     .open();
 

--- a/src/editors/actionEditor.ts
+++ b/src/editors/actionEditor.ts
@@ -27,6 +27,7 @@ type ActionData = {
   refresh: ActionRefresh
   runOnProtected: boolean
   outputToFile: string
+  postDownload: string
 }
 
 const editedActions: Set<{ name: string, type?: ActionType }> = new Set;
@@ -129,6 +130,7 @@ export function editAction(targetAction: Action, doAfterSave?: () => Thenable<vo
       }], vscode.l10n.t(`The browser level to refresh after the action is done`)
     )
     .addCheckbox("runOnProtected", vscode.l10n.t(`Run on protected/read only`), vscode.l10n.t(`Allows the execution of this Action on protected or read only targets`), targetAction.runOnProtected)
+    .addInput(`postDownload`, vscode.l10n.t(`Post execution downloads`), vscode.l10n.t("Remote files/folders to download when the Action is complete. Using `.evfevent` in combination with a build tool will populate the Problems view."), { default: targetAction.postDownload?.join(', ') })
     .addInput(`outputToFile`, vscode.l10n.t(`Copy output to file`), vscode.l10n.t(`Copy the action output to a file. Variables can be used to define the file's path; use <code>&i</code> to compute file index.<br/>Example: <code>~/outputs/&CURLIB_&OPENMBR&i.txt</code>.`), { default: targetAction.outputToFile })
     .open();
 
@@ -137,14 +139,21 @@ export function editAction(targetAction: Action, doAfterSave?: () => Thenable<vo
 
 async function save(targetAction: Action, actionData: ActionData, workspace?: vscode.WorkspaceFolder) {
   const oldType = targetAction.type;
-  Object.assign(targetAction, actionData);
+  const postDownload = actionData.postDownload.split(',').map(path => path.trim()).filter(Boolean);
+  const extensions = actionData.extensions.split(`,`).map(item => item.trim().toUpperCase()).filter(Boolean);
+  Object.assign(targetAction, actionData,
+    //Fields that needs to be tranformed before saving
+    {
+      command: targetAction.command.replace(new RegExp(`\\\r`, `g`), ``), // We don't want \r (Windows line endings)
+      extensions: extensions.length ? extensions : undefined,
+      outputToFile: actionData.outputToFile || undefined,
+      postDownload: postDownload.length ? postDownload : undefined
+    });
   const typeChanged = (oldType !== targetAction.type);
   if (typeChanged && (await getActions(workspace)).some(a => a.name === targetAction.name && a.type === targetAction.type)) {
     throw new Error(l10n.t("The action '{0}' already exists for the '{1}' type", targetAction.name, targetAction.type!))
   }
-  // We don't want \r (Windows line endings)
-  targetAction.command = targetAction.command.replace(new RegExp(`\\\r`, `g`), ``);
-  targetAction.extensions = actionData.extensions.split(`,`).map(item => item.trim().toUpperCase())
+  
   await updateAction(targetAction, workspace, { oldType });
   if (typeChanged) {
     editedActions.delete({ name: targetAction.name, type: oldType });

--- a/src/editors/actionEditor.ts
+++ b/src/editors/actionEditor.ts
@@ -27,6 +27,7 @@ type ActionData = {
   refresh: ActionRefresh
   runOnProtected: boolean
   outputToFile: string
+  deployFirst: boolean
   postDownload: string
 }
 
@@ -131,6 +132,7 @@ export function editAction(targetAction: Action, doAfterSave?: () => Thenable<vo
     );
 
   if (workspace) {
+    actionEditor.addCheckbox(`deployFirst`, vscode.l10n.t(`Deploy before running`), vscode.l10n.t("When enabled, the local workspace will be deployed before the action is run."), targetAction.deployFirst);
     actionEditor.addInput(`postDownload`, vscode.l10n.t(`Post execution downloads`), vscode.l10n.t("A comma separated list of remote files/folders to download when the Action is complete. Supports variables. Using <code>.evfevent</code> in combination with a build tool will populate the Problems view."), { default: targetAction.postDownload?.join(', ') });
   }
 

--- a/src/editors/actionEditor.ts
+++ b/src/editors/actionEditor.ts
@@ -38,7 +38,7 @@ export function isActionEdited(action: Action) {
 
 export function editAction(targetAction: Action, doAfterSave?: () => Thenable<void>, workspace?: vscode.WorkspaceFolder) {
   const customVariables = CustomVariables.getAll().map(variable => `<li><b><code>&amp;${variable.name}</code></b>: <code>${variable.value}</code></li>`).join(``);
-  new CustomEditor<ActionData>(`${targetAction.type}/${targetAction.name}.action`, (actionData) => save(targetAction, actionData, workspace).then(doAfterSave), () => editedActions.delete({ name: targetAction.name, type: targetAction.type }))
+  const actionEditor = new CustomEditor<ActionData>(`${targetAction.type}/${targetAction.name}.action`, (actionData) => save(targetAction, actionData, workspace).then(doAfterSave), () => editedActions.delete({ name: targetAction.name, type: targetAction.type }))
     .addInput(
       `command`,
       vscode.l10n.t(`Command(s) to run`),
@@ -128,9 +128,14 @@ export function editAction(targetAction: Action, doAfterSave?: () => Thenable<vo
         description: vscode.l10n.t(`Browser`),
         text: vscode.l10n.t(`The entire browser is refreshed`)
       }], vscode.l10n.t(`The browser level to refresh after the action is done`)
-    )
+    );
+
+  if (workspace) {
+    actionEditor.addInput(`postDownload`, vscode.l10n.t(`Post execution downloads`), vscode.l10n.t("A comma separated list of remote files/folders to download when the Action is complete. Supports variables. Using <code>.evfevent</code> in combination with a build tool will populate the Problems view."), { default: targetAction.postDownload?.join(', ') });
+  }
+
+  actionEditor
     .addCheckbox("runOnProtected", vscode.l10n.t(`Run on protected/read only`), vscode.l10n.t(`Allows the execution of this Action on protected or read only targets`), targetAction.runOnProtected)
-    .addInput(`postDownload`, vscode.l10n.t(`Post execution downloads`), vscode.l10n.t("A comma separated list of remote files/folders to download when the Action is complete. Using `.evfevent` in combination with a build tool will populate the Problems view."), { default: targetAction.postDownload?.join(', ') })
     .addInput(`outputToFile`, vscode.l10n.t(`Copy output to file`), vscode.l10n.t(`Copy the action output to a file. Variables can be used to define the file's path; use <code>&i</code> to compute file index.<br/>Example: <code>~/outputs/&CURLIB_&OPENMBR&i.txt</code>.`), { default: targetAction.outputToFile })
     .open();
 
@@ -153,7 +158,7 @@ async function save(targetAction: Action, actionData: ActionData, workspace?: vs
   if (typeChanged && (await getActions(workspace)).some(a => a.name === targetAction.name && a.type === targetAction.type)) {
     throw new Error(l10n.t("The action '{0}' already exists for the '{1}' type", targetAction.name, targetAction.type!))
   }
-  
+
   await updateAction(targetAction, workspace, { oldType });
   if (typeChanged) {
     editedActions.delete({ name: targetAction.name, type: oldType });

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -382,9 +382,9 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
                           target.hasRun = true;
                           const isIleCommand = environment === `ile`;
 
-                          const useLocalEvfevent =
-                            fromWorkspace && chosenAction.postDownload &&
-                            (chosenAction.postDownload.includes(`.evfevent`) || chosenAction.postDownload.includes(`.evfevent/`));
+                          const postDownload = chosenAction.postDownload?.map(path => variables.expand(path)) || [];
+                          const useLocalEvfevent = fromWorkspace && postDownload.length &&
+                            (postDownload.includes(`.evfevent`) || postDownload.includes(`.evfevent/`));
 
                           const possibleObjects = getObjectsFromJoblog(commandResult.stderr) || getObjectFromCommand(commandResult.command);
                           if (isIleCommand && possibleObjects) {
@@ -428,14 +428,14 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
                             await outputToFile(connection, chosenAction.outputToFile, variables, target.output);
                           }
 
-                          if (chosenAction.type === `file` && chosenAction.postDownload?.length) {
+                          if (chosenAction.type === `file` && postDownload?.length) {
                             if (fromWorkspace) {
                               const remoteDir = remoteCwd;
                               const localDir = fromWorkspace.uri;
 
                               const postDownloads: { type: vscode.FileType, localPath: string, remotePath: string }[] = [];
                               const downloadDirectories = new Set<vscode.Uri>();
-                              for (const download of chosenAction.postDownload) {
+                              for (const download of postDownload) {
                                 const remotePath = path.posix.join(remoteDir, download);
                                 const localPath = vscode.Uri.joinPath(localDir, download).path;
 
@@ -498,7 +498,7 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
                               await Promise.all(downloads)
                                 .then(async () => {
                                   // Done!
-                                  writeEmitter.fire(`Downloaded files as part of Action: ${chosenAction.postDownload!.join(`, `)}\n`);
+                                  writeEmitter.fire(`Downloaded files as part of Action: ${postDownload!.join(`, `)}\n`);
 
                                   // Process locally downloaded evfevent files:
                                   if (useLocalEvfevent) {


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Following up on #3109 

This PR adds a Post Execution Downloads and a Deploy before running field to the Action editor for Local Actions only.
<img width="763" height="192" alt="image" src="https://github.com/user-attachments/assets/8c0d8d9e-76ab-4b48-bd6a-0077ef4c42ba" />


Other types of action will not display these fields in the editor.

These fields could only be added and edited manually from the settings/actions.json files.They can now also be changed from the editor.

The `postDownload` field also now supports variables replacement when the action is executed.

The PR also makes sure that some optional action fields are cleaned up before being saved to avoid writing blank strings/empty array in the settings.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Edit an action
2. Set one or more post execution download paths
3. Save
4. The paths must be saved as an array in the settings
5. Remove the paths
6. Save
7. The postDownload array must be removed from the settings

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change