### PR TITLE
Improve permissions check when home dir is symlink

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+
 # Contributing to Code for IBM i
 
 We welcome all users to contribute. Whether it be to documentation, or code, we love it all. We use a typical PR system:
@@ -73,3 +74,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@SamJessep](https://github.com/SamJessep)
 * [@MerelSoftware](https://github.com/MerelSoftware)
 * [@agatabrzeczek](https://github.com/agatabrzeczek)
+* [@phpdave](https://github.com/phpdave)

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -430,18 +430,8 @@ export default class IBMi {
         // and chmod follows the link, so detection must follow it too or it can never converge.
         // Returns 'error' when the output can't be parsed (empty stdout, ls error, banner noise).
         const getPermissions = async (path: string) => {
-          const out = (await this.sendCommand({ command: `ls -ldL "${path}" 2>/dev/null` })).stdout.trim();
-          // type char + 9 perm chars (s/S = setuid/setgid, t/T = sticky; trailing ACL marker ignored)
-          const match = out.match(/^[-dlbcps]([-r][-w][-xsS][-r][-w][-xsS][-r][-w][-xtT])/);
-          if (!match) {
-            return 'error';
-          }
-          const field = match[1];
-          const permissions: number[] = [];
-          for (let i = 0; i < 9; i += 3) {
-            permissions.push((field[i] === "r" ? 4 : 0) + (field[i + 1] === "w" ? 2 : 0) + (["x", "s", "t"].includes(field[i + 2]) ? 1 : 0));
-          }
-          return permissions.map(String).join("");
+          const out = (await this.sendCommand({ command: `ls -ldL "${path}" 2>/dev/null` })).stdout;
+          return Tools.parseLsPermissions(out) ?? 'error';
         };
 
         const homePerms = await getPermissions(defaultHomeDir);

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -424,12 +424,22 @@ export default class IBMi {
           message: `Checking directory permissions.`
         });
 
-        // Get home directory permissions (stat -c '%a' returns octal permissions)
+        // Parse the rwx mode field from `ls -ld` into octal (e.g. "750").
+        // -L dereferences symlinks so we read the TARGET's permissions: IBM i home
+        // directories are frequently symlinks into an ASP (e.g. /home/me -> /ASP/home/me),
+        // and chmod follows the link, so detection must follow it too or it can never converge.
+        // Returns 'error' when the output can't be parsed (empty stdout, ls error, banner noise).
         const getPermissions = async (path: string) => {
-          const permissionString = (await this.sendCommand({ command: `ls -ld "${path}"` })).stdout.substring(1, 10);
+          const out = (await this.sendCommand({ command: `ls -ldL "${path}" 2>/dev/null` })).stdout.trim();
+          // type char + 9 perm chars (s/S = setuid/setgid, t/T = sticky; trailing ACL marker ignored)
+          const match = out.match(/^[-dlbcps]([-r][-w][-xsS][-r][-w][-xsS][-r][-w][-xtT])/);
+          if (!match) {
+            return 'error';
+          }
+          const field = match[1];
           const permissions: number[] = [];
           for (let i = 0; i < 9; i += 3) {
-            permissions.push((permissionString[i] == "r" ? 4 : 0) + (permissionString[i + 1] == "w" ? 2 : 0) + (["x", "s"].includes(permissionString[i + 2]) ? 1 : 0));
+            permissions.push((field[i] === "r" ? 4 : 0) + (field[i + 1] === "w" ? 2 : 0) + (["x", "s", "t"].includes(field[i + 2]) ? 1 : 0));
           }
           return permissions.map(String).join("");
         };

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -249,4 +249,33 @@ export namespace Tools {
     // (it will remain relative)
     return inputPath;
   }
+
+  /**
+   * Parses the leading mode field of an `ls -l`/`ls -ld` listing into an octal
+   * permission string (e.g. `drwxr-x---` -> `"750"`).
+   *
+   * The first character is the file type (`-dlbcps`) and is ignored; the next
+   * nine characters are the owner/group/other `rwx` triplets. The execute slot
+   * also encodes the special bits, which are treated as execute being present:
+   * `s`/`S` (setuid/setgid) and `t`/`T` (sticky). Any trailing content, such as
+   * the `+`/`.` ACL marker that `ls` may append, is ignored.
+   *
+   * @param lsOutput raw (trimmed or untrimmed) stdout from `ls -l`/`ls -ld`
+   * @returns the 3-digit octal permission string, or `undefined` when the input
+   * does not start with a valid mode field (empty output, `ls` error, banner noise)
+   */
+  export function parseLsPermissions(lsOutput: string): string | undefined {
+    // type char + 9 perm chars (s/S = setuid/setgid, t/T = sticky; trailing ACL marker ignored)
+    const match = lsOutput.trim().match(/^[-dlbcps]([-r][-w][-xsS][-r][-w][-xsS][-r][-w][-xtT])/);
+    if (!match) {
+      return undefined;
+    }
+
+    const field = match[1];
+    const permissions: number[] = [];
+    for (let i = 0; i < 9; i += 3) {
+      permissions.push((field[i] === "r" ? 4 : 0) + (field[i + 1] === "w" ? 2 : 0) + (["x", "s", "t"].includes(field[i + 2]) ? 1 : 0));
+    }
+    return permissions.map(String).join("");
+  }
 }

--- a/src/api/tests/suites/tools.test.ts
+++ b/src/api/tests/suites/tools.test.ts
@@ -136,3 +136,124 @@ describe('Tools.ensureFullPath tests', { concurrent: true }, () => {
     });
   });
 });
+
+describe('Tools.parseLsPermissions tests', { concurrent: true }, () => {
+  describe('Basic rwx triplets', () => {
+    it('should parse the expected home directory mode 750', () => {
+      expect(Tools.parseLsPermissions('drwxr-x--- 2 me grp 4096 Jun 8 /home/me')).toBe('750');
+    });
+
+    it('should parse the expected .vscode mode 700', () => {
+      expect(Tools.parseLsPermissions('drwx------ 2 me grp 4096 Jun 8 /home/me/.vscode')).toBe('700');
+    });
+
+    it('should parse a regular file with 644', () => {
+      expect(Tools.parseLsPermissions('-rw-r--r-- 1 me grp 12 Jun 8 file.txt')).toBe('644');
+    });
+
+    it('should parse all permissions set (777)', () => {
+      expect(Tools.parseLsPermissions('drwxrwxrwx 2 me grp 4096 Jun 8 /tmp')).toBe('777');
+    });
+
+    it('should parse no permissions set (000)', () => {
+      expect(Tools.parseLsPermissions('---------- 1 me grp 0 Jun 8 locked')).toBe('000');
+    });
+  });
+
+  describe('File type characters (ignored, must still match)', () => {
+    it('should accept a symlink listing (l)', () => {
+      // ls -ld without -L reports the link itself
+      expect(Tools.parseLsPermissions('lrwxrwxrwx 1 me grp 20 Jun 8 home -> /ASP/home/me')).toBe('777');
+    });
+
+    it('should accept a block device (b)', () => {
+      expect(Tools.parseLsPermissions('brw-rw---- 1 root disk 8, 0 Jun 8 sda')).toBe('660');
+    });
+
+    it('should accept a character device (c)', () => {
+      expect(Tools.parseLsPermissions('crw-rw-rw- 1 root tty 1, 3 Jun 8 null')).toBe('666');
+    });
+
+    it('should accept a named pipe (p)', () => {
+      expect(Tools.parseLsPermissions('prw-r--r-- 1 me grp 0 Jun 8 fifo')).toBe('644');
+    });
+
+    it('should accept a socket (s)', () => {
+      expect(Tools.parseLsPermissions('srwxr-xr-x 1 me grp 0 Jun 8 sock')).toBe('755');
+    });
+  });
+
+  describe('Special bits (setuid / setgid / sticky)', () => {
+    it('should treat lowercase s (setuid + execute) as execute present', () => {
+      expect(Tools.parseLsPermissions('-rwsr-xr-x 1 root grp 0 Jun 8 prog')).toBe('755');
+    });
+
+    it('should treat uppercase S (setuid without execute) as no execute', () => {
+      expect(Tools.parseLsPermissions('-rwSr--r-- 1 root grp 0 Jun 8 prog')).toBe('644');
+    });
+
+    it('should treat lowercase s in the group slot (setgid + execute) as execute present', () => {
+      expect(Tools.parseLsPermissions('drwxr-sr-x 2 me grp 4096 Jun 8 shared')).toBe('755');
+    });
+
+    it('should treat uppercase S in the group slot (setgid without execute) as no execute', () => {
+      expect(Tools.parseLsPermissions('drwxr-Sr-x 2 me grp 4096 Jun 8 shared')).toBe('745');
+    });
+
+    it('should treat lowercase t (sticky + execute) as execute present', () => {
+      expect(Tools.parseLsPermissions('drwxrwxrwt 2 root grp 4096 Jun 8 tmp')).toBe('777');
+    });
+
+    it('should treat uppercase T (sticky without execute) as no execute', () => {
+      expect(Tools.parseLsPermissions('drwxrwxrwT 2 root grp 4096 Jun 8 tmp')).toBe('776');
+    });
+  });
+
+  describe('Trailing content and whitespace', () => {
+    it('should ignore a trailing ACL marker (+)', () => {
+      expect(Tools.parseLsPermissions('drwxr-x---+ 2 me grp 4096 Jun 8 /home/me')).toBe('750');
+    });
+
+    it('should ignore a trailing SELinux/alternate-access marker (.)', () => {
+      expect(Tools.parseLsPermissions('drwxr-x---. 2 me grp 4096 Jun 8 /home/me')).toBe('750');
+    });
+
+    it('should tolerate leading and trailing whitespace', () => {
+      expect(Tools.parseLsPermissions('   drwxr-x--- 2 me grp 4096 Jun 8 /home/me  \n')).toBe('750');
+    });
+
+    it('should parse a bare mode field with nothing after it', () => {
+      expect(Tools.parseLsPermissions('drwxr-x---')).toBe('750');
+    });
+  });
+
+  describe('Unparseable input returns undefined', () => {
+    it('should return undefined for empty output', () => {
+      expect(Tools.parseLsPermissions('')).toBeUndefined();
+    });
+
+    it('should return undefined for whitespace-only output', () => {
+      expect(Tools.parseLsPermissions('   \n  ')).toBeUndefined();
+    });
+
+    it('should return undefined for an ls error message', () => {
+      expect(Tools.parseLsPermissions('ls: cannot access /home/me: No such file or directory')).toBeUndefined();
+    });
+
+    it('should return undefined for banner/noise that is not a mode field', () => {
+      expect(Tools.parseLsPermissions('total 8')).toBeUndefined();
+    });
+
+    it('should return undefined for an invalid file type character', () => {
+      expect(Tools.parseLsPermissions('xrwxr-x--- 2 me grp 4096 Jun 8 weird')).toBeUndefined();
+    });
+
+    it('should return undefined for a truncated mode field', () => {
+      expect(Tools.parseLsPermissions('drwxr-x-')).toBeUndefined();
+    });
+
+    it('should return undefined for an invalid character in a permission slot', () => {
+      expect(Tools.parseLsPermissions('drwxr-zr-x 2 me grp 4096 Jun 8 weird')).toBeUndefined();
+    });
+  });
+});

--- a/src/ui/connection.ts
+++ b/src/ui/connection.ts
@@ -115,13 +115,13 @@ export async function handleConnectionResults(connection: IBMi, error: Connectio
           let updateCmd = '';
           
           if (homePerms && homePerms !== '750') {
-            updateCmd += `chmod 0750 ${homeDir}`;
+            updateCmd += `chmod 0750 "${homeDir}"`;
           }
-          
+
           if (!vscodeExists) {
-            updateCmd += (updateCmd ? ' && ' : '') + `mkdir -p ${homeDir}/.vscode && chmod 0700 ${homeDir}/.vscode`;
+            updateCmd += (updateCmd ? ' && ' : '') + `mkdir -p "${homeDir}/.vscode" && chmod 0700 "${homeDir}/.vscode"`;
           } else if (vscodePerms && vscodePerms !== '700') {
-            updateCmd += (updateCmd ? ' && ' : '') + `chmod 0700 ${homeDir}/.vscode`;
+            updateCmd += (updateCmd ? ' && ' : '') + `chmod 0700 "${homeDir}/.vscode"`;
           }
           
           if (updateCmd) {


### PR DESCRIPTION
### Changes
If the homedir is a symlink the user will always get the pop up that they need to update their permissions for home dir, because the current check is for the symlink's permissions and not the target folder.  

### How to test this PR
Run 
```sh
ls -ldL "/home/yourhomedir"
```

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [x] have tested my test cases via ```npm run test```
* [x] have created one or more test cases https://github.com/codefori/vscode-ibmi/pull/3264/changes#diff-3e5b149af4d8692a7f05d678495bf24eb82215de0eadd88357fa789348a66001R140-R258
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md) https://github.com/codefori/vscode-ibmi/pull/3264/changes#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R77
