### PR TITLE
Failsafe: fall back to using a default home dir if the user's is '/'

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -384,14 +384,14 @@ export default class IBMi {
       //   - stdout contains the name of the home directory (even if it does not exist)
       //   - The 'cd' command causes an error if the home directory does not exist or otherwise can't be cd'ed into
       //   - The 'test' command causes an error if the home directory is not writable (one can cd into a non-writable directory)
-      let isHomeUsable = (0 == echoHomeResult.code);
-      if (isHomeUsable) {
-        defaultHomeDir = echoHomeResult.stdout.trim();
+      const isHomeUsable = (0 == echoHomeResult.code);
+      const homeOutput = echoHomeResult.stdout.trim();
+      if (isHomeUsable && homeOutput && homeOutput !== "/") {
+        defaultHomeDir = homeOutput;
       } else {
         // Let's try to provide more valuable information to the user about why their home directory
         // is bad and maybe even provide the opportunity to create the home directory
-
-        let actualHomeDir = echoHomeResult.stdout.trim();
+        let actualHomeDir = homeOutput;
 
         // we _could_ just assume the home directory doesn't exist but maybe there's something more going on, namely mucked-up permissions
         let doesHomeExist = (0 === (await this.sendCommand({ command: `test -e ${actualHomeDir}` })).code);
@@ -421,6 +421,14 @@ export default class IBMi {
           if (homedirCreated) {
             defaultHomeDir = actualHomeDir;
           }
+        }
+      }
+
+      if(!defaultHomeDir || defaultHomeDir === "/"){
+        defaultHomeDir = `/home/${connectionObject.username}`;
+        //We'll warn only once
+        if(!this.config.homeDirectory || this.config.homeDirectory === "/"){
+          callbacks.message(`warning`, `Your home directory is set to '/' on your user profile. Code for IBM i will use ${defaultHomeDir} instead. Please contact a system administrator to fix this.`);
         }
       }
 

--- a/src/api/components/manager.ts
+++ b/src/api/components/manager.ts
@@ -123,7 +123,7 @@ export class ComponentManager {
     }
 
     await installed.component.uninstall?.(this.connection);
-    await installed.overrideState({ status: `NotInstalled`, remoteSignature: "" });
+    installed.overrideState({ status: `NotInstalled`, remoteSignature: "" });
 
     return {
       id: installed.component.getIdentification(),
@@ -137,7 +137,7 @@ export class ComponentManager {
       component.component.reset?.();
 
       const state = component.handleState(await component.component.getRemoteState(this.connection, await component.getInstallDirectory()));
-      await component.overrideState(state);
+      component.overrideState(state);
       return state;
     }
   }
@@ -169,7 +169,7 @@ export class ComponentManager {
     if ((!installedBefore || !sameVersion || installedBefore.state.status === `NotChecked`)) {
       await newComponent.startupCheck();
     } else if (installedBefore) {
-      await newComponent.overrideState(installedBefore.state);
+      newComponent.overrideState(installedBefore.state);
     }
 
     const newState = newComponent.getState();

--- a/src/api/components/mapepire/index.ts
+++ b/src/api/components/mapepire/index.ts
@@ -40,7 +40,7 @@ export class Mapepire implements IBMiComponent {
 
   async getRemoteState(connection: IBMi, installDirectory: string): Promise<SecureComponentState> {
     this.setInstallDirectory(installDirectory);
-    const remoteVersions = (await connection.sendCommand({ command: `find . -type f -name ${SERVER_FILE_PREFIX}\\*`, directory: installDirectory }))
+    const remoteVersions = (await connection.sendCommand({ command: `/QOpenSys/usr/bin/find ${installDirectory} -type f -name ${SERVER_FILE_PREFIX}\\*` }))
       .stdout.split("\n")
       .map(line => line.trim().substring(2))
       .map(line => new RegExp(`${SERVER_FILE_PREFIX}(\\d+)\\.(\\d+)\\.(\\d+)\\.jar$`).exec(line))

--- a/src/api/components/runtime.ts
+++ b/src/api/components/runtime.ts
@@ -2,19 +2,14 @@ import IBMi from "../IBMi";
 import { ComponentState, IBMiComponent, SecureComponentState } from "./component";
 
 export class IBMiComponentRuntime {
-  public static readonly InstallDirectory = `$HOME/.vscode/`;
   private state: SecureComponentState = { status: `NotChecked`, remoteSignature: "" };
   private cachedInstallDirectory: string | undefined;
 
   constructor(protected readonly connection: IBMi, readonly component: IBMiComponent) { }
 
-  async getInstallDirectory() {
+  getInstallDirectory() {
     if (!this.cachedInstallDirectory) {
-      const result = await this.connection.sendCommand({
-        command: `echo "${IBMiComponentRuntime.InstallDirectory}"`,
-      });
-
-      this.cachedInstallDirectory = result.stdout.trim() || `/home/${this.connection.currentUser.toLowerCase()}/.vscode/`;
+      this.cachedInstallDirectory = `${this.connection.getConfig().homeDirectory}/.vscode`;
     }
 
     return this.cachedInstallDirectory;
@@ -29,14 +24,14 @@ export class IBMiComponentRuntime {
     return IBMi.GlobalStorage.storeComponentState(this.connection.currentConnectionName, { id: this.component.getIdentification(), state: newState });
   }
 
-  async overrideState(newState: SecureComponentState) {
-    const installDir = await this.getInstallDirectory();
-    await this.component.setInstallDirectory?.(installDir);
-    await this.setState(newState);
+  overrideState(newState: SecureComponentState) {
+    const installDir = this.getInstallDirectory();
+    this.component.setInstallDirectory?.(installDir);
+    this.setState(newState);
   }
 
   async update() {
-    const newState = this.handleState(await this.component.update(this.connection, await this.getInstallDirectory()));
+    const newState = this.handleState(await this.component.update(this.connection, this.getInstallDirectory()));
     await this.setState(newState);
   }
 


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Resolves #3226

This PR tries to bring a backup solution if users have their home folder set to `/`.
It will for the home directory to be `/home/<username> `. Keeping `/` breaks Code for i anyway.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Use a profile with '/' set as itheir home directory
2. The home dir used by code for i must be /home/<username>

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my chang