### PR TITLE
Fixed and improved EVFEVENT retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -2252,7 +2252,7 @@
 				},
 				{
 					"command": "code-for-ibmi.openErrors",
-					"when": "code-for-ibmi:connected"
+					"when": "never"
 				},
 				{
 					"command": "code-for-ibmi.launchTerminalPicker",

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -1457,10 +1457,7 @@ export default class IBMi {
 
       const lastResultSet: Tools.DB2Row[] = [];
 
-      for (let i = 0; i < list.length; i++) {
-        let statement = list[i];
-        const isLast = i === (list.length - 1);
-
+      for (const statement of list) {
         if (statement.startsWith(`@`)) {
           const command = statement.substring(1);
           const log = `Running CL through SQL: ${command}\n\t`;

--- a/src/commands/actions.ts
+++ b/src/commands/actions.ts
@@ -3,7 +3,7 @@ import { commands, Disposable, env, l10n, TreeItem, Uri, window, WorkspaceFolder
 import IBMi from "../api/IBMi";
 import { Tools } from "../api/Tools";
 import Instance from "../Instance";
-import { Action, ActionResult, DeploymentMethod } from "../typings";
+import { Action, DeploymentMethod } from "../typings";
 import { runAction } from "../ui/actions";
 import { refreshDiagnosticsFromServer } from "../ui/diagnostics";
 import { BrowserItem } from "../ui/types";
@@ -127,18 +127,17 @@ export function registerActionsCommands(instance: Instance): Disposable[] {
         ext: undefined
       };
 
-      let inputPath: string | undefined
+      let inputPath: string | undefined      
+      const connection = instance.getConnection()!; //safe as action requires to be connected
 
       if (options.qualifiedObject) {
         // Value passed in via parameter
         inputPath = options.qualifiedObject;
-
       } else {
         // Value collected from user input
 
         let initialPath = ``;
-        const editor = window.activeTextEditor;
-        const connection = instance.getConnection();
+        const editor = window.activeTextEditor;        
 
         if (editor && connection) {
           const config = connection.getConfig();
@@ -180,7 +179,7 @@ export function registerActionsCommands(instance: Instance): Disposable[] {
         const [library, object] = inputPath.split(`/`);
         if (library && object) {
           const nameDetail = path.parse(object);
-          refreshDiagnosticsFromServer(instance, [{ library, object: nameDetail.name, extension: (nameDetail.ext.length > 1 ? nameDetail.ext.substring(1) : undefined), workspace: options.workspace }], options.keepDiagnostics);
+          refreshDiagnosticsFromServer(connection, [{ library, object: nameDetail.name, extension: (nameDetail.ext.length > 1 ? nameDetail.ext.substring(1) : undefined), workspace: options.workspace }], options.keepDiagnostics);
         }
       }
     }),

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -432,7 +432,7 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
                           else if (evfeventInfo.object && evfeventInfo.library) {
                             if (chosenAction.command.includes(`*EVENTF`)) {
                               writeEmitter.fire(`Fetching errors for ` + (evfeventInfos.length > 1 ? `multiple objects` : `${evfeventInfos[0].library}/${evfeventInfos[0].object}.`) + CompileTools.NEWLINE);
-                              await refreshDiagnosticsFromServer(connection, evfeventInfos);
+                              refreshDiagnosticsFromServer(connection, evfeventInfos);
                               problemsFetched = true;
                             } else if (chosenAction.command.trimStart().toUpperCase().startsWith(`CRT`)) {
                               writeEmitter.fire(`*EVENTF not found in command string. Not fetching errors for ${evfeventInfo.library}/${evfeventInfo.object}.` + CompileTools.NEWLINE);

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import vscode, { CustomExecution, Pseudoterminal, TaskGroup, TaskPanelKind, TaskRevealKind, WorkspaceFolder, commands, l10n, tasks } from 'vscode';
+import { ActionTools } from '../api/actions';
 import { CompileTools } from '../api/CompileTools';
 import IBMi from '../api/IBMi';
 import { Tools } from '../api/Tools';
@@ -13,7 +14,6 @@ import { Action, ActionResult, DeploymentMethod } from '../typings';
 import { CustomUI, TreeListItem } from '../webviews/CustomUI';
 import { EvfEventInfo, refreshDiagnosticsFromLocal, refreshDiagnosticsFromServer, registerDiagnostics } from './diagnostics';
 import { VscodeTools } from './Tools';
-import { ActionTools } from '../api/actions';
 import { BrowserItem } from './types';
 
 type CommandObject = {
@@ -393,21 +393,31 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
                             (postDownload.includes(`.evfevent`) || postDownload.includes(`.evfevent/`));
 
                           const possibleObjects = getObjectsFromJoblog(commandResult.stderr) || getObjectFromCommand(commandResult.command);
-                          if (isIleCommand && possibleObjects) {
-                            evfeventInfos.length = 0;
-                            if (Array.isArray(possibleObjects)) {
-                              for (const o of possibleObjects) {
-                                evfeventInfos.push({
-                                  library: o.library || evfeventInfo.library,
-                                  object: o.object,
-                                  extension: evfeventInfo.extension,
-                                  asp: evfeventInfo.asp
-                                })
-                              };
-                            } else {
-                              evfeventInfo.library = possibleObjects.library ? possibleObjects.library : evfeventInfo.library;
-                              evfeventInfo.object = possibleObjects.object;
-                              evfeventInfos.push(evfeventInfo);
+                          if (isIleCommand) {
+                            if (possibleObjects) {
+                              if (Array.isArray(possibleObjects)) {
+                                for (const o of possibleObjects) {
+                                  evfeventInfos.push({
+                                    library: o.library || evfeventInfo.library,
+                                    object: o.object,
+                                    extension: evfeventInfo.extension,
+                                    asp: evfeventInfo.asp
+                                  })
+                                };
+                              } else {
+                                evfeventInfo.library = possibleObjects.library ? possibleObjects.library : evfeventInfo.library;
+                                evfeventInfo.object = possibleObjects.object;
+                                evfeventInfos.push(evfeventInfo);
+                              }
+                            }
+                            else {
+                              //Add a default eventf target
+                              evfeventInfos.push({
+                                library: evfeventInfo.library,
+                                object: evfeventInfo.object,
+                                extension: evfeventInfo.extension,
+                                asp: evfeventInfo.asp
+                              });
                             }
                           }
 
@@ -418,12 +428,11 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
 
                           if (useLocalEvfevent) {
                             writeEmitter.fire(`Fetching errors from .evfevent.${CompileTools.NEWLINE}`);
-
                           }
                           else if (evfeventInfo.object && evfeventInfo.library) {
                             if (chosenAction.command.includes(`*EVENTF`)) {
                               writeEmitter.fire(`Fetching errors for ` + (evfeventInfos.length > 1 ? `multiple objects` : `${evfeventInfos[0].library}/${evfeventInfos[0].object}.`) + CompileTools.NEWLINE);
-                              await refreshDiagnosticsFromServer(instance, evfeventInfos);
+                              await refreshDiagnosticsFromServer(connection, evfeventInfos);
                               problemsFetched = true;
                             } else if (chosenAction.command.trimStart().toUpperCase().startsWith(`CRT`)) {
                               writeEmitter.fire(`*EVENTF not found in command string. Not fetching errors for ${evfeventInfo.library}/${evfeventInfo.object}.` + CompileTools.NEWLINE);
@@ -508,7 +517,7 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
 
                                   // Process locally downloaded evfevent files:
                                   if (useLocalEvfevent) {
-                                    await refreshDiagnosticsFromLocal(instance, evfeventInfo);
+                                    await refreshDiagnosticsFromLocal(connection, evfeventInfo);
                                     problemsFetched = true;
                                   }
                                 })

--- a/src/ui/diagnostics.ts
+++ b/src/ui/diagnostics.ts
@@ -1,8 +1,8 @@
 
 import * as vscode from "vscode";
-import Instance from "../Instance";
 import IBMi from "../api/IBMi";
 import { parseErrors } from "../api/errors/parser";
+import { instance } from "../instantiate";
 import { FileError } from "../typings";
 import { VscodeTools } from "./Tools";
 
@@ -56,28 +56,27 @@ export function clearDiagnostic(uri: vscode.Uri, changeRange: vscode.Range) {
   }
 }
 
-export async function refreshDiagnosticsFromServer(instance: Instance, evfeventInfo: EvfEventInfo[], keepDiagnostics?: boolean) {
-  const connection = instance.getConnection();
-
-  if (connection) {
-    const content = connection.getContent();
-
-    if (IBMi.connectionManager.get(`clearErrorsBeforeBuild`) && !keepDiagnostics) {
-      // Clear all errors if the user has this setting enabled
-      clearDiagnostics();
-    }
-
-    evfeventInfo.forEach(async e => {
-      const tableData = await content.getTable(e.library, `EVFEVENT`, e.object);
-      const lines = tableData.map(row => String(row.EVFEVENT));
-      handleEvfeventLines(lines, instance, e);
-    });
-  } else {
-    throw new Error('Please connect to an IBM i');
+export function refreshDiagnosticsFromServer(connection: IBMi, evfeventInfo: EvfEventInfo[], keepDiagnostics?: boolean) {
+  if (IBMi.connectionManager.get(`clearErrorsBeforeBuild`) && !keepDiagnostics) {
+    // Clear all errors if the user has this setting enabled
+    clearDiagnostics();
   }
+
+  evfeventInfo.forEach(async e => {
+    const lines = (await connection.runSQL(/* sql */
+      `select trim(cast(LINE as VarChar(400) CCSID 1208)) EVFEVENT
+      from table(QSYS2.ifs_read_utf8(
+        path_name => '${e.asp ? `/${e.asp}` : ''}/QSYS.LIB/${e.library}.LIB/EVFEVENT.FILE/${e.object}.MBR',
+        maximum_line_length => 400))`
+    )).map(row => String(row.EVFEVENT));
+
+    if (lines.length) {
+      handleEvfeventLines(connection, lines, e);
+    }
+  });
 }
 
-export async function refreshDiagnosticsFromLocal(instance: Instance, evfeventInfo: EvfEventInfo) {
+export async function refreshDiagnosticsFromLocal(connection: IBMi, evfeventInfo: EvfEventInfo) {
   if (evfeventInfo.workspace) {
     const evfeventFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(evfeventInfo.workspace, `**/.evfevent/*`), null);
     if (evfeventFiles) {
@@ -93,7 +92,7 @@ export async function refreshDiagnosticsFromLocal(instance: Instance, evfeventIn
         const eol = content.includes(`\r\n`) ? `\r\n` : `\n`;
         const lines = content.split(eol);
 
-        handleEvfeventLines(lines, instance, evfeventInfo);
+        handleEvfeventLines(connection, lines, evfeventInfo);
       }
 
     } else {
@@ -102,8 +101,7 @@ export async function refreshDiagnosticsFromLocal(instance: Instance, evfeventIn
   }
 }
 
-export function handleEvfeventLines(lines: string[], instance: Instance, evfeventInfo: EvfEventInfo) {
-  const connection = instance.getConnection()!;
+export function handleEvfeventLines(connection: IBMi, lines: string[], evfeventInfo: EvfEventInfo) {
   const config = connection.getConfig();
   const asp = evfeventInfo.asp ? `${evfeventInfo.asp}/` : ``;
 

--- a/src/ui/diagnostics.ts
+++ b/src/ui/diagnostics.ts
@@ -65,7 +65,7 @@ export function refreshDiagnosticsFromServer(connection: IBMi, evfeventInfo: Evf
   evfeventInfo.forEach(async e => {
     const lines = (await connection.runSQL(/* sql */
       `select trim(cast(LINE as VarChar(400) CCSID 1208)) EVFEVENT
-      from table(QSYS2.ifs_read_utf8(
+      from table(QSYS2.IFS_READ_UTF8(
         path_name => '${e.asp ? `/${e.asp}` : ''}/QSYS.LIB/${e.library}.LIB/EVFEVENT.FILE/${e.object}.MBR',
         maximum_line_length => 400))`
     )).map(row => String(row.EVFEVENT));


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Fixes #3241

This PR prevents the crash described in #3241 from happening.
It also replaces the use of `CPYTOIMPF` with the SQL service `QSYS2.IFS_READ_UTF8` to read `EVFEVENT` members:
- It's a bit faster
- It won't crash if the member doesn't exist (the error thrown by CPYTOIMPF was silent and not handled)

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Run a custom compilation command as described in #3241: there must be no TypeError crash
2. Run a standard compilation command: the compilation errors must be displayed

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change