### PR TITLE
Use LIBRARY_INFO to retrieve library's ASP name

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -1507,7 +1507,7 @@ export default class IBMi {
     library = this.upperCaseName(library);
     let libraryIASP = this.libraryAsps.get(library);
     if (!libraryIASP) {
-      const [row] = await this.runSQL(`select IASP_NAME from table(QSYS2.object_statistics('QSYS', 'LIB', '${library}'));`);
+      const [row] = await this.runSQL(`select IASP_NAME from table(QSYS2.LIBRARY_INFO('${library}'));`);
       libraryIASP = row?.IASP_NAME ? String(row.IASP_NAME) : "*SYSBAS";
       this.libraryAsps.set(library, libraryIASP);
     }

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -457,7 +457,7 @@ export default class IBMiContent {
           os.OBJTYPE AS TYPE,
           os.OBJATTRIBUTE AS ATTRIBUTE,
           OBJTEXT AS TEXT,
-          os.IASP_NAME AS IASP_NAME,
+          li.IASP_NAME AS IASP_NAME,
           os.OBJSIZE AS SIZE,
           EXTRACT(EPOCH FROM (os.OBJCREATED)) * 1000 AS CREATED,
           EXTRACT(EPOCH FROM (os.CHANGE_TIMESTAMP)) * 1000 AS CHANGED,
@@ -472,6 +472,7 @@ export default class IBMiContent {
           OBJTYPELIST => '*LIB',
           OBJECT_NAME => libs.ELEMENT
         )) AS os
+        CROSS JOIN TABLE(QSYS2.LIBRARY_INFO(library_name => os.OBJNAME)) AS li
       `;
     const results = await this.ibmi.runSQL(statement);
 
@@ -753,7 +754,6 @@ export default class IBMiContent {
       `SELECT RTRIM(OBJ_STAT.OBJNAME) AS SOURCE_FILE,
              RTRIM(PART_STAT.SYSTEM_TABLE_MEMBER) AS NAME,
              PART_STAT.AVGROWSIZE AS RECORD_LENGTH,
-             OBJ_STAT.IASP_NAME AS ASP,
              COALESCE(RTRIM(CAST(PART_STAT.SOURCE_TYPE AS VARCHAR(10))), '') AS TYPE,
              COALESCE(RTRIM(VARCHAR(PART_STAT.TEXT)), '') AS TEXT,
              PART_STAT.NUMBER_ROWS AS LINES,


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Fixes #3270 

To maintain 7.3 TR8 compatibility, we must use `LIBRARY_INFO` table functin instead of `OBJECT_STATISTICS` to retrieve the  `IASP_NAME` column.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Expand a filter
2. Refresh the library list

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change