### PR TITLE
Add extensions for action to action tooltip

### DIFF
--- a/src/ui/views/environment/actions.ts
+++ b/src/ui/views/environment/actions.ts
@@ -163,7 +163,7 @@ export class ActionItem extends EnvironmentItem {
 
     this.iconPath = new vscode.ThemeIcon("github-action", this.context.matched ? new vscode.ThemeColor(ActionItem.matchedColor) : undefined);
     this.description = this.context.matched ? l10n.t("search match") : undefined;
-    this.tooltip = this.action.command;
+    this.tooltip = `${ this.action.command }\nExtensions: ${this.action.extensions?.join(`, `)}`;
     this.resourceUri = vscode.Uri.from({
       scheme: ActionItem.context,
       authority: this.action.name,


### PR DESCRIPTION
### Changes
Having multiple actions with the same name for different extensions makes it hard to find the right one in the list of action in the ENVIRONMENT view.

This PR adds the extensions to the action tooltip:
<img width="910" height="258" alt="image" src="https://github.com/user-attachments/assets/555fbad7-2779-44d7-af61-7ed00d759b6a" />

### Checklist
* [x] have tested my change
