### PR TITLE
Add CLPrompter extension integration for library list commands

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -1203,6 +1203,7 @@ export default class IBMiContent {
           if (libraryName !== '1') {
             throw new Error(`Failed to run Library List Command ${command}`);
           }
+          break;
         case 'CURRENT':
           result.currentLibrary = libraryName;
           break;

--- a/src/ui/views/environment/environmentView.ts
+++ b/src/ui/views/environment/environmentView.ts
@@ -320,7 +320,7 @@ export function initializeEnvironmentView(context: vscode.ExtensionContext) {
           vscode.commands.executeCommand(`code-for-ibmi.refreshIFSBrowser`),
           vscode.commands.executeCommand(`code-for-ibmi.refreshObjectBrowser`)
         ]);
-        environmentView.refresh();        
+        environmentView.refresh();
 
         if (profile.name && profile.setLibraryListCommand) {
           await vscode.commands.executeCommand("code-for-ibmi.environment.profile.runLiblistCommand", profile);
@@ -339,9 +339,32 @@ export function initializeEnvironmentView(context: vscode.ExtensionContext) {
         const profile = profileItem && ("profile" in profileItem ? profileItem?.profile : profileItem) || getConnectionProfile(config.get);
 
         if (profile?.setLibraryListCommand) {
-          const command = profile.setLibraryListCommand.startsWith(`?`) ?
-            await vscode.window.showInputBox({ title: l10n.t(`Run Library List Command`), value: profile.setLibraryListCommand.substring(1) }) :
-            profile.setLibraryListCommand;
+          let command: string | undefined;
+
+          if (profile.setLibraryListCommand.startsWith(`?`)) {
+            // Command starts with '?' - needs prompting
+            const commandToPrompt = profile.setLibraryListCommand.substring(1);
+
+            // Check if CLPrompter extension is installed
+            const clPrompterExt = vscode.extensions.getExtension('CozziResearch.clprompter');
+            if (clPrompterExt) {
+              // Use CLPrompter for advanced prompting
+              if (!clPrompterExt.isActive) {
+                await clPrompterExt.activate();
+              }
+              const { CLPrompter } = clPrompterExt.exports;
+              command = await CLPrompter(commandToPrompt, context.extensionUri);
+            } else {
+              // Fall back to simple input box
+              command = await vscode.window.showInputBox({
+                title: l10n.t(`Run Library List Command`),
+                value: commandToPrompt
+              });
+            }
+          } else {
+            // No prompting needed
+            command = profile.setLibraryListCommand;
+          }
 
           if (command) {
             return await vscode.window.withProgress({ title: l10n.t("Running {0} profile's Library List Command...", profile.name), location: vscode.ProgressLocation.Notification }, async () => {

--- a/src/ui/views/environment/environmentView.ts
+++ b/src/ui/views/environment/environmentView.ts
@@ -374,7 +374,7 @@ export function initializeEnvironmentView(context: vscode.ExtensionContext) {
 
                 if (newSettings) {
                   config.libraryList = newSettings.libraryList;
-                  config.currentLibrary = newSettings.currentLibrary;
+                  config.currentLibrary = newSettings.currentLibrary || config.currentLibrary;
                   await IBMi.connectionManager.update(config);
                   await vscode.commands.executeCommand(`code-for-ibmi.refreshLibraryListView`);
                 } else {


### PR DESCRIPTION
When a connection profile's `setLibraryListCommand` starts with `?`, check if the [CLPrompter extension](https://marketplace.visualstudio.com/items?itemName=CozziResearch.clprompter) (`CozziResearch.clprompter`) is installed. If it is, use CLPrompter for advanced IBM i command prompting; otherwise fall back to the existing simple input box.