### PR TITLE
Fix disabling of components

### DIFF
--- a/src/api/components/manager.ts
+++ b/src/api/components/manager.ts
@@ -13,6 +13,7 @@ export interface ComponentSearchProps { ignoreState?: boolean };
 
 export class ComponentRegistry {
   private readonly components: Map<string, IBMiComponent[]> = new Map;
+  private readonly disabled: Map<string, string[]> = new Map;
 
   public registerComponent(context: ExtensionContextI | string, component: IBMiComponent) {
     const key = typeof context === `object` ? context.extension.id : context;
@@ -31,7 +32,28 @@ export class ComponentRegistry {
   }
 
   public getComponents() {
-    return this.components;
+    const filtered = new Map<string, IBMiComponent[]>();
+    
+    for (const [key, components] of this.components) {
+      const disabledIds = this.disabled.get(key) || [];
+      const enabledComponents = components.filter(c => !disabledIds.includes(c.getIdentification().name));
+      if (enabledComponents.length > 0) {
+        filtered.set(key, enabledComponents);
+      }
+    }
+    
+    return filtered;
+  }
+
+  disableComponent(key: string, id: string) {
+    const disabledIds = this.disabled.get(key);
+    if (disabledIds) {
+      if (!disabledIds.includes(id)) {
+        disabledIds.push(id);
+      }
+    } else {
+      this.disabled.set(key, [id]);
+    }
   }
 }
 
@@ -39,7 +61,6 @@ export const extensionComponentRegistry = new ComponentRegistry();
 
 export class ComponentManager {
   private readonly registered: IBMiComponentRuntime[] = [];
-  private readonly disabled: string[] = [];
 
   constructor(private readonly connection: IBMi) { }
 
@@ -56,23 +77,11 @@ export class ComponentManager {
     });
   }
 
-  disable(id: string) {
-    if (!this.disabled.includes(id)) {
-      this.disabled.push(id);
-    }
-
-    const registeredIndex = this.registered.findIndex(c => c.component.getIdentification().name === id);
-
-    if (registeredIndex >= 0) {
-      this.registered.splice(registeredIndex, 1);
-    }
-  }
-
   /**
    * Returns all components, user managed or not
    */
   getAllAvailableComponents() {
-    return Array.from(extensionComponentRegistry.getComponents().values()).flatMap(a => a.flat()).filter(c => !this.disabled.includes(c.getIdentification().name));
+    return Array.from(extensionComponentRegistry.getComponents().values()).flatMap(a => a.flat());
   }
 
   public async installComponent(key: string): Promise<ComponentInstallState> {

--- a/src/api/tests/components/customCli.ts
+++ b/src/api/tests/components/customCli.ts
@@ -4,13 +4,18 @@ import IBMi from "../../IBMi";
 import { ComponentIdentification, IBMiComponent, SecureComponentState } from "../../components/component";
 
 export class CustomCLI implements IBMiComponent {
-  static ID = "customCli";
+  static DEFAULT_ID = "customCli";
   static SIGNATURE = "ForTests";
+  id: string;
 
   installPath = "";
 
+  constructor(id: string = CustomCLI.DEFAULT_ID) {
+    this.id = id;
+  }
+
   getIdentification(): ComponentIdentification {
-    return { name: CustomCLI.ID, version: 1, userManaged: true, signature: CustomCLI.SIGNATURE };
+    return { name: this.id, version: 1, userManaged: true, signature: CustomCLI.SIGNATURE };
   }
 
   getFileName() {

--- a/src/api/tests/connection.ts
+++ b/src/api/tests/connection.ts
@@ -70,6 +70,9 @@ export async function newConnection(reloadSettings?: boolean) {
   const testingId = `testing`;
   extensionComponentRegistry.registerComponent(testingId, mapepire);
   extensionComponentRegistry.registerComponent(testingId, new CustomCLI());
+  const componentId = `toBeDeleted`;
+  extensionComponentRegistry.registerComponent(testingId, new CustomCLI(componentId));
+  extensionComponentRegistry.disableComponent(testingId, componentId);
 
   const creds: ConnectionData = {
     ...ENV_CREDS,

--- a/src/api/tests/suites/components.test.ts
+++ b/src/api/tests/suites/components.test.ts
@@ -14,7 +14,7 @@ describe('Component Tests', () => {
   });
 
   it('Can get component no matter the state', async () => {
-    const componentA = await connection.getComponent<CustomCLI>(CustomCLI.ID, { ignoreState: true });
+    const componentA = await connection.getComponent<CustomCLI>(CustomCLI.DEFAULT_ID, { ignoreState: true });
     expect(componentA).toBeDefined();
     expect(componentA?.getIdentification().version).toBe(1);
     expect(componentA?.getIdentification().userManaged).toBe(true);
@@ -24,33 +24,33 @@ describe('Component Tests', () => {
     const manager = connection.getComponentManager();
 
     try {
-      await manager.uninstallComponent(CustomCLI.ID);
+      await manager.uninstallComponent(CustomCLI.DEFAULT_ID);
     } catch (e) {
       console.log(e);
       console.log(`Component not installed, skipping uninstall.`);
     }
 
-    const requiredCheckA = await manager.getRemoteState(CustomCLI.ID);
+    const requiredCheckA = await manager.getRemoteState(CustomCLI.DEFAULT_ID);
     expect(requiredCheckA).toBeDefined();
     expect(requiredCheckA?.status).toBe(`NotInstalled`);
 
     const allComponents = manager.getComponentStates();
     expect(allComponents.length > 1).toBeTruthy();
-    const state = allComponents.some(c => c.id.name === CustomCLI.ID && c.state.status === `NotInstalled`);
+    const state = allComponents.some(c => c.id.name === CustomCLI.DEFAULT_ID && c.state.status === `NotInstalled`);
     expect(state).toBeTruthy();
 
-    const version1 = await connection.getComponent<CustomCLI>(CustomCLI.ID);
+    const version1 = await connection.getComponent<CustomCLI>(CustomCLI.DEFAULT_ID);
     expect(version1).toBeUndefined();
 
-    const resultA = await manager.installComponent(CustomCLI.ID);
+    const resultA = await manager.installComponent(CustomCLI.DEFAULT_ID);
     expect(resultA.state.status).toBe(`Installed`);
 
-    const requiredCheckB = await manager.getRemoteState(CustomCLI.ID);
+    const requiredCheckB = await manager.getRemoteState(CustomCLI.DEFAULT_ID);
     expect(requiredCheckB).toBeTruthy();
     expect(requiredCheckB?.status).toBe(`Installed`);
 
     try {
-      await manager.installComponent(CustomCLI.ID);
+      await manager.installComponent(CustomCLI.DEFAULT_ID);
       expect.fail(`Should not be able to install the same component twice.`);
     } catch (e) {
       expect(e).toBeInstanceOf(Error);
@@ -58,12 +58,11 @@ describe('Component Tests', () => {
 
     // Let's check we can disable it.
 
-    const requiredCheckC = await manager.getRemoteState(CustomCLI.ID);
+    const requiredCheckC = await manager.getRemoteState(CustomCLI.DEFAULT_ID);
     expect(requiredCheckC).toBeTruthy();
     expect(requiredCheckC?.status).toBe(`Installed`);
 
-    manager.disable(CustomCLI.ID);
-    const requiredCheckD = await manager.getRemoteState(CustomCLI.ID);
+    const requiredCheckD = await manager.getRemoteState(`toBeDeleted`);
     expect(requiredCheckD).toBeUndefined();
   });
 });


### PR DESCRIPTION
### Changes

This PR is a re-work of https://github.com/codefori/vscode-ibmi/pull/3195. The previous implementation did not actually prevent the component from being installed in the first place as the `ConnectionManager` is tied to the connection. By the time we connect and disable, the component may already be installed. This PR changes this logic to use the `ComponentRegistry` to track the set of disabled components instead as this can be done without any connection.

Some associated changes in the other extensions:
- https://github.com/codefori/vscode-db2i/pull/537
- https://github.com/IBM/vscode-clle/pull/70

### How to test this PR
1. Run the test cases

### Checklist
* [x] have tested my change
