### PR TITLE
Conditional WHERE clause if member type is *

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
       - run: npm ci
 
       - name: Type checker
-        run: npm run typings
+        run: npm run types
 
       # This step won't run when coming from a fork
       - name: Test suite

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -782,6 +782,7 @@ export default class IBMiContent {
         FROM TABLE (qsys2.object_statistics('${library}', '*FILE', '${sourceFile}')) OBJ_STAT,
         LATERAL (SELECT * FROM TABLE (qsys2.PARTITION_STATISTICS(RPAD(OBJ_STAT.OBJLIB, 10), RPAD(OBJ_STAT.OBJNAME, 10)))) PART_STAT
         ${singleMember ? `WHERE RTRIM(PART_STAT.SYSTEM_TABLE_MEMBER) like '${singleMember}'` : ``}
+        ${singleMemberExtension && singleMemberExtension.trim() !== '%' ? `${singleMember ? `AND` : `WHERE`} RTRIM(CAST(PART_STAT.SOURCE_TYPE AS VARCHAR(10))) like '${singleMemberExtension}'` : ``}
         ORDER BY ${sort.order === 'name' ? 'NAME' : 'CHANGED'} ${!sort.ascending ? 'DESC' : 'ASC'}`;
 
     const results = await this.ibmi.runSQL(statement);

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -782,7 +782,6 @@ export default class IBMiContent {
         FROM TABLE (qsys2.object_statistics('${library}', '*FILE', '${sourceFile}')) OBJ_STAT,
         LATERAL (SELECT * FROM TABLE (qsys2.PARTITION_STATISTICS(RPAD(OBJ_STAT.OBJLIB, 10), RPAD(OBJ_STAT.OBJNAME, 10)))) PART_STAT
         ${singleMember ? `WHERE RTRIM(PART_STAT.SYSTEM_TABLE_MEMBER) like '${singleMember}'` : ``}
-        ${singleMemberExtension ? `${singleMember ? `AND` : `WHERE`} RTRIM(CAST(PART_STAT.SOURCE_TYPE AS VARCHAR(10))) like '${singleMemberExtension}'` : ``}
         ORDER BY ${sort.order === 'name' ? 'NAME' : 'CHANGED'} ${!sort.ascending ? 'DESC' : 'ASC'}`;
 
     const results = await this.ibmi.runSQL(statement);


### PR DESCRIPTION
### Changes
With this PR, it will be possible to view source file members without extensions in the object browser

### How to test this PR

1. Create a member without extension
2. Update object browser
3. Now you can see created member

<img width="989" height="403" alt="image" src="https://github.com/user-attachments/assets/8ddc3318-848d-4cda-a6c3-e645209518fd" />

<img width="306" height="141" alt="image" src="https://github.com/user-attachments/assets/5cf8a3bd-6ccc-41ce-bc2b-ab8d3cad293d" />

**Member type must be * in the filter**
<img width="817" height="87" alt="image" src="https://github.com/user-attachments/assets/2a351993-9295-4ac2-be3d-5ace03cee890" />


### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)

Closes #3240