### PR TITLE
feat(addRowsParam): add rows parameter to runSQL method

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -1358,7 +1358,7 @@ export default class IBMi {
    * @param statements
    * @returns a Result set
    */
-  async runSQL(statements: string | string[], options: { bindings?: BindingValue[] } = {}): Promise<Tools.DB2Row[]> {
+  async runSQL(statements: string | string[], options: { bindings?: BindingValue[], rows?: number } = {}): Promise<Tools.DB2Row[]> {
     if (this.sqlJob) {
       let list = Array.isArray(statements) ? statements : statements.split(`;`).filter(x => x.trim().length > 0);
 
@@ -1401,7 +1401,7 @@ export default class IBMi {
           const log = `Running SQL query: ${statement}\n`;
           try {
             query = this.sqlJob.query<Tools.DB2Row>(statement, { parameters: options.bindings });
-            const rs = await query.execute(99999);
+            const rs = await query.execute(options.rows ?? 99999);
             if (rs.has_results) {
               lastResultSet.push(...rs.data);
               this.appendOutput(`${log}-> ${lastResultSet.length ? `${lastResultSet.length} row(s) returned` : 'no rows returned'}`);

--- a/src/api/tests/suites/content.test.ts
+++ b/src/api/tests/suites/content.test.ts
@@ -253,6 +253,33 @@ describe('Content Tests', { concurrent: true }, () => {
     expect(rows?.length).toBe(1);
   });
 
+  it('Test runSQL (with rows parameter)', async () => {
+    // First, get all rows to know the total count
+    const allRows = await connection.runSQL('select * from qiws.qcustcdt');
+    expect(allRows?.length).toBeGreaterThan(5);
+    
+    // Test with rows parameter set to 3
+    const limitedRows = await connection.runSQL('select * from qiws.qcustcdt', { rows: 3 });
+    expect(limitedRows?.length).toBe(3);
+    
+    // Verify row structure is still correct
+    const firstRow = limitedRows[0];
+    expect(typeof firstRow['BALDUE']).toBe('number');
+    expect(typeof firstRow['CITY']).toBe('string');
+    
+    // Test with rows parameter set to 1
+    const singleRow = await connection.runSQL('select * from qiws.qcustcdt', { rows: 1 });
+    expect(singleRow?.length).toBe(1);
+    
+    // Test without rows parameter (should default to 99999)
+    const defaultRows = await connection.runSQL('select * from qiws.qcustcdt');
+    expect(defaultRows?.length).toBe(allRows.length);
+    
+    // // Test with rows parameter greater than actual row count
+    const moreRowsThanAvailable = await connection.runSQL('select * from qiws.qcustcdt', { rows: 99999 });
+    expect(moreRowsThanAvailable?.length).toBe(allRows.length);
+  });
+
   it('Test getTable', async () => {
     const content = connection.getContent();
 


### PR DESCRIPTION
## Changes

Added an optional `rows` parameter to the `runSQL` method to allow users to limit the number of rows returned from SQL queries, replacing the hardcoded value of 99999.

### Key Changes:
- Updated `runSQL` method signature to accept `rows?: number` in the options parameter
- Modified the query execution to use `options.rows ?? 99999`, maintaining backward compatibility
- Added comprehensive test case covering multiple scenarios

### Benefits:
- Improves performance when working with large result sets by allowing users to limit rows
- Maintains backward compatibility - existing code continues to work without changes
- Provides more control over memory usage and query performance

### API Usage:
```typescript
// Default behavior (fetches up to 99999 rows)
await connection.runSQL("SELECT * FROM myTable");

// Fetch only the first 100 rows
await connection.runSQL("SELECT * FROM myTable", { rows: 100 });

// With bindings and custom row limit
await connection.runSQL("SELECT * FROM myTable WHERE id = ?", { 
  bindings: [123], 
  rows: 50 
});
```

## How to test this PR

1. Run the test suite: `npm test`
2. Run the specific test case: `npm test -- -t "with rows parameter"`
3. Verify all test scenarios pass:
   - Limiting rows to 3 returns exactly 3 rows
   - Limiting rows to 1 returns exactly 1 row
   - Default behavior without `rows` parameter still works
   - Requesting more rows than available returns all available rows
   - Data integrity is maintained with the new parameter

### Manual Testing (optional):
1. Connect to an IBM i system
2. Execute SQL queries using the `runSQL` method with different `rows` values
3. Verify the returned row count matches the specified limit
4. Test with queries that have fewer rows than the limit to ensure graceful handling

## Checklist

* [x] have tested my change
* [x] have created one or more test cases
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
