### PR TITLE
Fix octal permission check and temp directory handling

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -211,7 +211,7 @@ export default class IBMi {
 
   getConfig() {
     if (this.connected && this.config) {
-      return this.config!;
+      return this.config;
     } else {
       throw new Error(`Not connected to IBM i.`);
     }
@@ -219,6 +219,11 @@ export default class IBMi {
 
   setConfig(newConfig: ConnectionConfig) {
     this.config = newConfig;
+  }
+
+  getTempDirectory() {
+    const config = this.getConfig();
+    return Tools.ensureFullPath(config.tempDir, config.homeDirectory);
   }
 
   constructor() {
@@ -660,7 +665,7 @@ export default class IBMi {
           })
 
         this.sendCommand({
-          command: `rm -rf ${path.posix.join(this.getConfig().tempDir, `vscodetemp*`)}`
+          command: `rm -rf ${path.posix.join(this.getTempDirectory(), `vscodetemp*`)}`
         })
           .then(result => {
             // All good!
@@ -668,7 +673,7 @@ export default class IBMi {
           .catch(e => {
             // CPF2125: No objects deleted.
             // @ts-ignore We know the config exists.
-            callbacks.message(`error`, `Temporary data not cleared from ${this.getConfig().tempDir}.`);
+            callbacks.message(`error`, `Temporary data not cleared from ${this.getTempDirectory()}.`);
           });
       }
 
@@ -1110,32 +1115,25 @@ export default class IBMi {
   }
 
   private async checkOrCreateTempDirectory() {
-    let tempDirSet: boolean = false;
-
-    if (!this.config) {
-      return false;
-    }
-
+    const tempDir = this.getTempDirectory();
     let result = await this.sendCommand({
-      command: `[ -d "${this.getConfig().tempDir}" ]`
+      command: `[ -d "${tempDir}" ]`
     });
 
     if (result.code === 0) {
       // Directory exists
-      tempDirSet = true;
+      return true;
     } else {
       // Directory does not exist, try to create it
-      let result = await this.sendCommand({
-        command: `mkdir -p ${this.getConfig().tempDir}`
+      result = await this.sendCommand({
+        command: `mkdir -p ${tempDir}`
       });
       if (result.code === 0) {
         // Directory created
-        tempDirSet = true;
-      } else {
-        // Directory not created
+        return true;
       }
     }
-    return tempDirSet;
+    return false;
   }
 
   /**
@@ -1270,7 +1268,7 @@ export default class IBMi {
       return this.tempRemoteFiles[key];
     } else
       if (this.getConfig()) {
-        let value = path.posix.join(this.getConfig().tempDir, `vscodetemp-${Tools.makeid()}`);
+        let value = path.posix.join(this.getTempDirectory(), `vscodetemp-${Tools.makeid()}`);
         // console.log(`Using new temp: ${value}`);
         this.tempRemoteFiles[key] = value;
         return value;
@@ -1381,7 +1379,7 @@ export default class IBMi {
    * @param process the process that will run on the empty directory
    */
   async withTempDirectory<T>(process: (directory: string) => Promise<T>) {
-    const tempDirectory = Tools.ensureFullPath(`${this.getConfig()?.tempDir || '~/.vscode/tmp'}/code4itemp${Tools.makeid(20)}`, this.config?.homeDirectory);
+    const tempDirectory = path.posix.join(this.getTempDirectory(), `/code4itemp${Tools.makeid(20)}`);
     const prepareDirectory = await this.sendCommand({ command: `rm -rf ${tempDirectory} && mkdir -p ${tempDirectory}` });
     if (prepareDirectory.code === 0) {
       try {

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -16,7 +16,7 @@ import { ConnectionManager } from './configuration/config/ConnectionManager';
 import { ConnectionConfig, RemoteConfigFile } from './configuration/config/types';
 import { ConfigFile } from './configuration/serverFile';
 import { CachedServerSettings, CodeForIStorage } from './configuration/storage/CodeForIStorage';
-import { AspInfo, CommandData, CommandResult, ConnectionData, EditorPath, IBMiMember, RemoteCommand, QsysPath, CacheItem } from './types';
+import { AspInfo, CacheItem, CommandData, CommandResult, ConnectionData, EditorPath, IBMiMember, QsysPath, RemoteCommand } from './types';
 
 export interface MemberParts extends IBMiMember {
   basename: string
@@ -427,10 +427,14 @@ export default class IBMi {
         });
 
         // Get home directory permissions (stat -c '%a' returns octal permissions)
-        const homePermResult = await this.sendCommand({
-          command: `stat -c '%a' ${defaultHomeDir} 2>/dev/null || echo "error"`
-        });
-        const homePerms = homePermResult.stdout.trim();
+        const getPermissions = async (path: string) => {
+          let permissions = (await this.sendCommand({
+            command: `stat -c '%a' ${path} 2>/dev/null || echo "error"`
+          })).stdout.trim();
+          return permissions.length > 3 ? permissions.substring(1, 4) : permissions;
+        };
+
+        const homePerms = await getPermissions(defaultHomeDir);
 
         // Check if .vscode directory exists and get its permissions
         const vscodeDir = `${defaultHomeDir}/.vscode`;
@@ -438,14 +442,7 @@ export default class IBMi {
           command: `test -d ${vscodeDir} && echo "exists" || echo "notexists"`
         });
         const vscodeExists = vscodeExistsResult.stdout.trim() === 'exists';
-
-        let vscodePerms = '';
-        if (vscodeExists) {
-          const vscodePermResult = await this.sendCommand({
-            command: `stat -c '%a' ${vscodeDir} 2>/dev/null || echo "error"`
-          });
-          vscodePerms = vscodePermResult.stdout.trim();
-        }
+        const vscodePerms = vscodeExists ? await getPermissions(vscodeDir) : '';
 
         // Check if permissions need updating
         const needsPermissionUpdate =
@@ -1287,7 +1284,7 @@ export default class IBMi {
   async clearTempRemote(key: string) {
     const tempFile = this.tempRemoteFiles[key];
     if (tempFile) {
-      await this.sendCommand({ command: `rm -rf ${tempFile}`, directory: `.` }).catch(() => {});
+      await this.sendCommand({ command: `rm -rf ${tempFile}`, directory: `.` }).catch(() => { });
       delete this.tempRemoteFiles[key];
     }
   }
@@ -1609,7 +1606,7 @@ export default class IBMi {
     let lookupPath: string | QsysPath;
 
     if (isQsysPath) {
-      
+
       const localPath: QsysPath = { ...path };
       localPath.asp = localPath.asp ? this.sysNameInAmerican(localPath.asp) : undefined;
       localPath.library = this.sysNameInAmerican(localPath.library);

--- a/src/filesystems/local/deployment.ts
+++ b/src/filesystems/local/deployment.ts
@@ -1,5 +1,5 @@
 
-import path from 'path';
+import path, { posix } from 'path';
 import { create as tarCreate, t as tarT } from 'tar';
 import tmp from 'tmp';
 import vscode, { Uri } from 'vscode';
@@ -269,7 +269,7 @@ export namespace Deployment {
   export async function sendCompressed(parameters: DeploymentParameters, files: vscode.Uri[], progress: vscode.Progress<{ message?: string }>) {
     const connection = getConnection();
     const localTarball = tmp.fileSync({ postfix: ".tar" });
-    const remoteTarball = Tools.ensureFullPath(path.posix.join(getConnection().getConfig().tempDir || '~/.vscode/tmp', `deploy_${Tools.makeid()}.tar`), getConnection().getConfig().homeDirectory);
+    const remoteTarball = posix.join(connection.getTempDirectory(), `deploy_${Tools.makeid()}.tar`);
     try {
       const toSend = files.map(file => path.relative(parameters.workspaceFolder.uri.fsPath, file.fsPath));
 

--- a/src/testing/action.ts
+++ b/src/testing/action.ts
@@ -48,7 +48,7 @@ export const ActionSuite: TestSuite = {
     const config = connection.getConfig();
 
     const workspaceFolder = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0] : undefined;
-    const tempDir = config.tempDir;
+    const tempDir = connection.getTempDirectory();
     assert.ok(workspaceFolder, "No workspace folder to work with");
     assert.ok(tempDir, "Cannot run deploy tools tests: no remote temp directory defined");
 

--- a/src/testing/deployTools.ts
+++ b/src/testing/deployTools.ts
@@ -92,7 +92,7 @@ export const DeployToolsSuite: TestSuite = {
         assert.ok(features?.md5sum, "md5sum is required to run deploy tools test suite");
 
         const workspaceFolder = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0] : undefined;
-        const tempDir = Tools.ensureFullPath(config.tempDir, config.homeDirectory);
+        const tempDir = connection.getTempDirectory();
         assert.ok(workspaceFolder, "No workspace folder to work with");
         assert.ok(tempDir, "Cannot run deploy tools tests: no remote temp directory defined");
 


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
This PR fixes two issues introduced by V3 temp directory policy and permission checking:

- Octal permissions returned by `stat` can return four digits if a sticky bit is set. If that's the case, only the three last digits will be kept
- The SFTP connection does not expand `~` in a path. The expansion of the temporary directory path has been put in `IBMi::getTempDirectory` to avoid repeating the logic. That method is used whenever the temporary directory path is required. Before that fix, trying to open a non UTF8 IFS file would crash if Auto convert was on:
<img width="562" height="67" alt="image" src="https://github.com/user-attachments/assets/ddec41a9-7262-48bc-ab2f-02b89ea11b3a" />
This would prevent the debugger status from being loaded or the settings page to be opened once connected.


### How to test this PR
#### Permissions check fix
1. Set the sticky bit on your home directory
2. Connect
3. The "change homedir permission" dialog should not show up once the permissions are fixed

#### Temp directory fix
1. Turn on Automatic Conversion in the connection settings
2. Open a non UTF8 IFS file
3. The file must open

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change