### PR TITLE
Fixed CustomUI Treeview implementation

### DIFF
--- a/src/editors/actionEditor.ts
+++ b/src/editors/actionEditor.ts
@@ -146,15 +146,15 @@ export function editAction(targetAction: Action, doAfterSave?: () => Thenable<vo
 
 async function save(targetAction: Action, actionData: ActionData, workspace?: vscode.WorkspaceFolder) {
   const oldType = targetAction.type;
-  const postDownload = actionData.postDownload.split(',').map(path => path.trim()).filter(Boolean);
-  const extensions = actionData.extensions.split(`,`).map(item => item.trim().toUpperCase()).filter(Boolean);
+  const postDownload = actionData.postDownload?.split(',').map(path => path.trim()).filter(Boolean);
+  const extensions = actionData.extensions?.split(`,`).map(item => item.trim().toUpperCase()).filter(Boolean);
   Object.assign(targetAction, actionData,
     //Fields that needs to be tranformed before saving
     {
       command: actionData.command.replace(new RegExp(`\\\r`, `g`), ``), // We don't want \r (Windows line endings)
-      extensions: extensions.length ? extensions : undefined,
+      extensions: extensions?.length ? extensions : undefined,
       outputToFile: actionData.outputToFile || undefined,
-      postDownload: postDownload.length ? postDownload : undefined
+      postDownload: postDownload?.length ? postDownload : undefined
     });
   const typeChanged = (oldType !== targetAction.type);
   if (typeChanged && (await ActionTools.getActions(workspace)).some(a => a.name === targetAction.name && a.type === targetAction.type)) {

--- a/src/webviews/CustomUI.ts
+++ b/src/webviews/CustomUI.ts
@@ -142,9 +142,6 @@ export class Section {
   addBrowser(id: string, items: TreeListItem[]) {
     const browser = new Field('browser', id, '');
     browser.treeList = items;
-    if (browser.treeList[0]) {
-      browser.treeList[0].selected = true;
-    }
     browser.treeLeafAction = 'browse';
     this.addField(browser);
     return this;
@@ -366,12 +363,9 @@ export class CustomHTML extends Section {
               var currentTree;
               ${trees.map(tree => /* javascript */`
                 currentTree = document.getElementById('${tree.id}');
-                currentTree.data = ${JSON.stringify(tree.treeList)};
                 currentTree.addEventListener('vsc-tree-select', (event) => {
-                  console.log(JSON.stringify(event.detail));
-                  if (event.detail.itemType === 'leaf') {
-                    treeItemClick('${tree.id}', '${tree.treeLeafAction}', event.detail.value);
-                  }
+                  const treeItem = event.detail[0];
+                  treeItemClick('${tree.id}', '${tree.treeLeafAction}', treeItem.dataset.value);
                 });`
       )}
             });
@@ -465,31 +459,32 @@ export class CustomUI extends CustomHTML {
   protected getSpecificScript() {
     return /* javascript */ `
       const theForm = document.querySelector('#laforma');
+      if(theForm) { //no form when fullpage is true
+        const doDone = (event, button) => {
+          console.log('submit now!!', button || 'enter pressed')
+          event?.preventDefault();
+          const isValid = (!button || button.requiresValidation) ? validateInputs() : true;
+          if (isValid) {
+            const data = { buttons: button?.id };
+            new FormData(theForm).entries().forEach(([key, value]) => data[key] = value);
 
-      const doDone = (event, button) => {
-        console.log('submit now!!', button || 'enter pressed')
-        event?.preventDefault();
-        const isValid = (!button || button.requiresValidation) ? validateInputs() : true;
-        if (isValid) {
-          const data = { buttons: button?.id };
-          new FormData(theForm).entries().forEach(([key, value]) => data[key] = value);
+            // Convert checkboxes value to actual boolean
+            checkboxes.forEach(checkbox => data[checkbox] = (data[checkbox] === 'on'));
 
-          // Convert checkboxes value to actual boolean
-          checkboxes.forEach(checkbox => data[checkbox] = (data[checkbox] === 'on'));
+            vscode.postMessage({ type: 'submit', data });
+          }
+        };
 
-          vscode.postMessage({ type: 'submit', data });
+        //Pressing enter will submit the form
+        theForm.addEventListener("submit", doDone);
+
+        // Now many buttons can be pressed to submit
+        for (const fieldData of groupButtons) {
+          const button = document.getElementById(fieldData.id);
+
+          button.onclick = () => doDone(event, fieldData);
+          button.onKeyDown = () => doDone(event, fieldData);
         }
-      };
-
-      //Pressing enter will submit the form
-      theForm.addEventListener("submit", doDone);
-
-      // Now many buttons can be pressed to submit
-      for (const fieldData of groupButtons) {
-        const button = document.getElementById(fieldData.id);
-
-        button.onclick = () => doDone(event, fieldData);
-        button.onKeyDown = () => doDone(event, fieldData);
       }
     `;
   }
@@ -508,7 +503,7 @@ export interface TreeListItem {
   subItems?: TreeListItem[];
   open?: boolean;
   selected?: boolean;
-  focused?: boolean;
+  active?: boolean;
   icons?: TreeListItemIcon;
   value?: string;
   path?: number[];
@@ -657,7 +652,7 @@ export class Field {
       case `browser`:
         return /* html */`
         <vscode-split-layout initial-handle-position="20%">
-          <div slot="start"><vscode-tree id="${this.id}"></vscode-tree></div>
+          <div slot="start"><vscode-tree id="${this.id}">${this.treeList?.map(t => this.renderTreeItem(t)).join("")}</vscode-tree></div>
           <div slot="end"><div id="browse_${this.id}">${this.treeList?.at(0)?.value}</div></div>
       </vscode-split-layout>`;
     }
@@ -669,5 +664,20 @@ export class Field {
 
   private renderDescription() {
     return this.description ? /* html */ `<vscode-form-helper>${this.description}</vscode-form-helper>` : ``;
+  }
+
+  private renderTreeItem(treeItem: TreeListItem) {
+    return /* html */ `<vscode-tree-item ${treeItem.active ? "active " : " "}${treeItem.open ? "open " : " "}${treeItem.selected ? "selected " : " "}${treeItem.value ? `data-value="${treeItem.value}"` : ""}>
+      ${treeItem.icons?.branch ? this.renderIcon("icon-branch", treeItem.icons?.branch) : ""}
+      ${treeItem.icons?.open ? this.renderIcon("icon-branch-opened", treeItem.icons?.open) : ""}
+      ${treeItem.icons?.leaf ? this.renderIcon("icon-leaf", treeItem.icons?.leaf) : ""}      
+      ${treeItem.label}
+    </vscode-tree-item>`;
+  }
+
+  private renderIcon(slot: string, name: string) {
+    return name.startsWith('/') ?
+      /* html */ `<vscode-icon name="${name}" slot="${slot}"></vscode-icon>` :
+      /* html */ `<img src="${name}" slot="${slot}" />`;
   }
 }


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
CustomUI's Treeview implementation is broken since we switched to VS Code element v2.
As a result, it's no longer possible to browse the output when running an action on multiple items.

This PR fixes the implementation and make treeviews working again.
It also fixes a small issue when saving an action that has some undefined fields.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Run an action on multiple items (ctrl/shift+click on items in browsers)
2. Click on `Open output(s)` in the notification when the action is done
3. The left treeview in the output must show up correctly, listing every item the action was run on
4. Clicking on a treeview item must display the output for that item

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change