### PR TITLE
Retrieve job default CCSID if user CCSID is *HEX

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -173,14 +173,6 @@ export default class IBMi {
     }
   }
 
-
-  /**
-   * Primarily used for running SQL statements.
-   */
-  get userCcsidInvalid() {
-    return this.userJobCcsid === IBMi.CCSID_NOCONVERSION;
-  }
-
   get dangerousVariants() {
     return this.variantChars.local !== this.variantChars.local.toLocaleUpperCase();
   };
@@ -651,6 +643,17 @@ export default class IBMi {
               this.userJobCcsid = this.qccsid;
             }
 
+            if (this.userJobCcsid === IBMi.CCSID_NOCONVERSION) {
+              //At this point, if it's still *HEX, we get the job's default CCSID
+              const [row] = await this.runSQL(/* sql */`
+                select DEFAULT_CCSID from table(
+                  QSYS2.ACTIVE_JOB_INFO(
+                    JOB_NAME_FILTER => '*',
+                    DETAILED_INFO => 'WORK'
+                  )
+                )`);
+              this.userJobCcsid = row?.DEFAULT_CCSID ? Number(row.DEFAULT_CCSID) : this.userJobCcsid;
+            }
           } catch (e) {
             // Oh well!
             console.log(e);


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Fixes #3283 

The user CCSID is used to convert physical source files when their CCSID is *HEX or EVENTF when reading compilation errors. But since the user CCSID can be *HEX too if the LPAR is configured so, we fall back to reading the job's default CCSID so it's never *HEX. 

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Connect and reload settings
2. Compile a program with errors
3. Errors must be retrieved
4. Try to open a member from a SPF wwith CCSID *HEX

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change