### PR TITLE
Replaced stat with ls -ld parsing to check permissions

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -438,10 +438,12 @@ export default class IBMi {
 
         // Get home directory permissions (stat -c '%a' returns octal permissions)
         const getPermissions = async (path: string) => {
-          let permissions = (await this.sendCommand({
-            command: `stat -c '%a' ${path} 2>/dev/null || echo "error"`
-          })).stdout.trim();
-          return permissions.length > 3 ? permissions.substring(1, 4) : permissions;
+          const permissionString = (await this.sendCommand({ command: `ls -ld "${path}"` })).stdout.substring(1, 10);
+          const permissions : number[] = [];
+          for (let i = 0; i < 9; i += 3) {
+            permissions.push((permissionString[i] == "r" ? 4 : 0) + (permissionString[i+1] == "w" ? 2 : 0) + (["x", "s"].includes(permissionString[i+2]) ? 1 : 0));
+          }
+          return permissions.map(String).join("");
         };
 
         const homePerms = await getPermissions(defaultHomeDir);


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Since `stat` is part of the `core-utils` package which is not installed by default on eveyr LPAR, the permission check performed when connecting will fail every time.

This PR replaces the use of `stat` with a call to `ls -ld` and the parsing of the output to the octal form.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Connect
2. The permission dialog must show up if the permissions are not the expected ones
3. Reply Yes in that case
4. Disconnect
5. Reconnect
6. The dialog must not show up again

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change