### PR TITLE
updated actions for rpg and rpgle member file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -648,8 +648,7 @@
 						{
 							"type": "member",
 							"extensions": [
-								"RPGLE",
-								"RPG"
+								"RPGLE"
 							],
 							"name": "Create Bound RPG Program (CRTBNDRPG)",
 							"command": "CRTBNDRPG PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT)"
@@ -657,10 +656,27 @@
 						{
 							"type": "member",
 							"extensions": [
-								"GLOBAL"
+								"RPGLE"
 							],
 							"name": "Create Service Program (CRTSRVPGM)",
 							"command": "?CRTSRVPGM SRVPGM(&OPENLIB/&OPENMBR) EXPORT(*ALL) BNDSRVPGM(*NONE) BNDDIR(*NONE) ACTGRP(*CALLER) TGTRLS(*CURRENT)"
+						},
+						{
+							"type": "member",
+							"extensions": [
+								"RPG",
+								"RPG38"
+							],
+							"name": "Create RPG Program (CRTRPGPGM)",
+							"command": "CRTRPGPGM PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) SRCMBR(&OPENMBR) REPLACE(*NO)"
+						},
+						{
+							"type": "member",
+							"extensions": [
+								"RPG36"
+							],
+							"name": "Create RPG Program (CRTRPGPGM)",
+							"command": "CRTS36RPG PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) SRCMBR(&OPENMBR) REPLACE(*NO)"
 						},
 						{
 							"type": "member",
@@ -681,8 +697,7 @@
 						{
 							"type": "member",
 							"extensions": [
-								"RPGLE",
-								"RPG"
+								"RPGLE"
 							],
 							"name": "Create RPG Module (CRTRPGMOD)",
 							"command": "?CRTRPGMOD MODULE(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT)"
@@ -765,7 +780,7 @@
 						{
 							"type": "member",
 							"extensions": [
-								"GLOBAL"
+								"RPGLE"
 							],
 							"name": "Create Program (CRTPGM)",
 							"command": "?CRTPGM PGM(&OPENLIB/&OPENMBR) MODULE(*PGM) ENTMOD(*FIRST) BNDSRVPGM(*NONE) BNDDIR(*NONE) ACTGRP(*ENTMOD) TGTRLS(*CURRENT)"

--- a/package.json
+++ b/package.json
@@ -656,7 +656,7 @@
 						{
 							"type": "member",
 							"extensions": [
-								"RPGLE"
+								"GLOBAL"
 							],
 							"name": "Create Service Program (CRTSRVPGM)",
 							"command": "?CRTSRVPGM SRVPGM(&OPENLIB/&OPENMBR) EXPORT(*ALL) BNDSRVPGM(*NONE) BNDDIR(*NONE) ACTGRP(*CALLER) TGTRLS(*CURRENT)"
@@ -664,19 +664,10 @@
 						{
 							"type": "member",
 							"extensions": [
-								"RPG",
-								"RPG38"
+								"RPG"
 							],
 							"name": "Create RPG Program (CRTRPGPGM)",
 							"command": "CRTRPGPGM PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) SRCMBR(&OPENMBR) REPLACE(*NO)"
-						},
-						{
-							"type": "member",
-							"extensions": [
-								"RPG36"
-							],
-							"name": "Create RPG Program (CRTRPGPGM)",
-							"command": "CRTS36RPG PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) SRCMBR(&OPENMBR) REPLACE(*NO)"
 						},
 						{
 							"type": "member",
@@ -780,7 +771,7 @@
 						{
 							"type": "member",
 							"extensions": [
-								"RPGLE"
+								"GLOBAL"
 							],
 							"name": "Create Program (CRTPGM)",
 							"command": "?CRTPGM PGM(&OPENLIB/&OPENMBR) MODULE(*PGM) ENTMOD(*FIRST) BNDSRVPGM(*NONE) BNDDIR(*NONE) ACTGRP(*ENTMOD) TGTRLS(*CURRENT)"

--- a/src/testing/action.ts
+++ b/src/testing/action.ts
@@ -143,7 +143,7 @@ export const ActionSuite: TestSuite = {
           ],
         };
         const uri = getMemberUri({ library: tempLib, file: 'QRPGLESRC', name: 'HELLO', extension: 'RPGLE' })
-        await testHelloWorldProgram(uri, action, tempLib, 'HELLO');
+        await testHelloWorldProgram(uri, action, tempLib);
       }
     },
 

--- a/src/testing/action.ts
+++ b/src/testing/action.ts
@@ -26,7 +26,7 @@ export const helloWorldProject: Folder = {
       `     A                                      DSPATR(HI)`,
       `     A                                      DSPATR(UL)`,
     ]),
-    new File("TRPG.pgm.rpg", [
+    new File("HELLO.pgm.rpg", [
       `     C           'HELLO'   DSPLY`,
       `     C                     SETON                     LR`,
     ]),
@@ -130,10 +130,9 @@ export const ActionSuite: TestSuite = {
         const config = connection.getConfig();
         const content = connection.getContent();
         const tempLib = config!.tempLibrary;
-        const pgmName = 'HELLO';
 
-        await connection!.runCommand({ command: `ADDPFM FILE(${tempLib}/QRPGLESRC) MBR(${pgmName}) SRCTYPE(RPGLE)` });
-        await content!.uploadMemberContent(tempLib, 'QRPGLESRC', pgmName, helloWorldProject.files![0].content.join('\n'));
+        await connection!.runCommand({ command: `ADDPFM FILE(${tempLib}/QRPGLESRC) MBR(HELLO) SRCTYPE(RPGLE)` });
+        await content!.uploadMemberContent(tempLib, 'QRPGLESRC', 'HELLO', helloWorldProject.files![0].content.join('\n'));
         const action: Action = {
           "name": "Create Bound RPG Program (CRTBNDRPG)",
           "command": "CRTBNDRPG PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT)",
@@ -143,8 +142,8 @@ export const ActionSuite: TestSuite = {
             "RPGLE",
           ],
         };
-        const uri = getMemberUri({ library: tempLib, file: 'QRPGLESRC', name: pgmName, extension: 'RPGLE' })
-        await testHelloWorldProgram(uri, action, tempLib, pgmName);
+        const uri = getMemberUri({ library: tempLib, file: 'QRPGLESRC', name: 'HELLO', extension: 'RPGLE' })
+        await testHelloWorldProgram(uri, action, tempLib, 'HELLO');
       }
     },
 
@@ -177,11 +176,10 @@ export const ActionSuite: TestSuite = {
         const config = connection.getConfig();
         const content = connection.getContent();
         const tempLib = config!.tempLibrary;
-        const SRCTYPE = 'RPG';
-        const pgmName = "TRPG";
+        const srcType = 'RPG';
 
-        await connection!.runCommand({ command: `ADDPFM FILE(${tempLib}/QRPGSRC) MBR(${pgmName}) SRCTYPE(${SRCTYPE})` });
-        await content!.uploadMemberContent(tempLib, 'QRPGSRC', pgmName, helloWorldProject.files![3].content.join('\n'));
+        await connection!.runCommand({ command: `ADDPFM FILE(${tempLib}/QRPGSRC) MBR(HELLO) SRCTYPE(${srcType})` });
+        await content!.uploadMemberContent(tempLib, 'QRPGSRC', 'HELLO', helloWorldProject.files![3].content.join('\n'));
         const action: Action = {
           "name": "Create RPG Program (CRTRPGPGM)",
           "command": "CRTRPGPGM PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) SRCMBR(&OPENMBR) REPLACE(*NO)",
@@ -191,8 +189,8 @@ export const ActionSuite: TestSuite = {
             "RPG"
           ],
         };
-        const uri = getMemberUri({ library: tempLib, file: 'QRPGSRC', name: pgmName, extension: SRCTYPE })
-        await testHelloWorldProgram(uri, action, tempLib, pgmName, SRCTYPE);
+        const uri = getMemberUri({ library: tempLib, file: 'QRPGSRC', name: 'HELLO', extension: srcType })
+        await testHelloWorldProgram(uri, action, tempLib, srcType);
       }
     },
     {
@@ -201,9 +199,9 @@ export const ActionSuite: TestSuite = {
         const config = connection.getConfig();
         const content = connection.getContent();
         const tempLib = config!.tempLibrary;
-        const SRCTYPE = 'RPG';
+        const srcType = 'RPG';
 
-        await connection!.runCommand({ command: `ADDPFM FILE(${tempLib}/QRPGSRC) MBR(BADRPG) SRCTYPE(${SRCTYPE})` });
+        await connection!.runCommand({ command: `ADDPFM FILE(${tempLib}/QRPGSRC) MBR(BADRPG) SRCTYPE(${srcType})` });
         await content!.uploadMemberContent(tempLib, 'QRPGSRC', 'BADRPG', helloWorldProject.files![4].content.join('\n'));
         const action: Action = {
           "name": "Create RPG Program (CRTRPGPGM)",
@@ -214,7 +212,7 @@ export const ActionSuite: TestSuite = {
             "RPG"
           ],
         };
-        const uri = getMemberUri({ library: tempLib, file: 'QRPGSRC', name: 'BADRPG', extension: SRCTYPE })
+        const uri = getMemberUri({ library: tempLib, file: 'QRPGSRC', name: 'BADRPG', extension: srcType })
         const success = await runAction(instance, uri, action, `all`);
         assert.strictEqual(success, false);
       }
@@ -336,7 +334,12 @@ export const ActionSuite: TestSuite = {
   ]
 };
 
-async function testHelloWorldProgram(uri: vscode.Uri, action: Action, library: string, pgmName: string | undefined = undefined, SRCTYPE: string = 'RPGLE') {
+/**
+ * @param srcType Source type identifier (RPG or RPGLE). 
+ * Defaults to 'RPGLE' to maintain backward compatibility with existing .rpgle test cases while allowing reuse for .rpg test cases.
+ */
+
+async function testHelloWorldProgram(uri: vscode.Uri, action: Action, library: string, srcType: string = 'RPGLE') {
   const actionRan = await runAction(instance, uri, action, `all`);
   assert.ok(actionRan);
 
@@ -345,16 +348,16 @@ async function testHelloWorldProgram(uri: vscode.Uri, action: Action, library: s
     if (keysToCompare.includes(key)) { return value }
   });
   const content = instance.getConnection()?.getContent();
-  const helloWorldProgram = (await content?.getObjectList({ library: library, object: pgmName, types: ['*PGM'] }))![0];
+  const helloWorldProgram = (await content?.getObjectList({ library: library, object: 'HELLO', types: ['*PGM'] }))![0];
   assert.deepStrictEqual(toJSON(helloWorldProgram), toJSON({
     library: library,
-    name: pgmName,
+    name: 'HELLO',
     type: '*PGM',
     text: '',
-    attribute: SRCTYPE,
+    attribute: srcType,
     sourceFile: false
   } as IBMiObject));
 
   const connection = instance.getConnection();
-  await connection?.runCommand({ command: `DLTOBJ OBJ(${library}/${pgmName}) OBJTYPE(*PGM)` });
+  await connection?.runCommand({ command: `DLTOBJ OBJ(${library}/HELLO) OBJTYPE(*PGM)` });
 }

--- a/src/testing/action.ts
+++ b/src/testing/action.ts
@@ -25,6 +25,14 @@ export const helloWorldProject: Folder = {
       `     A                                  6 10'ID'`,
       `     A                                      DSPATR(HI)`,
       `     A                                      DSPATR(UL)`,
+    ]),
+    new File("TRPG.pgm.rpg", [
+      `     C           'HELLO'   DSPLY`,
+      `     C                     SETON                     LR`,
+    ]),
+    new File("BADRPG.pgm.rpg", [
+      `     C           'HELLO'DSPLY`,
+      `     CSETON                     LR`,
     ])
   ],
 }
@@ -59,7 +67,9 @@ export const ActionSuite: TestSuite = {
 
     const tempLib = config!.tempLibrary;
     await connection!.runCommand({ command: `DLTOBJ OBJ(${tempLib}/QRPGLESRC) OBJTYPE(*FILE)`, noLibList: true });
+    await connection!.runCommand({ command: `DLTOBJ OBJ(${tempLib}/QRPGSRC) OBJTYPE(*FILE)`, noLibList: true });
     await connection!.runCommand({ command: `CRTSRCPF FILE(${tempLib}/QRPGLESRC) RCDLEN(112)`, noLibList: true });
+    await connection!.runCommand({ command: `CRTSRCPF FILE(${tempLib}/QRPGSRC) RCDLEN(112)`, noLibList: true });
   },
   tests: [
     {
@@ -120,9 +130,10 @@ export const ActionSuite: TestSuite = {
         const config = connection.getConfig();
         const content = connection.getContent();
         const tempLib = config!.tempLibrary;
+        const pgmName = 'HELLO';
 
-        await connection!.runCommand({ command: `ADDPFM FILE(${tempLib}/QRPGLESRC) MBR(HELLO) SRCTYPE(RPGLE)` });
-        await content!.uploadMemberContent(tempLib, 'QRPGLESRC', 'HELLO', helloWorldProject.files![0].content.join('\n'));
+        await connection!.runCommand({ command: `ADDPFM FILE(${tempLib}/QRPGLESRC) MBR(${pgmName}) SRCTYPE(RPGLE)` });
+        await content!.uploadMemberContent(tempLib, 'QRPGLESRC', pgmName, helloWorldProject.files![0].content.join('\n'));
         const action: Action = {
           "name": "Create Bound RPG Program (CRTBNDRPG)",
           "command": "CRTBNDRPG PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT)",
@@ -130,11 +141,10 @@ export const ActionSuite: TestSuite = {
           "environment": "ile",
           "extensions": [
             "RPGLE",
-            "RPG"
           ],
         };
-        const uri = getMemberUri({ library: tempLib, file: 'QRPGLESRC', name: 'HELLO', extension: 'RPGLE' })
-        await testHelloWorldProgram(uri, action, tempLib);
+        const uri = getMemberUri({ library: tempLib, file: 'QRPGLESRC', name: pgmName, extension: 'RPGLE' })
+        await testHelloWorldProgram(uri, action, tempLib, pgmName);
       }
     },
 
@@ -153,11 +163,58 @@ export const ActionSuite: TestSuite = {
           "type": "member",
           "environment": "ile",
           "extensions": [
-            "RPGLE",
-            "RPG"
+            "RPGLE"
           ],
         };
         const uri = getMemberUri({ library: tempLib, file: 'QRPGLESRC', name: 'THEBADONE', extension: 'RPGLE' })
+        const success = await runAction(instance, uri, action, `all`);
+        assert.strictEqual(success, false);
+      }
+    },
+    {
+      name: `Create RPG Program (from member, custom action)`, test: async () => {
+        const connection = instance.getConnection()!;
+        const config = connection.getConfig();
+        const content = connection.getContent();
+        const tempLib = config!.tempLibrary;
+        const SRCTYPE = 'RPG';
+        const pgmName = "TRPG";
+
+        await connection!.runCommand({ command: `ADDPFM FILE(${tempLib}/QRPGSRC) MBR(${pgmName}) SRCTYPE(${SRCTYPE})` });
+        await content!.uploadMemberContent(tempLib, 'QRPGSRC', pgmName, helloWorldProject.files![3].content.join('\n'));
+        const action: Action = {
+          "name": "Create RPG Program (CRTRPGPGM)",
+          "command": "CRTRPGPGM PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) SRCMBR(&OPENMBR) REPLACE(*NO)",
+          "type": "member",
+          "environment": "ile",
+          "extensions": [
+            "RPG"
+          ],
+        };
+        const uri = getMemberUri({ library: tempLib, file: 'QRPGSRC', name: pgmName, extension: SRCTYPE })
+        await testHelloWorldProgram(uri, action, tempLib, pgmName, SRCTYPE);
+      }
+    },
+    {
+      name: `Create RPG Program failure (from member, custom action)`, test: async () => {
+        const connection = instance.getConnection()!;
+        const config = connection.getConfig();
+        const content = connection.getContent();
+        const tempLib = config!.tempLibrary;
+        const SRCTYPE = 'RPG';
+
+        await connection!.runCommand({ command: `ADDPFM FILE(${tempLib}/QRPGSRC) MBR(BADRPG) SRCTYPE(${SRCTYPE})` });
+        await content!.uploadMemberContent(tempLib, 'QRPGSRC', 'BADRPG', helloWorldProject.files![4].content.join('\n'));
+        const action: Action = {
+          "name": "Create RPG Program (CRTRPGPGM)",
+          "command": "CRTRPGPGM PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) SRCMBR(&OPENMBR) REPLACE(*NO)",
+          "type": "member",
+          "environment": "ile",
+          "extensions": [
+            "RPG"
+          ],
+        };
+        const uri = getMemberUri({ library: tempLib, file: 'QRPGSRC', name: 'BADRPG', extension: SRCTYPE })
         const success = await runAction(instance, uri, action, `all`);
         assert.strictEqual(success, false);
       }
@@ -279,7 +336,7 @@ export const ActionSuite: TestSuite = {
   ]
 };
 
-async function testHelloWorldProgram(uri: vscode.Uri, action: Action, library: string) {
+async function testHelloWorldProgram(uri: vscode.Uri, action: Action, library: string, pgmName: string | undefined = undefined, SRCTYPE: string = 'RPGLE') {
   const actionRan = await runAction(instance, uri, action, `all`);
   assert.ok(actionRan);
 
@@ -288,16 +345,16 @@ async function testHelloWorldProgram(uri: vscode.Uri, action: Action, library: s
     if (keysToCompare.includes(key)) { return value }
   });
   const content = instance.getConnection()?.getContent();
-  const helloWorldProgram = (await content?.getObjectList({ library: library, object: 'HELLO', types: ['*PGM'] }))![0];
+  const helloWorldProgram = (await content?.getObjectList({ library: library, object: pgmName, types: ['*PGM'] }))![0];
   assert.deepStrictEqual(toJSON(helloWorldProgram), toJSON({
     library: library,
-    name: 'HELLO',
+    name: pgmName,
     type: '*PGM',
     text: '',
-    attribute: 'RPGLE',
+    attribute: SRCTYPE,
     sourceFile: false
   } as IBMiObject));
 
   const connection = instance.getConnection();
-  await connection?.runCommand({ command: `DLTOBJ OBJ(${library}/HELLO) OBJTYPE(*PGM)` });
+  await connection?.runCommand({ command: `DLTOBJ OBJ(${library}/${pgmName}) OBJTYPE(*PGM)` });
 }


### PR DESCRIPTION
### Changes
As of now code for ibm i returns rpgle actions for when user invokes get actions tool to fetch available actions for rpg member file. These 4 commands are only valid for .rpgle. This pr will update the code for ibmi to return 4 valid rpgle commands and 1 valid .rpg command . test cases are added for .rpg command as well.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [x] have created one or more test cases
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
