### PR TITLE
Fetch EVFEVENT content using OVRDBF

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -1212,4 +1212,14 @@ export default class IBMiContent {
       libraryList: [] as string[]
     });
   }
+
+  async overDBFile(library: string, file: string, member: string) {
+    const overFile = Tools.makeid().toUpperCase();
+    await this.ibmi.runSQL(`@QSYS/OVRDBF FILE(${overFile}) TOFILE(${library}/${file}) MBR(${member}) OVRSCOPE(*JOB)`);
+    return overFile;
+  }
+
+  async deleteOVRDBFile(overFile: string) {
+    await this.ibmi.runSQL(`@QSYS/DLTOVR FILE(${overFile}) LVL(*JOB)`);
+  }
 }

--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -28,7 +28,7 @@ export class ExtendedIBMiContent {
     if (connection) {
       const alias = getAliasName(uri);
       const { library, file, name } = connection.parserMemberPath(uri.path);
-      const overFile = await this.overDBFile(connection, library, file, name);
+      const overFile = await connection.getContent().overDBFile(library, file, name);
       try {
         // Query the column-specific CCSID and LENGTH for SRCDTA from SYSCOLUMNS
         // Mapepire SQL cannot read columns with CCSID 65535, so we must cast to the job CCSID
@@ -80,7 +80,7 @@ export class ExtendedIBMiContent {
         return body;
       }
       finally {
-        await this.deleteOVRDBFile(connection, overFile);
+        await connection.getContent().deleteOVRDBFile(overFile);
       }
     }
   }
@@ -117,7 +117,6 @@ export class ExtendedIBMiContent {
 
       const tempLib = "QTEMP";
       const alias = getAliasName(uri);
-      const aliasPath = `${tempLib}.${alias}`;
 
       let sourceDates;
 
@@ -138,7 +137,7 @@ export class ExtendedIBMiContent {
       if (tempRmt) {
         const tmpobj = await tmpFile();
 
-        const overFile = await this.overDBFile(connection, library, file, name);
+        const overFile = await connection.getContent().overDBFile(library, file, name);
         try {
           const sourceData = body.split(`\n`);
           const recordLength = await this.readRecordLength(connection, alias, overFile);
@@ -217,23 +216,13 @@ export class ExtendedIBMiContent {
           this.sourceDateHandler.baseDates.set(alias, sourceDates);
           this.sourceDateHandler.baseSequences.delete(alias);
         } finally {
-          await this.deleteOVRDBFile(connection, overFile);
+          await connection.getContent().deleteOVRDBFile(overFile);
           // Clean up temporary file
           await connection.clearTempRemote(tempKey);
         }
       }
     }
-  }
-
-  private async overDBFile(connection: IBMi, library: string, file: string, member: string) {
-    const overFile = Tools.makeid();
-    await connection.runSQL(`@QSYS/OVRDBF FILE(${overFile}) TOFILE(${library}/${file}) MBR(${member}) OVRSCOPE(*JOB)`);
-    return overFile;
-  }
-
-  private async deleteOVRDBFile(connection: IBMi, overFile: string) {
-    await connection.runSQL(`@QSYS/DLTOVR FILE(${overFile}) LVL(*JOB)`);
-  }
+  }  
 }
 
 function sliceUp(arr: any[], size: number): any[] {

--- a/src/ui/diagnostics.ts
+++ b/src/ui/diagnostics.ts
@@ -63,15 +63,17 @@ export function refreshDiagnosticsFromServer(connection: IBMi, evfeventInfo: Evf
   }
 
   evfeventInfo.forEach(async e => {
-    const lines = (await connection.runSQL(/* sql */
-      `select trim(cast(LINE as VarChar(400) CCSID 1208)) EVFEVENT
-      from table(QSYS2.IFS_READ_UTF8(
-        path_name => '${e.asp ? `/${e.asp}` : ''}/QSYS.LIB/${e.library}.LIB/EVFEVENT.FILE/${e.object}.MBR',
-        maximum_line_length => 400))`
-    )).map(row => String(row.EVFEVENT));
+    const overFile = await connection.getContent().overDBFile(e.library, "EVFEVENT", e.object);
+    try {
+      const lines = (await connection.runSQL(/* sql */`select trim(cast(EVFEVENT as VarChar(400) CCSID ${connection.getCcsid()})) EVFEVENT from ${overFile}`))
+        .map(row => String(row.EVFEVENT));
 
-    if (lines.length) {
-      handleEvfeventLines(connection, lines, e);
+      if (lines.length) {
+        handleEvfeventLines(connection, lines, e);
+      }
+    }
+    finally{
+      connection.getContent().deleteOVRDBFile(overFile);
     }
   });
 }


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Fixed #3265 

This PR replaces the use of `read_ifs_utf8` to fetch EVFEVENT file content with `OVRDBF`. `read_ifs_utf8` doesn't fetch all the lines are reported in #3265.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Compile comething
2. Compilation errors must be fetched and displayed

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change