### PR TITLE
Fix/search ifs tool 509

### DIFF
--- a/src/api/SearchTools.ts
+++ b/src/api/SearchTools.ts
@@ -152,7 +152,7 @@ export namespace SearchTools {
           command: `${find} ${Tools.escapePath(path)} ${ignoreString} -type f -iname '*${findTerm}*' -print`
         });
 
-        if (findRes.code == 0 || findRes.stdout) {
+        if (findRes.stdout) {
           return {
             term: findTerm,
             hits: parseFindOutput(findRes.stdout),

--- a/src/api/SearchTools.ts
+++ b/src/api/SearchTools.ts
@@ -156,7 +156,7 @@ export namespace SearchTools {
           return {
             term: findTerm,
             hits: parseFindOutput(findRes.stdout),
-            warnings:parseFindOutput(findRes.stderr)
+            ...(findRes.stderr ? { warnings: parseFindOutput(findRes.stderr) } : {})
           }
         }
       } else {
@@ -171,10 +171,7 @@ export namespace SearchTools {
   function parseFindOutput(output: string, readonly?: boolean, pathTransformer?: (path: string) => string): SearchHit[] {
     const results: SearchHit[] = [];
     for (const line of output.split('\n')) {
-      const trimmedLine = line.trim();
-      if (!trimmedLine) continue;
-
-      const path = pathTransformer?.(trimmedLine) || trimmedLine;
+      const path = pathTransformer?.(line) || line;
       results.push(results.find(r => r.path === path) || { path, readonly, lines: [] });
     }
     return results;

--- a/src/api/SearchTools.ts
+++ b/src/api/SearchTools.ts
@@ -152,10 +152,11 @@ export namespace SearchTools {
           command: `${find} ${Tools.escapePath(path)} ${ignoreString} -type f -iname '*${findTerm}*' -print`
         });
 
-        if (findRes.code == 0 && findRes.stdout) {
+        if (findRes.code == 0 || findRes.stdout) {
           return {
             term: findTerm,
-            hits: parseFindOutput(findRes.stdout)
+            hits: parseFindOutput(findRes.stdout),
+            warnings:parseFindOutput(findRes.stderr)
           }
         }
       } else {
@@ -170,7 +171,10 @@ export namespace SearchTools {
   function parseFindOutput(output: string, readonly?: boolean, pathTransformer?: (path: string) => string): SearchHit[] {
     const results: SearchHit[] = [];
     for (const line of output.split('\n')) {
-      const path = pathTransformer?.(line) || line;
+      const trimmedLine = line.trim();
+      if (!trimmedLine) continue;
+
+      const path = pathTransformer?.(trimmedLine) || trimmedLine;
       results.push(results.find(r => r.path === path) || { path, readonly, lines: [] });
     }
     return results;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -193,7 +193,8 @@ export type AttrOperands = 'ACCESS_TIME' | 'ALLOC_SIZE' | 'ALLOC_SIZE_64' | 'ALW
 
 export type SearchResults = {
   term: string,
-  hits: SearchHit[]
+  hits: SearchHit[],
+  warnings?: SearchHit[]
 }
 
 export type SearchHit = {

--- a/src/ui/views/searchView.ts
+++ b/src/ui/views/searchView.ts
@@ -27,12 +27,12 @@ export function initializeSearchView(context: vscode.ExtensionContext) {
         searchViewViewer.message = vscode.l10n.t(`{0} file(s) contain(s) '{1}'`, hits, searchResults.term);
 
         if (warningCount) {
-          searchViewViewer.message += vscode.l10n.t(` — Permission denied to {0} file(s)`, warningCount);
+          searchViewViewer.message += vscode.l10n.t(` — Permission denied to {0} folder(s)`, warningCount);
         }
       }
       else {
         searchViewViewer.message = warningCount
-          ? vscode.l10n.t(`{0} file(s) name '{1}' — Permission denied to {2} file(s)`, hits, searchResults.term, warningCount)
+          ? vscode.l10n.t(`{0} file(s) name '{1}' — Permission denied to {2} folder(s)`, hits, searchResults.term, warningCount)
           : vscode.l10n.t(`{0} file(s) name '{1}'`, hits, searchResults.term);
       }
 

--- a/src/ui/views/searchView.ts
+++ b/src/ui/views/searchView.ts
@@ -18,19 +18,31 @@ export function initializeSearchView(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(`code-for-ibmi.collapseSearchView`, async () => searchView.collapse()),
     vscode.commands.registerCommand(`code-for-ibmi.setSearchResults`, async (searchResults: SearchResults, appendResults?: boolean) => {
       const hits = appendResults ? searchView.hits + searchResults.hits.length : searchResults.hits.length;
-      if (searchResults.hits.some(hit => hit.lines.length)) {
+      const warningCount = appendResults
+        ? searchView.warningCount + (searchResults.warnings?.length || 0)
+        : (searchResults.warnings?.length || 0);
+      const isContentSearch = searchResults.hits.some(hit => hit.lines.length);
+
+      if (isContentSearch) {
         searchViewViewer.message = vscode.l10n.t(`{0} file(s) contain(s) '{1}'`, hits, searchResults.term);
+
+        if (warningCount) {
+          searchViewViewer.message += vscode.l10n.t(` — Permission denied to {0} file(s)`, warningCount);
+        }
       }
       else {
-        searchViewViewer.message = vscode.l10n.t(`{0} file(s) named '{1}'`, hits, searchResults.term);
+        searchViewViewer.message = warningCount
+          ? vscode.l10n.t(`{0} file(s) name '{1}' — Permission denied to {2} file(s)`, hits, searchResults.term, warningCount)
+          : vscode.l10n.t(`{0} file(s) name '{1}'`, hits, searchResults.term);
       }
+
       searchView.setResults(searchResults, appendResults);
     })
   )
 }
 
 class SearchView implements vscode.TreeDataProvider<vscode.TreeItem> {
-  private readonly _results: SearchResults = { term: "", hits: [] };
+  private readonly _results: SearchResults = { term: "", hits: [], warnings: [] };
   private readonly _onDidChangeTreeData: vscode.EventEmitter<vscode.TreeItem | undefined | null | void> = new vscode.EventEmitter<vscode.TreeItem | undefined | null | void>();
   readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined | null | void> = this._onDidChangeTreeData.event;
 
@@ -41,10 +53,13 @@ class SearchView implements vscode.TreeDataProvider<vscode.TreeItem> {
   setResults(results: SearchResults, appendResults?: boolean) {
     if(!appendResults){
       this._results.term = results.term;
-      this._results.hits = [];      
-    }    
+      this._results.hits = [];
+      this._results.warnings = [];
+    }
+
     this._results.hits.push(...results.hits);
-    
+    this._results.warnings?.push(...(results.warnings || []));
+
     this.refresh();
     this.setViewVisible(true);
 
@@ -73,6 +88,10 @@ class SearchView implements vscode.TreeDataProvider<vscode.TreeItem> {
 
   get hits() {
     return this._results.hits.length;
+  }
+
+  get warningCount() {
+    return this._results.warnings?.length || 0;
   }
 }
 


### PR DESCRIPTION
### Changes
Updated IFS search result handling so permission-denied errors are surfaced in the search view summary instead of separate warnings. Search results now count permission-denied entries from stderr via the `warnings` array and display them in the message, for example: `179 file(s) contain(s) 'hello' — Permission denied to 5 file(s)` and `179 file(s) name 'test1.pf' — Permission denied to 5 file(s)`. This also keeps the search result flow focused on actual command output instead of relying on exit status alone, since for `find`/`grep` searches the presence of useful `stdout`/`stderr` data matters more than whether the command exits with zero or non-zero status. A non-zero code can still return valid matches or permission-denied entries, so checking the output is sufficient and more reliable than checking `findRes.code`.

### How to test this PR
1. Connect to an IBM i system with at least one IFS directory or file that the current user cannot access.
2. Run an IFS content search and confirm the search view shows the hit count plus `— Permission denied to X file(s)`.
3. Run an IFS filename search and confirm the search view shows the filename match count plus `— Permission denied to X file(s)`.
4. Verify no separate popup warning appears for permission-denied results.

### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)

<img width="896" height="428" alt="image" src="https://github.com/user-attachments/assets/a39956f4-774f-4fb5-abf6-859949ce8a8c" />
<img width="935" height="674" alt="image" src="https://github.com/user-attachments/assets/f23f8d31-af86-47cc-a554-1ec62afd2f96" />
