### PR TITLE
fix/sourceDateHandler: fix text editor ruler offsetting when source dates in gutter option on

### DIFF
--- a/src/filesystems/qsys/sourceDateHandler.ts
+++ b/src/filesystems/qsys/sourceDateHandler.ts
@@ -11,7 +11,7 @@ const annotationDecoration = vscode.window.createTextEditorDecorationType({
     textDecoration: `none`,
     fontWeight: `normal`,
     fontStyle: `normal`,
-    margin: `0 1em 0 0`,
+    margin: `0 1ch 0 0`,
     width: `7ch`,
     // Pull the decoration out of the document flow if we want to be scrollable
   },


### PR DESCRIPTION
Closes #3278 

### Changes
Replaced the `em` CSS unit which does not have to align with characters with the `ch` CSS unit. This fixes editor.rulers alignment.

### How to test this PR
1. Define editor.rulers in vscode settings
2. Edit connection settings for IBM i server to allow source dates in gutter
3. Visually inspect ruler position

### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
