### PR TITLE
Fix write operations in QSYS file system where deleting entire contents

### DIFF
--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -198,7 +198,7 @@ export class QSysFS implements vscode.FileSystemProvider {
         if (connection) {
             const readonly = connection.getConfig().readOnlyMode;
             if (readonly) {
-              throw new FileSystemError("Connection is in readonly mode");
+                throw new FileSystemError("Connection is in readonly mode");
             }
             const contentApi = connection.getContent();
             let { asp, library, file, name: member, extension } = this.parseMemberPath(connection, uri.path);
@@ -213,7 +213,10 @@ export class QSysFS implements vscode.FileSystemProvider {
                     this.savedAsMembers.add(uri.path);
                     vscode.commands.executeCommand(`code-for-ibmi.refreshObjectBrowser`);
                 } else {
-                    throw new FileSystemError(addMember.stderr);
+                    const copyMessages = Tools.parseMessages(addMember.stderr);
+                    if (!copyMessages.findId(`CPF5812`)) { // CPF5812 - Member already exists
+                        throw new FileSystemError(addMember.stderr);
+                    }
                 }
             }
             else {
@@ -254,11 +257,11 @@ export class QSysFS implements vscode.FileSystemProvider {
             }
             else if (uri.path === '/') {
                 let statement = `select OBJNAME from table (QSYS2.OBJECT_STATISTICS ('*ALLSIMPLE', 'LIB', '*ALLSIMPLE'))`;
-                
+
                 const fsOptions = parseFSOptions(uri);
                 if (fsOptions.libraries) {
                     let libraries: string[];
-                    
+
                     // Check if it's a reference to the library list
                     if (fsOptions.libraries.toLowerCase() === 'librarylist') {
                         libraries = connection.getConfig().libraryList;
@@ -266,7 +269,7 @@ export class QSysFS implements vscode.FileSystemProvider {
                         // Parse comma-separated library names
                         libraries = fsOptions.libraries.split(',').map(lib => lib.trim()).filter(Boolean);
                     }
-                    
+
                     if (libraries.length > 0) {
                         statement += ` where OBJNAME in (${libraries.map(entry => `'${connection.upperCaseName(entry)}'`).join(`, `)})`;
                     }


### PR DESCRIPTION
### Changes
In `QsysFs#writeFile`, we always assumed that the content was empty only when doing a `Save as` [here](https://github.com/codefori/vscode-ibmi/blob/master/src/filesystems/qsys/QSysFs.ts#L207). However, this can also happen when the user is deleting the entire contents of a member. This PR now checks for `CPF5812` (example - `Member TEST already exists in file QCLSRC in library SANJULA`) when we do an `ADDPFM` and proceed as normal in this scenario.

Fixes #3155

### How to test this PR
1. Create a member and save some content into it.
2. Now wipe the entire contents and try to save.
3. Observe that you do not hit any error.

### Checklist
* [x] have tested my change