### PR TITLE
Ability to disable component

### DIFF
--- a/src/api/components/manager.ts
+++ b/src/api/components/manager.ts
@@ -39,6 +39,7 @@ export const extensionComponentRegistry = new ComponentRegistry();
 
 export class ComponentManager {
   private readonly registered: IBMiComponentRuntime[] = [];
+  private readonly disabled: string[] = [];
 
   constructor(private readonly connection: IBMi) { }
 
@@ -55,11 +56,23 @@ export class ComponentManager {
     });
   }
 
+  disable(id: string) {
+    if (!this.disabled.includes(id)) {
+      this.disabled.push(id);
+    }
+
+    const registeredIndex = this.registered.findIndex(c => c.component.getIdentification().name === id);
+
+    if (registeredIndex >= 0) {
+      this.registered.splice(registeredIndex, 1);
+    }
+  }
+
   /**
    * Returns all components, user managed or not
    */
   getAllAvailableComponents() {
-    return Array.from(extensionComponentRegistry.getComponents().values()).flatMap(a => a.flat());
+    return Array.from(extensionComponentRegistry.getComponents().values()).flatMap(a => a.flat()).filter(c => !this.disabled.includes(c.getIdentification().name));
   }
 
   public async installComponent(key: string): Promise<ComponentInstallState> {

--- a/src/api/tests/suites/components.test.ts
+++ b/src/api/tests/suites/components.test.ts
@@ -55,5 +55,15 @@ describe('Component Tests', () => {
     } catch (e) {
       expect(e).toBeInstanceOf(Error);
     }
+
+    // Let's check we can disable it.
+
+    const requiredCheckC = await manager.getRemoteState(CustomCLI.ID);
+    expect(requiredCheckC).toBeTruthy();
+    expect(requiredCheckC).toBe(`Installed`);
+
+    manager.disable(CustomCLI.ID);
+    const requiredCheckD = await manager.getRemoteState(CustomCLI.ID);
+    expect(requiredCheckD).toBeUndefined();
   });
 });

--- a/src/api/tests/suites/components.test.ts
+++ b/src/api/tests/suites/components.test.ts
@@ -60,7 +60,7 @@ describe('Component Tests', () => {
 
     const requiredCheckC = await manager.getRemoteState(CustomCLI.ID);
     expect(requiredCheckC).toBeTruthy();
-    expect(requiredCheckC).toBe(`Installed`);
+    expect(requiredCheckC?.status).toBe(`Installed`);
 
     manager.disable(CustomCLI.ID);
     const requiredCheckD = await manager.getRemoteState(CustomCLI.ID);


### PR DESCRIPTION
### Changes

Allows the API to disable specific components by ID for the duration of the runtime.

1. If you call disable before the component is registered, it will still be added to the disable list
2. If you call disable after the component has been registered, it will add it to the disabled list and de-register it from the runtime.


### How to test this PR

1. Run the test cases

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
