### PR TITLE
Added IBM i FS to the list of issues target

### DIFF
--- a/src/ui/views/helpView.ts
+++ b/src/ui/views/helpView.ts
@@ -123,6 +123,7 @@ async function openNewIssue() {
     { label: "Code for IBM i", target: 'vscode-ibmi' },
     { label: "Db2 for IBM i", target: 'vscode-db2i' },
     { label: "RPGLE language tools", target: 'vscode-rpgle' },
+    { label: "IBM i FileSystem", target: 'vscode-ibmi-fs' },
     { label: "IBM i Debugger", target: 'vscode-ibmi-debug-issues' },
   ], { title: l10n.t("Please pick the extension to report the issue on"), placeHolder: l10n.t("Report an issue on...") }))?.target;
 


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
This PR adds the FS extension in the list of extensions users can open an issues for.

<img width="631" height="190" alt="image" src="https://github.com/user-attachments/assets/084cbc91-ce79-425e-b6ba-0c68bc595a7a" />

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Click on `Report an issue` in the Help and Support view
2. IBM i FileSystem must be in the list
3. Clicking on it must open a new pre-filled template in the IBM i FS repository

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change