### PR TITLE
Fix `&WORKDIR` variable being overwritten

### DIFF
--- a/src/api/tests/suites/variables.test.ts
+++ b/src/api/tests/suites/variables.test.ts
@@ -62,13 +62,13 @@ describe(`variables tests`, { concurrent: true }, () => {
         { name: "WARCRY", value: "Fus Roh Dah!" },
         { name: "EXPANDED", value: `I am &USERNAME!` }
       );
-      const connectionVariables = new Variables(connection);
+      const connectionVariables = new Variables(connection, { "&WORKDIR": "/home/MYUSER/my-work-dir" });
       expect(connectionVariables.get("&USERNAME")).toBe(connection.currentUser);
       expect(connectionVariables.get("{usrprf}")).toBe(connectionVariables.get("&USERNAME"));
       expect(connectionVariables.get("&HOST")).toBe(connection.currentHost);
       expect(connectionVariables.get("{host}")).toBe(connectionVariables.get("&HOST"));
       expect(connectionVariables.get("&HOME")).toBe(config.homeDirectory);
-      expect(connectionVariables.get("&WORKDIR")).toBe(connectionVariables.get("&HOME"));
+      expect(connectionVariables.get("&WORKDIR")).toBe(connectionVariables.get("/home/MYUSER/my-work-dir"));
 
       expect(connectionVariables.get("&CUSTOM")).toBe("value");
       expect(connectionVariables.get("&WARCRY")).toBe("Fus Roh Dah!");

--- a/src/api/tests/suites/variables.test.ts
+++ b/src/api/tests/suites/variables.test.ts
@@ -68,7 +68,7 @@ describe(`variables tests`, { concurrent: true }, () => {
       expect(connectionVariables.get("&HOST")).toBe(connection.currentHost);
       expect(connectionVariables.get("{host}")).toBe(connectionVariables.get("&HOST"));
       expect(connectionVariables.get("&HOME")).toBe(config.homeDirectory);
-      expect(connectionVariables.get("&WORKDIR")).toBe(connectionVariables.get("/home/MYUSER/my-work-dir"));
+      expect(connectionVariables.get("&WORKDIR")).toBe("/home/MYUSER/my-work-dir");
 
       expect(connectionVariables.get("&CUSTOM")).toBe("value");
       expect(connectionVariables.get("&WARCRY")).toBe("Fus Roh Dah!");

--- a/src/api/variables.ts
+++ b/src/api/variables.ts
@@ -19,7 +19,9 @@ export class Variables extends Map<string, string> {
         .set(`&HOST`, connection.currentHost)
         .set(`{host}`, connection.currentHost)
         .set(`&HOME`, config.homeDirectory)
-        .set(`&WORKDIR`, config.homeDirectory);
+      if (!this.get(`&WORKDIR`)) {
+        this.set(`&WORKDIR`, config.homeDirectory);
+      }
 
       for (const variable of config.customVariables) {
         this.set(`&${variable.name.toUpperCase()}`, variable.value || '');


### PR DESCRIPTION
### Changes

This PR fixes the `&WORKDIR` variable which was previously always overwritten to the user's home directory even though `file` type actions initially set it correctly to the working directory.

Fixes #3153

### How to test this PR
1. Run the following action:
```json
[
  {
    "name": "Variable Test",
    "command": "SNDMSG MSG('WORKDIR: &WORKDIR')",
    "deployFirst": true,
    "environment": "ile",
    "extensions": [
      "GLOBAL"
    ]
  }
]
```
2. Verify the `&WORKDIR` is substituted correctly:
<img width="585" height="112" alt="image" src="https://github.com/user-attachments/assets/288504c9-469e-4d8a-bee0-b29ad100513d" />


### Checklist
* [x] have tested my change
* [x] have created one or more test cases
