### PR TITLE
Fix: Replaced sha256sum with openssl  for getting ifs file's hash

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -39,6 +39,10 @@ const remoteApps = [ // All names MUST also be defined as key in 'remoteFeatures
     names: [`setccsid`, `iconv`, `attr`, `tar`, `ls`, `uname`]
   },
   {
+    path: `/QOpenSys/usr/bin/`,
+    names: [`openssl`]
+  },
+  {
     path: `/QOpenSys/pkgs/bin/`,
     names: [`git`, `grep`, `tn5250`, `pfgrep`, `md5sum`, 'sha256sum', `bash`, `chsh`, `stat`, `sort`, `tar`, `ls`, `find`]
   },
@@ -230,6 +234,7 @@ export default class IBMi {
       setccsid: undefined,
       md5sum: undefined,
       sha256sum: undefined,
+      openssl: undefined,
       bash: undefined,
       chsh: undefined,
       stat: undefined,

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -1188,24 +1188,14 @@ export default class IBMiContent {
 
   async getSHA256FileHash(remoteFile: string) {
 
-    //We use OPENSSL that is already build in inside os
-    /*if (this.ibmi.remoteFeatures.sha256sum) {
-      const sha256Sum = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.sha256sum} ${remoteFile}` });
-      if (sha256Sum.code === 0) {
-        return sha256Sum.stdout.split(' ')[0];
-      }
-      else {
-        throw new Error(`Call to sha256sum failed: ${sha256Sum.stderr || sha256Sum.stdout}`);
-      }
-    }*/
-   
+    //We use OPENSSL that is already build in inside os   
     if (this.ibmi.remoteFeatures.openssl) {
-      const sha256Sum = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.openssl} dgst -sha256 ${remoteFile} ` });
-      if (sha256Sum.code === 0) {
-        return sha256Sum.stdout.split(' ')[1];
+      const objhash = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.openssl} dgst -sha256 ${remoteFile} ` });
+      if (objhash.code === 0) {
+        return objhash.stdout.split(' ').pop();
       }
       else {
-        throw new Error(`Call to openssl failed: ${sha256Sum.stderr || sha256Sum.stdout}`);
+        throw new Error(`Call to openssl failed: ${objhash.stderr || objhash.stdout}`);
       }
     }
   }

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -1187,13 +1187,25 @@ export default class IBMiContent {
   }
 
   async getSHA256FileHash(remoteFile: string) {
-    if (this.ibmi.remoteFeatures.sha256sum) {
+
+    //We use OPENSSL that is already build in inside os
+    /*if (this.ibmi.remoteFeatures.sha256sum) {
       const sha256Sum = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.sha256sum} ${remoteFile}` });
       if (sha256Sum.code === 0) {
         return sha256Sum.stdout.split(' ')[0];
       }
       else {
         throw new Error(`Call to sha256sum failed: ${sha256Sum.stderr || sha256Sum.stdout}`);
+      }
+    }*/
+   
+    if (this.ibmi.remoteFeatures.openssl) {
+      const sha256Sum = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.openssl} dgst -sha256 ${remoteFile} ` });
+      if (sha256Sum.code === 0) {
+        return sha256Sum.stdout.split(' ')[1];
+      }
+      else {
+        throw new Error(`Call to openssl failed: ${sha256Sum.stderr || sha256Sum.stdout}`);
       }
     }
   }


### PR DESCRIPTION
### Changes
This patch replaces the use of sha256sum (a package that needs to be installed) with OpenSSL (which is already installed on the systems) for calculating the hash of ifs files

### How to test this PR


### Checklist
<!-- Put an `x` in the relevant boxes -->
* [X] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [X] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)

closes #3196 
