### PR TITLE
Add CLPrompter extension integration for library list commands

### DIFF
--- a/src/ui/views/environment/environmentView.ts
+++ b/src/ui/views/environment/environmentView.ts
@@ -337,9 +337,32 @@ export function initializeEnvironmentView(context: vscode.ExtensionContext) {
         const profile = profileItem && ("profile" in profileItem ? profileItem?.profile : profileItem) || getConnectionProfile(config.get);
 
         if (profile?.setLibraryListCommand) {
-          const command = profile.setLibraryListCommand.startsWith(`?`) ?
-            await vscode.window.showInputBox({ title: l10n.t(`Run Library List Command`), value: profile.setLibraryListCommand.substring(1) }) :
-            profile.setLibraryListCommand;
+          let command: string | undefined;
+
+          if (profile.setLibraryListCommand.startsWith(`?`)) {
+            // Command starts with '?' - needs prompting
+            const commandToPrompt = profile.setLibraryListCommand.substring(1);
+
+            // Check if CLPrompter extension is installed
+            const clPrompterExt = vscode.extensions.getExtension('CozziResearch.clprompter');
+            if (clPrompterExt) {
+              // Use CLPrompter for advanced prompting
+              if (!clPrompterExt.isActive) {
+                await clPrompterExt.activate();
+              }
+              const { CLPrompter } = clPrompterExt.exports;
+              command = await CLPrompter(commandToPrompt, context.extensionUri);
+            } else {
+              // Fall back to simple input box
+              command = await vscode.window.showInputBox({
+                title: l10n.t(`Run Library List Command`),
+                value: commandToPrompt
+              });
+            }
+          } else {
+            // No prompting needed
+            command = profile.setLibraryListCommand;
+          }
 
           if (command) {
             return await vscode.window.withProgress({ title: l10n.t("Running {0} profile's Library List Command...", profile.name), location: vscode.ProgressLocation.Notification }, async () => {


### PR DESCRIPTION
- Integrate with CozziResearch.clprompter extension for enhanced CL command prompting
- When library list command starts with '?', use CLPrompter if available
- Gracefully fall back to simple input box if CLPrompter not installed
- Provides better user experience for prompting complex CL commands with parameters

### Changes
<!-- Describe your change here. -->

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [x] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
