### PR TITLE
return the search matches if code is not equal to zero

### DIFF
--- a/src/api/SearchTools.ts
+++ b/src/api/SearchTools.ts
@@ -152,7 +152,7 @@ export namespace SearchTools {
           command: `${find} ${Tools.escapePath(path)} ${ignoreString} -type f -iname '*${findTerm}*' -print`
         });
 
-        if (findRes.code == 0 && findRes.stdout) {
+        if ((findRes.code == 0 && findRes.stdout) || findRes.stdout) {
           return {
             term: findTerm,
             hits: parseFindOutput(findRes.stdout)


### PR DESCRIPTION
### description : 
When the user searches for a file in the IFS browser without specifying a path, the FindIFS function searches across all directories. However, for some directories the user does not have permission access, resulting in "Permission Denied" errors. Because of these errors, the command returns a non-zero exit code, and currently the overall result is treated as failure even when the file is successfully found in accessible directories. Due to this, valid search results are not being displayed to the user.


### Changes:
I have added the condition to check for code is not equal to zero and stdres data



### Checklist
<!-- Put an `x` in the relevant boxes -->
* [ x] have tested my change
* [x ] have created one or more test cases
* [ ] updated relevant documentation
* [x ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)

### reference PR: https://github.com/codefori/vscode-ibmi/pull/3114
