### PR TITLE
Use OVRDBF instead of aliases for reading/saving members when source date support is enabled

### DIFF
--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -4,9 +4,9 @@ import util from "util";
 import vscode from "vscode";
 import IBMi from "../../api/IBMi";
 import { Tools } from "../../api/Tools";
+import { CommandResult } from "../../api/types";
 import { instance } from "../../instantiate";
 import { getAliasName, SourceDateHandler } from "./sourceDateHandler";
-import { CommandResult } from "../../api/types";
 
 const tmpFile = util.promisify(tmp.file);
 const writeFileAsync = util.promisify(fs.writeFile);
@@ -26,75 +26,58 @@ export class ExtendedIBMiContent {
   async downloadMemberContentWithDates(uri: vscode.Uri) {
     const connection = instance.getConnection();
     if (connection) {
-      const config = connection.getConfig();
-      const tempLib = "QTEMP";
       const alias = getAliasName(uri);
-      const aliasPath = `${tempLib}.${alias}`;
       const { library, file, name } = connection.parserMemberPath(uri.path);
+      const overFile = await this.overDBFile(connection, library, file, name);
       try {
-        await connection.runSQL(`CREATE OR REPLACE ALIAS ${aliasPath} for "${library}"."${file}"("${name}")`);
-      } catch (e) {
-        console.log(e);
+        await this.readRecordLength(connection, alias, overFile);
+        const rows = await connection.runSQL(
+          `select case when locate('40',hex(srcdat)) > 0 then 0 else srcdat end as srcdat, srcseq, srcdta from ${overFile}`
+        ) as { SRCDAT: number, SRCDTA: string, SRCSEQ: number }[];
+
+        if (rows.length === 0) {
+          rows.push({
+            SRCDAT: 0,
+            SRCDTA: ``,
+            SRCSEQ: 0
+          });
+        }
+
+        const sourceDates = rows.map(row => String(row.SRCDAT).padStart(6, `0`));
+        const body = rows
+          .map(row => row.SRCDTA.includes(`\\\t`) ? row.SRCDTA.replaceAll(`\\\t`, `\t`) : row.SRCDTA)
+          .join(`\n`);
+        const sequences = rows.map(row => Number(row.SRCSEQ));
+
+        this.sourceDateHandler.baseDates.set(alias, sourceDates);
+        this.sourceDateHandler.baseSource.set(alias, body);
+        this.sourceDateHandler.baseSequences.set(alias, sequences);
+
+        return body;
       }
-
-      if (!this.sourceDateHandler.recordLengths.has(alias)) {
-        let recordLength = await this.getRecordLength(aliasPath, library, file);
-        this.sourceDateHandler.recordLengths.set(alias, recordLength);
+      finally {
+        await this.deleteOVRDBFile(connection, overFile);
       }
-
-      let rows = await connection.runSQL(
-        `select case when locate('40',hex(srcdat)) > 0 then 0 else srcdat end as srcdat, srcseq, srcdta from ${aliasPath}`
-      ) as { SRCDAT: number, SRCDTA: string, SRCSEQ: number }[];
-
-      if (rows.length === 0) {
-        rows.push({
-          SRCDAT: 0,
-          SRCDTA: ``,
-          SRCSEQ: 0
-        });
-      }
-
-      const sourceDates = rows.map(row => String(row.SRCDAT).padStart(6, `0`));
-      const body = rows
-        .map(row => row.SRCDTA.includes(`\\\t`) ? row.SRCDTA.replaceAll(`\\\t`, `\t`) : row.SRCDTA)
-        .join(`\n`);
-      const sequences = rows.map(row => Number(row.SRCSEQ));
-
-      this.sourceDateHandler.baseDates.set(alias, sourceDates);
-      this.sourceDateHandler.baseSource.set(alias, body);
-      this.sourceDateHandler.baseSequences.set(alias, sequences);
-
-      return body;
     }
   }
 
   /**
-   * Determine the member record length 
-   * @param {string} aliasPath member sql alias path e.g. ILEDITOR.QGPL_QRPGLESC_MYRPGPGM
-   * @param {string} lib
-   * @param {string} spf
+   * Determine the member record length
    */
-  private async getRecordLength(aliasPath: string, lib: string, spf: string): Promise<number> {
-    const connection = instance.getConnection();
-    let recordLength: number = DEFAULT_RECORD_LENGTH;
-
-    if (connection) {
-      const [result] = await connection.runSQL(`select length(SRCDTA) as LENGTH from ${aliasPath} limit 1`);
+  private async readRecordLength(connection: IBMi, alias: string, overFile: string): Promise<number> {
+    let recordLenth = this.sourceDateHandler.recordLengths.get(alias);
+    if (!recordLenth) {
+      const [result] = await connection.runSQL(`select length(SRCDTA) as LENGTH from ${overFile} limit 1`);
       if (result) {
-        recordLength = Number(result.LENGTH);
-      } else {
-        const [result] = await connection.runSQL([
-          `@QSYS/DSPFD FILE(${lib}/${spf}) TYPE(*ATR) OUTPUT(*OUTFILE) FILEATR(*PF) OUTFILE(QTEMP/PFS)`,
-          /* sql */
-          `select PHMXRL - 12 as LENGTH from QTEMP.PFS limit 1`
-        ]);
-        if (result) {
-          recordLength = Number(result.LENGTH);
-        }
+        recordLenth = Number(result.LENGTH);
       }
+      else {
+        recordLenth = DEFAULT_RECORD_LENGTH;
+      }
+      this.sourceDateHandler.recordLengths.set(alias, recordLenth);
     }
 
-    return recordLength;
+    return recordLenth;
   }
 
   /**
@@ -131,91 +114,101 @@ export class ExtendedIBMiContent {
       if (tempRmt) {
         const tmpobj = await tmpFile();
 
+        const overFile = await this.overDBFile(connection, library, file, name);
         try {
+          const sourceData = body.split(`\n`);
+          const recordLength = await this.readRecordLength(connection, alias, overFile);
 
-        const sourceData = body.split(`\n`);
-        const recordLength = this.sourceDateHandler.recordLengths.get(alias) || await this.getRecordLength(aliasPath, library, file);
+          const decimalSequence = sourceData.length >= 10000;
 
-        const decimalSequence = sourceData.length >= 10000;
+          let rows = [],
+            sequence = 0;
+          for (let i = 0; i < sourceData.length; i++) {
+            sequence = decimalSequence ? ((i + 1) / 100) : i + 1;
+            sourceData[i] = sourceData[i].trimEnd();
+            if (sourceData[i].length > recordLength) {
+              sourceData[i] = sourceData[i].substring(0, recordLength);
+            }
 
-        let rows = [],
-          sequence = 0;
-        for (let i = 0; i < sourceData.length; i++) {
-          sequence = decimalSequence ? ((i + 1) / 100) : i + 1;
-          sourceData[i] = sourceData[i].trimEnd();
-          if (sourceData[i].length > recordLength) {
-            sourceData[i] = sourceData[i].substring(0, recordLength);
+            rows.push(
+              `(${sequence}, ${sourceDates[i] ? sourceDates[i].padEnd(6, `0`) : `0`}, '${escapeString(sourceData[i])}')`,
+            );
           }
 
-          rows.push(
-            `(${sequence}, ${sourceDates[i] ? sourceDates[i].padEnd(6, `0`) : `0`}, '${escapeString(sourceData[i])}')`,
-          );
+          //We assume the alias still exists....
+          const tempTable = `QTEMP.NEWMEMBER`;
+          const query: string[] = [
+            `CREATE OR REPLACE TABLE ${tempTable} LIKE ${library}.${file} ON REPLACE DELETE ROWS;`,
+          ];
 
-        }
+          // Row length is the length of the SQL string used to insert each row
+          const rowLength = recordLength + 55;
+          // 450000 is just below the maxiumu length for each insert.
+          const perInsert = Math.floor(400000 / rowLength);
 
-        //We assume the alias still exists....
-        const tempTable = `QTEMP.NEWMEMBER`;
-        const query: string[] = [
-          `CREATE OR REPLACE TABLE ${tempTable} LIKE "${library}"."${file}" ON REPLACE DELETE ROWS;`,
-        ];
-
-        // Row length is the length of the SQL string used to insert each row
-        const rowLength = recordLength + 55;
-        // 450000 is just below the maxiumu length for each insert.
-        const perInsert = Math.floor(400000 / rowLength);
-
-        const rowGroups = sliceUp(rows, perInsert);
-        rowGroups.forEach(rowGroup => {
-          query.push(`insert into ${tempTable} values ${rowGroup.join(`,`)};`);
-        });
-
-        query.push(
-          `CALL QSYS2.QCMDEXC('CLRPFM FILE(${library}/${file}) MBR(${name})');`,
-          `insert into ${aliasPath} (select * from ${tempTable});`
-        )
-
-        await writeFileAsync(tmpobj, query.join(`\n`), `utf8`);
-        await client.putFile(tmpobj, tempRmt);
-
-        if (setccsid) {
-          await connection.sendCommand({ command: `${setccsid} 1208 ${tempRmt}` });
-        }
-
-        // Fetch source file CCSID and determine if conversion is needed
-        const memberPath = { library, name: file, member: name };
-        const sourceCcsid = await connection.getFileCcsid(memberPath);
-        const {requiresConversion, targetCcsid} = Tools.determineCcsidConversion(sourceCcsid, config);
-
-        let insertResult: CommandResult = { code: 0, stdout: '', stderr: '' };
-        if (requiresConversion) {
-          await connection.runSQL([
-            `@QSYS/CPY OBJ('${tempRmt}') TOOBJ('${tempRmt}') TOCCSID(${targetCcsid}) DTAFMT(*TEXT) REPLACE(*YES)`
-          ].join("\n")).catch(e => {
-            insertResult.code = -1;
-            insertResult.stderr = String(e);
+          const rowGroups = sliceUp(rows, perInsert);
+          rowGroups.forEach(rowGroup => {
+            query.push(`insert into ${tempTable} values ${rowGroup.join(`,`)};`);
           });
-        }
 
-        if (insertResult.code === 0) {
-          insertResult = await connection.runCommand({
-            command: `QSYS/RUNSQLSTM SRCSTMF('${tempRmt}') COMMIT(*NONE) NAMING(*SQL)`,
-            noLibList: true
-          });
-        }
+          query.push(
+            `CALL QSYS2.QCMDEXC('CLRPFM FILE(${library}/${file}) MBR(${name})');`,
+            `insert into ${overFile} (select * from ${tempTable});`
+          )
 
-        if (insertResult.code !== 0) {
-          throw new Error(`Failed to save member: ` + insertResult.stderr);
-        }
+          await writeFileAsync(tmpobj, query.join(`\n`), `utf8`);
+          await client.putFile(tmpobj, tempRmt);
 
-        this.sourceDateHandler.baseSource.set(alias, body);
-        this.sourceDateHandler.baseDates.set(alias, sourceDates);
-        this.sourceDateHandler.baseSequences.delete(alias);
+          if (setccsid) {
+            await connection.sendCommand({ command: `${setccsid} 1208 ${tempRmt}` });
+          }
+
+          // Fetch source file CCSID and determine if conversion is needed
+          const memberPath = { library, name: file, member: name };
+          const sourceCcsid = await connection.getFileCcsid(memberPath);
+          const { requiresConversion, targetCcsid } = Tools.determineCcsidConversion(sourceCcsid, config);
+
+          let insertResult: CommandResult = { code: 0, stdout: '', stderr: '' };
+          if (requiresConversion) {
+            await connection.runSQL([
+              `@QSYS/CPY OBJ('${tempRmt}') TOOBJ('${tempRmt}') TOCCSID(${targetCcsid}) DTAFMT(*TEXT) REPLACE(*YES)`
+            ].join("\n")).catch(e => {
+              insertResult.code = -1;
+              insertResult.stderr = String(e);
+            });
+          }
+
+          if (insertResult.code === 0) {
+            insertResult = await connection.runCommand({
+              command: `QSYS/RUNSQLSTM SRCSTMF('${tempRmt}') COMMIT(*NONE) NAMING(*SQL)`,
+              noLibList: true
+            });
+          }
+
+          if (insertResult.code !== 0) {
+            throw new Error(`Failed to save member: ` + insertResult.stderr);
+          }
+
+          this.sourceDateHandler.baseSource.set(alias, body);
+          this.sourceDateHandler.baseDates.set(alias, sourceDates);
+          this.sourceDateHandler.baseSequences.delete(alias);
         } finally {
+          await this.deleteOVRDBFile(connection, overFile);
           // Clean up temporary file
           await connection.clearTempRemote(tempKey);
         }
       }
     }
+  }
+
+  private async overDBFile(connection: IBMi, library: string, file: string, member: string) {
+    const overFile = Tools.makeid();
+    await connection.runSQL(`@QSYS/OVRDBF FILE(${overFile}) TOFILE(${library}/${file}) MBR(${member}) OVRSCOPE(*JOB)`);
+    return overFile;
+  }
+
+  private async deleteOVRDBFile(connection: IBMi, overFile: string) {
+    await connection.runSQL(`@QSYS/DLTOVR FILE(${overFile}) LVL(*JOB)`);
   }
 }
 

--- a/src/filesystems/qsys/sourceDateHandler.ts
+++ b/src/filesystems/qsys/sourceDateHandler.ts
@@ -1,4 +1,3 @@
-import Crypto from "crypto";
 import vscode from "vscode";
 import { DiffComputer } from "vscode-diff";
 import { instance } from "../../instantiate";
@@ -458,7 +457,7 @@ export class SourceDateHandler {
 }
 
 export function getAliasName(uri: vscode.Uri) {
-  return `TEMP_${Crypto.createHash('sha1').update(uri.toString()).digest('hex')}`.toUpperCase();
+  return uri.toString();
 }
 
 /**


### PR DESCRIPTION
### Changes
Fixes #3223 

When source date support is enabled, an alias on the member being edited is created into QTEMP. When the member is saved, the system assumes the alias exists. This is not the case when a user reconnects after leaving a member opened. This can cause the member to be cleared when the user tries to save after reconnecting, as described in #3223 (because `CLRPFM` is executed and then`insert into` crashes because there is no alias).

This PR fixes this by replacing the aliases with calls to `OVRDBF`/`DLTOVR` when reading and saving a member with source date support enabled.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Open a source member
2. Leave it open
3. Reload VS Code window / kill VPN / turn off Wifi / pull ethernet cable
4. Wait for the reconnect dialog and reconnect
5. Save the member left open
6. There must be no error

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change