### PR TITLE
Fixed JDBC options not being used with new SQLJob

### DIFF
--- a/src/api/components/mapepire/index.ts
+++ b/src/api/components/mapepire/index.ts
@@ -117,10 +117,7 @@ export class Mapepire implements IBMiComponent {
   public async newJob(connection: IBMi, options?: { javaPath?: string, jdbc?: JDBCOptions }) {
     const config = connection.getConfig();
     const useServer = config.mapepireUseServer;
-    const sqlJob = useServer ? new SQLJob() : new SSHSQLJob();
-    if (options) {
-      sqlJob.options;
-    }
+    const sqlJob = useServer ? new SQLJob(options?.jdbc) : new SSHSQLJob(options?.jdbc);
     sqlJob.options.secure = sqlJob.options.secure || config.secureSQL;
     if (useServer) {
       connection.appendOutput(`Connecting to Mapepire over HTTP on port ${config.mapepireServerPort}${config.mapepireAllowSelfCert ? ", allowing self-signed certificates" : ""}`);

--- a/src/api/components/mapepire/sshSqlJob.ts
+++ b/src/api/components/mapepire/sshSqlJob.ts
@@ -74,7 +74,6 @@ export class SSHSQLJob extends SQLJob {
 
   getStatus(): JobStatus {
     const currentListenerCount = this.responseEmitter.eventNames().length;
-
     return this.channel && currentListenerCount > 0 ? JobStatus.BUSY : this.status as JobStatus;
   }
 


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
This PR fixes JDBC options not being passed onto SQKL jobs when being created.