### PR TITLE
perf: optimize getLibraryList by replacing SYSTOOLS.SPLIT with VALUES clause

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -354,6 +354,9 @@ export default class IBMiContent {
   async getLibraryList(libraries: string[]): Promise<IBMiObject[]> {
     let objects: IBMiObject[];
     if (this.ibmi.enableSQL) {
+      // Build VALUES clause from the libraries array
+      const valuesClause = libraries.map(lib => `('${lib.trim()}')`).join(',\n          ');
+
       const statement = `
         SELECT
           os.OBJNAME AS NAME,
@@ -366,8 +369,14 @@ export default class IBMiContent {
           EXTRACT(EPOCH FROM (os.CHANGE_TIMESTAMP)) * 1000 AS CHANGED,
           os.OBJOWNER AS OWNER,
           os.OBJDEFINER AS CREATED_BY
-        from table( SYSTOOLS.SPLIT( INPUT_LIST => '${libraries.toString()}', DELIMITER => ',' ) ) libs,
-        table( QSYS2.OBJECT_STATISTICS( OBJECT_SCHEMA => 'QSYS', OBJTYPELIST => '*LIB', OBJECT_NAME => libs.ELEMENT ) ) os
+        FROM TABLE(VALUES
+          ${valuesClause}
+        ) AS libs(ELEMENT),
+        TABLE(QSYS2.OBJECT_STATISTICS(
+          OBJECT_SCHEMA => 'QSYS',
+          OBJTYPELIST => '*LIB',
+          OBJECT_NAME => libs.ELEMENT
+        )) AS os
       `;
       const results = await this.ibmi.runSQL(statement);
 
@@ -507,7 +516,7 @@ export default class IBMiContent {
     const localVariants = this.ibmi.variantChars.local;
     let translateName = false;
     if (sourceFilesOnly) {
-      //DSPFD only      
+      //DSPFD only
       createOBJLIST = [
         `with SRCFILES as (`,
         `  select `,


### PR DESCRIPTION
## Summary
This PR optimizes the `getLibraryList()` function by replacing `SYSTOOLS.SPLIT()` with a `TABLE(VALUES ...)` clause for better performance on older Power systems.

## Changes
- Replace `SYSTOOLS.SPLIT()` with `TABLE(VALUES ...)` in the SQL query
- Build VALUES clause dynamically from the libraries array

## Performance Benefit
`SYSTOOLS.SPLIT` is a SQL/PL function with overhead, while the VALUES clause uses native SQL. This provides better performance, especially on older/slower IBM i systems.

## Testing
Tested on older IBM i systems and verified:
- Library list retrieval works correctly
- Generic library names (e.g., `SQL*`) are supported
- Performance improvement observed on older Power servers