### PR TITLE
Fixed getObjectList crashing for *ALL object types filters

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -26,6 +26,8 @@ export type SortOptions = {
 export default class IBMiContent {
   constructor(readonly ibmi: IBMi) { }
 
+  private dummyDSPF = false;
+
   private get config() {
     return this.ibmi.getConfig();
   }
@@ -167,18 +169,18 @@ export default class IBMiContent {
     const path = Tools.qualifyPath(library, sourceFile, member, asp, true);
     const tempRmt = Tools.ensureFullPath(this.getTempRemote(path), this.config.homeDirectory);
     let retry = false;
-    
+
     // Fetch source file CCSID and determine if conversion is needed
     const sourceCcsid = await this.ibmi.getFileCcsid(path);
-    const {requiresConversion, targetCcsid} = Tools.determineCcsidConversion(sourceCcsid, this.config);
-  
+    const { requiresConversion, targetCcsid } = Tools.determineCcsidConversion(sourceCcsid, this.config);
+
     try {
       while (true) {
         let copyResult: CommandResult;
         if (this.ibmi.dangerousVariants && new RegExp(`[${this.ibmi.variantChars.local}]`).test(path)) {
           copyResult = { code: 0, stdout: '', stderr: '' };
           if (requiresConversion) {
-            await this.ibmi.runSQL(`@QSYS/RMVLNK OBJLNK('${tempRmt}')`).catch(_ => {}); // ignore error
+            await this.ibmi.runSQL(`@QSYS/RMVLNK OBJLNK('${tempRmt}')`).catch(_ => { }); // ignore error
             await this.ibmi.runSQL([
               `Drop table if exists QTEMP.QTEMPSRC`,
               `@QSYS/CPYF FROMFILE(${library}/${sourceFile}) TOFILE(QTEMP/QTEMPSRC) FROMMBR(${member}) TOMBR(TEMPMEMBER) MBROPT(*REPLACE) CRTFILE(*YES)`,
@@ -189,22 +191,22 @@ export default class IBMiContent {
               copyResult.stderr = String(e);
             });
           } else {
-          try {
-            await this.ibmi.runSQL([
-              `Drop table if exists QTEMP.QTEMPSRC`,
-              `@QSYS/CPYF FROMFILE(${library}/${sourceFile}) TOFILE(QTEMP/QTEMPSRC) FROMMBR(${member}) TOMBR(TEMPMEMBER) MBROPT(*REPLACE) CRTFILE(*YES)`,
-              `@QSYS/CPYTOSTMF FROMMBR('${Tools.qualifyPath("QTEMP", "QTEMPSRC", "TEMPMEMBER", undefined)}') TOSTMF('${tempRmt}') STMFOPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`]);
-          } catch (error: any) {
-            copyResult.code = -1;
-            copyResult.stderr = String(error);
-          }
+            try {
+              await this.ibmi.runSQL([
+                `Drop table if exists QTEMP.QTEMPSRC`,
+                `@QSYS/CPYF FROMFILE(${library}/${sourceFile}) TOFILE(QTEMP/QTEMPSRC) FROMMBR(${member}) TOMBR(TEMPMEMBER) MBROPT(*REPLACE) CRTFILE(*YES)`,
+                `@QSYS/CPYTOSTMF FROMMBR('${Tools.qualifyPath("QTEMP", "QTEMPSRC", "TEMPMEMBER", undefined)}') TOSTMF('${tempRmt}') STMFOPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`]);
+            } catch (error: any) {
+              copyResult.code = -1;
+              copyResult.stderr = String(error);
+            }
           }
         }
         else {
           if (requiresConversion) {
             copyResult = { code: 0, stdout: '', stderr: '' };
 
-            await this.ibmi.runSQL(`@QSYS/RMVLNK OBJLNK('${tempRmt}')`).catch(_ => {}); // ignore error
+            await this.ibmi.runSQL(`@QSYS/RMVLNK OBJLNK('${tempRmt}')`).catch(_ => { }); // ignore error
             try {
               await this.ibmi.runSQL([
                 `@QSYS/CPYTOSTMF FROMMBR('${path}') TOSTMF('${tempRmt}') STMFOPT(*REPLACE) STMFCCSID(${targetCcsid}) DBFCCSID(${this.config.sourceFileCCSID})`,
@@ -276,8 +278,8 @@ export default class IBMiContent {
       const path = Tools.qualifyPath(library, sourceFile, member, asp, true);
       // Fetch source file CCSID and determine if conversion is needed
       const sourceCcsid = await this.ibmi.getFileCcsid(path);
-      const {requiresConversion, targetCcsid} = Tools.determineCcsidConversion(sourceCcsid, this.config);
-      
+      const { requiresConversion, targetCcsid } = Tools.determineCcsidConversion(sourceCcsid, this.config);
+
       const tempRmt = Tools.ensureFullPath(this.getTempRemote(path), this.config.homeDirectory);
 
       try {
@@ -287,57 +289,57 @@ export default class IBMiContent {
         }
         await client.putFile(tmpobj, tempRmt);
 
-      let copyResult: CommandResult;
-      if (this.ibmi.dangerousVariants && new RegExp(`[${this.ibmi.variantChars.local}]`).test(path)) {
-        copyResult = { code: 0, stdout: '', stderr: '' };
-
-        if (requiresConversion) {
-          try {
-          await this.ibmi.runSQL([
-            `@QSYS/CPYF FROMFILE(${library}/${sourceFile}) TOFILE(QTEMP/QTEMPSRC) FROMMBR(${member}) TOMBR(TEMPMEMBER) MBROPT(*REPLACE) CRTFILE(*YES)`,
-            `@QSYS/CPY OBJ('${tempRmt}') TOOBJ('${tempRmt}') TOCCSID(${targetCcsid}) DTAFMT(*TEXT) REPLACE(*YES)`,
-            `@QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${Tools.qualifyPath("QTEMP", "QTEMPSRC", "TEMPMEMBER", undefined)}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
-            `@QSYS/CPYF FROMFILE(QTEMP/QTEMPSRC) FROMMBR(TEMPMEMBER) TOFILE(${library}/${sourceFile}) TOMBR(${member}) MBROPT(*REPLACE)`,
-            `@CHGATR OBJ('${tempRmt}') ATR(*CCSID) VALUE(1208)`
-            ].join("\n"));
-          } catch (e: any) {
-            copyResult.code = -1;
-            copyResult.stderr = String(e);
-          }
-        } else {
-        try {
-          await this.ibmi.runSQL([
-            `Drop table if exists QTEMP.QTEMPSRC`,
-            `@QSYS/CPYF FROMFILE(${library}/${sourceFile}) FROMMBR(${member}) TOFILE(QTEMP/QTEMPSRC) TOMBR(TEMPMEMBER) MBROPT(*REPLACE) CRTFILE(*YES)`,
-            `@QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${Tools.qualifyPath("QTEMP", "QTEMPSRC", "TEMPMEMBER", undefined)}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
-            `@QSYS/CPYF FROMFILE(QTEMP/QTEMPSRC) FROMMBR(TEMPMEMBER) TOFILE(${library}/${sourceFile}) TOMBR(${member}) MBROPT(*REPLACE)`
-          ]);
-        } catch (error: any) {
-          copyResult.code = -1;
-          copyResult.stderr = String(error);
-        }
-      }
-      }
-      else {
-         if (requiresConversion) {
+        let copyResult: CommandResult;
+        if (this.ibmi.dangerousVariants && new RegExp(`[${this.ibmi.variantChars.local}]`).test(path)) {
           copyResult = { code: 0, stdout: '', stderr: '' };
-          try {
-            await this.ibmi.runSQL([
-            `@QSYS/CPY OBJ('${tempRmt}') TOOBJ('${tempRmt}') TOCCSID(${targetCcsid}) DTAFMT(*TEXT) REPLACE(*YES)`,
-            `@QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${path}') MBROPT(*REPLACE) STMFCCSID(${targetCcsid}) DBFCCSID(${this.config.sourceFileCCSID})`,
-            `@QSYS/CHGATR OBJ('${tempRmt}') ATR(*CCSID) VALUE(1208)`
-            ]);
-          } catch (e: any) {
-            copyResult.code = -1;
-            copyResult.stderr = String(e);
+
+          if (requiresConversion) {
+            try {
+              await this.ibmi.runSQL([
+                `@QSYS/CPYF FROMFILE(${library}/${sourceFile}) TOFILE(QTEMP/QTEMPSRC) FROMMBR(${member}) TOMBR(TEMPMEMBER) MBROPT(*REPLACE) CRTFILE(*YES)`,
+                `@QSYS/CPY OBJ('${tempRmt}') TOOBJ('${tempRmt}') TOCCSID(${targetCcsid}) DTAFMT(*TEXT) REPLACE(*YES)`,
+                `@QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${Tools.qualifyPath("QTEMP", "QTEMPSRC", "TEMPMEMBER", undefined)}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
+                `@QSYS/CPYF FROMFILE(QTEMP/QTEMPSRC) FROMMBR(TEMPMEMBER) TOFILE(${library}/${sourceFile}) TOMBR(${member}) MBROPT(*REPLACE)`,
+                `@CHGATR OBJ('${tempRmt}') ATR(*CCSID) VALUE(1208)`
+              ].join("\n"));
+            } catch (e: any) {
+              copyResult.code = -1;
+              copyResult.stderr = String(e);
+            }
+          } else {
+            try {
+              await this.ibmi.runSQL([
+                `Drop table if exists QTEMP.QTEMPSRC`,
+                `@QSYS/CPYF FROMFILE(${library}/${sourceFile}) FROMMBR(${member}) TOFILE(QTEMP/QTEMPSRC) TOMBR(TEMPMEMBER) MBROPT(*REPLACE) CRTFILE(*YES)`,
+                `@QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${Tools.qualifyPath("QTEMP", "QTEMPSRC", "TEMPMEMBER", undefined)}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
+                `@QSYS/CPYF FROMFILE(QTEMP/QTEMPSRC) FROMMBR(TEMPMEMBER) TOFILE(${library}/${sourceFile}) TOMBR(${member}) MBROPT(*REPLACE)`
+              ]);
+            } catch (error: any) {
+              copyResult.code = -1;
+              copyResult.stderr = String(error);
+            }
           }
-        } else {
-        copyResult = await this.ibmi.runCommand({
-          command: `QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${path}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
-          noLibList: true
-        });
-      }
-      }
+        }
+        else {
+          if (requiresConversion) {
+            copyResult = { code: 0, stdout: '', stderr: '' };
+            try {
+              await this.ibmi.runSQL([
+                `@QSYS/CPY OBJ('${tempRmt}') TOOBJ('${tempRmt}') TOCCSID(${targetCcsid}) DTAFMT(*TEXT) REPLACE(*YES)`,
+                `@QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${path}') MBROPT(*REPLACE) STMFCCSID(${targetCcsid}) DBFCCSID(${this.config.sourceFileCCSID})`,
+                `@QSYS/CHGATR OBJ('${tempRmt}') ATR(*CCSID) VALUE(1208)`
+              ]);
+            } catch (e: any) {
+              copyResult.code = -1;
+              copyResult.stderr = String(e);
+            }
+          } else {
+            copyResult = await this.ibmi.runCommand({
+              command: `QSYS/CPYFRMSTMF FROMSTMF('${tempRmt}') TOMBR('${path}') MBROPT(*REPLACE) STMFCCSID(1208) DBFCCSID(${this.config.sourceFileCCSID})`,
+              noLibList: true
+            });
+          }
+        }
 
         if (copyResult.code === 0) {
           const messages = Tools.parseMessages(copyResult.stderr);
@@ -567,7 +569,6 @@ export default class IBMiContent {
       }
     }
 
-    const usLocalLibrary = this.ibmi.sysNameInAmerican(localLibrary);
     const singleEntry = filters.filterType !== 'regex' ? singleGenericName(filters.object) : undefined;
     const nameFilter = parseFilter(filters.object, filters.filterType);
     const objectFilter = filters.object && (nameFilter.noFilter || singleEntry) && filters.object !== `*` ? this.ibmi.upperCaseName(filters.object) : undefined;
@@ -582,9 +583,22 @@ export default class IBMiContent {
 
     let createOBJLIST: string[];
 
+    if (sourceFilesOnly || withSourceFiles) {
+      if (this.dummyDSPF) {
+        //Clear the PFS table
+        await this.ibmi.runSQL(`Delete from QTEMP.PFS`);
+      }
+      else {
+        //Create a dummy PFS table
+        await this.ibmi.runSQL('@DSPFD FILE(QSYSINC/H) TYPE(*ATR) OUTPUT(*OUTFILE) FILEATR(*PF) OUTFILE(QTEMP/PFS)');
+        this.dummyDSPF = true;
+      }
+      //Fill the PFs list - if the command crashes it won't break the queries below
+      await this.ibmi.runCommand({ command: `QSYS/DSPFD FILE(${localLibrary}/*ALL) TYPE(*ATR) OUTPUT(*OUTFILE) FILEATR(*PF) OUTFILE(QTEMP/PFS)` });
+    }
+
     if (sourceFilesOnly) {
       createOBJLIST = [
-        `@QSYS/DSPFD FILE(${localLibrary}/*ALL) TYPE(*ATR) OUTPUT(*OUTFILE) FILEATR(*PF) OUTFILE(QTEMP/PFS)`,
         /* sql */
         `select
             trim(PHFILE) NAME,
@@ -616,7 +630,6 @@ export default class IBMiContent {
     }
     else {
       createOBJLIST = [
-        `@QSYS/DSPFD FILE(${localLibrary}/*ALL) TYPE(*ATR) OUTPUT(*OUTFILE) FILEATR(*PF) OUTFILE(QTEMP/PFS)`,
         /* sql */
         `with SRCFILES as (
           select

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -585,12 +585,12 @@ export default class IBMiContent {
 
     if (sourceFilesOnly || withSourceFiles) {
       if (!this.dummyDSPF) {
-        //Create a dummy PFS table
-        await this.ibmi.runSQL('@DSPFD FILE(QSYSINC/H) TYPE(*ATR) OUTPUT(*OUTFILE) FILEATR(*PF) OUTFILE(QTEMP/PFS)');
+        //Create an empty PFS table
+        await this.ibmi.runSQL('declare global temporary table SESSION.PFS like QSYS.QAFDPHY rcdfmt QWHFDPHY');
         this.dummyDSPF = true;
       }
       //Clear and fill the PFs list - if the command crashes it won't break the queries below
-      await this.ibmi.runSQL(`Delete from QTEMP.PFS`);
+      await this.ibmi.runSQL(`delete from SESSION.PFS`);
       await this.ibmi.runCommand({ command: `QSYS/DSPFD FILE(${localLibrary}/*ALL) TYPE(*ATR) OUTPUT(*OUTFILE) FILEATR(*PF) OUTFILE(QTEMP/PFS)` });
     }
 
@@ -604,7 +604,7 @@ export default class IBMiContent {
             PHMXRL SOURCE_LENGTH,
             1 as IS_SOURCE,
             '*FILE' as TYPE
-            from QTEMP.PFS
+            from SESSION.PFS
             where PHDTAT = 'S'
             ${sourceFileNameLike()}`
       ];
@@ -633,7 +633,7 @@ export default class IBMiContent {
             trim(PHFILE) NAME,
             1 as IS_SOURCE,
             PHMXRL as SOURCE_LENGTH
-          from QTEMP.PFS
+          from SESSION.PFS
           where PHDTAT = 'S'
         ),
          OBJD as (

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -584,16 +584,13 @@ export default class IBMiContent {
     let createOBJLIST: string[];
 
     if (sourceFilesOnly || withSourceFiles) {
-      if (this.dummyDSPF) {
-        //Clear the PFS table
-        await this.ibmi.runSQL(`Delete from QTEMP.PFS`);
-      }
-      else {
+      if (!this.dummyDSPF) {
         //Create a dummy PFS table
         await this.ibmi.runSQL('@DSPFD FILE(QSYSINC/H) TYPE(*ATR) OUTPUT(*OUTFILE) FILEATR(*PF) OUTFILE(QTEMP/PFS)');
         this.dummyDSPF = true;
       }
-      //Fill the PFs list - if the command crashes it won't break the queries below
+      //Clear and fill the PFs list - if the command crashes it won't break the queries below
+      await this.ibmi.runSQL(`Delete from QTEMP.PFS`);
       await this.ibmi.runCommand({ command: `QSYS/DSPFD FILE(${localLibrary}/*ALL) TYPE(*ATR) OUTPUT(*OUTFILE) FILEATR(*PF) OUTFILE(QTEMP/PFS)` });
     }
 


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Expanding a filter defined with object types `*ALL`crashes if the target library doesn't contain any PF object. The `DSPFD` command that is run along with the SQL queries crashes if there is no PF in the queried library.

This PR fixes that by:
- Creating a dummy output table for DSPFD (so it's always found)
- Clearing and filling that table when listing PFs is requested 

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Define a filter with object type *ALL on a library that contains no PF
2. Expand the filter
3. All the objects must show up


### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change