### PR TITLE
Fix EVFEVENT errors mapping to server file instead of open local document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,3 +75,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@MerelSoftware](https://github.com/MerelSoftware)
 * [@agatabrzeczek](https://github.com/agatabrzeczek)
 * [@phpdave](https://github.com/phpdave)
+* [@neerup](https://github.com/neerup)

--- a/src/ui/diagnostics.ts
+++ b/src/ui/diagnostics.ts
@@ -169,17 +169,19 @@ export function handleEvfeventLines(connection: IBMi, lines: string[], evfeventI
             continue;
           }
 
-          // If we get there, that means that even though we compiled from local, we likely had to use a temp member.
-          // We should try to find the file in the workspace. Since we can use findFile (it's async), then we look for open
-          // tabs like we do below.
-          if (evfeventInfo.extension) {
-            const baseName = file.split(`/`).pop();
-            const openFile = VscodeTools.findExistingDocumentByName(`${baseName}.${evfeventInfo.extension}`);
-            if (openFile) {
-              ileDiagnostics.set(openFile, diagnostics);
-              continue;
-            }
-          }
+        }
+      }
+
+      // For member paths: try to find an open local document by name before falling back to server URI.
+      // findExistingDocumentByName searches all open tabs — no workspace needed — so this works for
+      // member-type actions too (where evfeventInfo.workspace is not set).
+      if (!file.startsWith(`/`) && evfeventInfo.extension) {
+        const baseName = file.split(`/`).pop();
+        const lookupName = `${baseName}.${evfeventInfo.extension}`;
+        const openFile = VscodeTools.findExistingDocumentByName(lookupName);
+        if (openFile) {
+          ileDiagnostics.set(openFile, diagnostics);
+          continue;
         }
       }
 


### PR DESCRIPTION
Fixes #3274

## Summary

When compiling a member-type action, clicking an error in the Problems
panel opened the source member on the server instead of the locally open
file.

Root cause: `findExistingDocumentByName` — which searches all open editor
tabs by filename — was inside the `if (evfeventInfo.workspace)` guard.
For member-type actions `workspace` is never set (only `file` actions
populate it), so the lookup was always skipped and errors fell through to
the server member URI.

Fix: move `findExistingDocumentByName` outside the workspace guard.
It needs no workspace context, so it now runs for member-type actions too,
resolving to the locally open file when one matches before falling back to
the server URI.

## Test plan

- [ ] Open a source member locally in the editor
- [ ] Run a compile action that uses `*EVENTF`
- [ ] Verify that clicking an error in the Problems panel opens the local file, not the server member
- [ ] Verify that workspace deploy-path mapping still works for `file`-type actions (errors in deployed IFS files still map to local workspace files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)