### PR TITLE
Fix: missing break in getLibraryListFromCommand causes currentLibrary to be set to '1'

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -539,8 +539,8 @@ export default class IBMiContent {
     const localLibrary = this.ibmi.upperCaseName(filters.library);
 
      // Libraries (*LIB) can only be listed from QSYS
-    const isListingLibraries = !!filters?.types?.some(type => type === '*LIB'); 
-     
+    const isListingLibraries = !!filters?.types?.some(type => type === '*LIB');
+
     if (isListingLibraries && localLibrary !== `QSYS`) {
       // Return empty array when trying to list libraries from non-QSYS library
       return [];
@@ -596,7 +596,7 @@ export default class IBMiContent {
     } else if (!withSourceFiles) {
       createOBJLIST = [
         /* sql */
-        `select 
+        `select
           OBJNAME          as NAME,
           OBJTYPE          as TYPE,
           OBJATTRIBUTE     as ATTRIBUTE,
@@ -622,7 +622,7 @@ export default class IBMiContent {
           where PHDTAT = 'S'
         ),
          OBJD as (
-          select 
+          select
             OBJNAME           as NAME,
             OBJTYPE           as TYPE,
             OBJATTRIBUTE      as ATTRIBUTE,
@@ -1162,10 +1162,10 @@ export default class IBMiContent {
 
   /**
    * Returns the signature of an SQL component
-   * @param library 
-   * @param name 
-   * @param type 
-   * @returns 
+   * @param library
+   * @param name
+   * @param type
+   * @returns
    */
   async getSQLRoutineSignature(library: string, name: string, type: "PROCEDURE" | "FUNCTION") {
     return (await this.ibmi.runSQL(
@@ -1175,7 +1175,7 @@ export default class IBMiContent {
 
   async getSHA256FileHash(remoteFile: string) {
 
-    //We use OPENSSL that is already build in inside os   
+    //We use OPENSSL that is already build in inside os
     if (this.ibmi.remoteFeatures.openssl) {
       const objhash = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.openssl} dgst -sha256 ${remoteFile} ` });
       if (objhash.code === 0) {
@@ -1203,6 +1203,7 @@ export default class IBMiContent {
           if (libraryName !== '1') {
             throw new Error(`Failed to run Library List Command ${command}`);
           }
+          break;
         case 'CURRENT':
           result.currentLibrary = libraryName;
           break;

--- a/src/ui/views/environment/environmentView.ts
+++ b/src/ui/views/environment/environmentView.ts
@@ -320,7 +320,7 @@ export function initializeEnvironmentView(context: vscode.ExtensionContext) {
           vscode.commands.executeCommand(`code-for-ibmi.refreshIFSBrowser`),
           vscode.commands.executeCommand(`code-for-ibmi.refreshObjectBrowser`)
         ]);
-        environmentView.refresh();        
+        environmentView.refresh();
 
         if (profile.name && profile.setLibraryListCommand) {
           await vscode.commands.executeCommand("code-for-ibmi.environment.profile.runLiblistCommand", profile);
@@ -351,7 +351,7 @@ export function initializeEnvironmentView(context: vscode.ExtensionContext) {
 
                 if (newSettings) {
                   config.libraryList = newSettings.libraryList;
-                  config.currentLibrary = newSettings.currentLibrary;
+                  config.currentLibrary = newSettings.currentLibrary || config.currentLibrary;
                   await IBMi.connectionManager.update(config);
                   await vscode.commands.executeCommand(`code-for-ibmi.refreshLibraryListView`);
                 } else {


### PR DESCRIPTION
## Problem

Fixes #3295

In `getLibraryListFromCommand()` (`IBMiContent.ts`), the `RESULT` case in the `switch` was missing a `break`, causing fall-through into the `CURRENT` case:

```typescript
case 'RESULT':
  if (libraryName !== '1') {
    throw new Error(...);
  }
  // ← missing break, falls through!
case 'CURRENT':
  result.currentLibrary = libraryName; // gets set to '1'
```

`QSYS2.QCMDEXC` returns `'1'` on success. Without the `break`, `currentLibrary` is set to `'1'` from the RESULT row. Normally the subsequent `CURRENT` row from `QSYS2.QSQLIBL()` overwrites it — but when the `setLibraryListCommand` does not change `*CURLIB` (e.g. `IMPLIBL`), no `CURRENT` row is returned and `currentLibrary` stays as `'1'`, breaking the object browser.

## Fix

1. Add the missing `break` after the `RESULT` case in `IBMiContent.ts`
2. Guard against overwriting `config.currentLibrary` with an empty string in `environmentView.ts` when the command result returns no current library entry