### PR TITLE
Fix SQL query to ensure non-empty member names are processed correctly

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -769,8 +769,9 @@ export default class IBMiContent {
              EXTRACT(EPOCH FROM (PART_STAT.LAST_SOURCE_UPDATE_TIMESTAMP)) * 1000 AS CHANGED
         FROM TABLE (qsys2.object_statistics('${library}', '*FILE', '${sourceFile}')) OBJ_STAT,
         LATERAL (SELECT * FROM TABLE (qsys2.PARTITION_STATISTICS(RPAD(OBJ_STAT.OBJLIB, 10), RPAD(OBJ_STAT.OBJNAME, 10)))) PART_STAT
-        ${singleMember ? `WHERE RTRIM(PART_STAT.SYSTEM_TABLE_MEMBER) like '${singleMember}'` : ``}
-        ${singleMemberExtension && singleMemberExtension.trim() !== '%' ? `${singleMember ? `AND` : `WHERE`} RTRIM(CAST(PART_STAT.SOURCE_TYPE AS VARCHAR(10))) like '${singleMemberExtension}'` : ``}
+        WHERE TRIM(PART_STAT.SYSTEM_TABLE_MEMBER) <> ''
+        ${singleMember ? `AND RTRIM(PART_STAT.SYSTEM_TABLE_MEMBER) like '${singleMember}'` : ``}
+        ${singleMemberExtension && singleMemberExtension.trim() !== '%' ? `AND RTRIM(CAST(PART_STAT.SOURCE_TYPE AS VARCHAR(10))) like '${singleMemberExtension}'` : ``}
         ORDER BY ${sort.order === 'name' ? 'NAME' : 'CHANGED'} ${!sort.ascending ? 'DESC' : 'ASC'}`;
 
     const results = await this.ibmi.runSQL(statement);


### PR DESCRIPTION
### Changes
With #3246 the where clause of the query used for members has been changed in order to allow member without extension. With this PR now the query returns only rows with member name.

### How to test this PR
1. Create an empty source file
2. Expand it, if it's empty now you won't see any row (before that you are able to see a . member)

### Checklist
* [x] have tested my change

