### PR TITLE
Fix EVENTF retrieval and problems display when compiling from an iASP

### DIFF
--- a/src/ui/diagnostics.ts
+++ b/src/ui/diagnostics.ts
@@ -72,7 +72,7 @@ export function refreshDiagnosticsFromServer(connection: IBMi, evfeventInfo: Evf
         await handleEvfeventLines(connection, lines, e);
       }
     }
-    finally{
+    finally {
       connection.getContent().deleteOVRDBFile(overFile);
     }
   });
@@ -109,32 +109,33 @@ export async function handleEvfeventLines(connection: IBMi, lines: string[], evf
 
   const diagnostics: vscode.Diagnostic[] = [];
   if (errorsByFiles.size) {
-    for (const [file, errors] of errorsByFiles.entries()) {
-      diagnostics.length = 0;
-      for (const error of errors) {
-        error.column = Math.max(error.column - 1, 0);
-        error.lineNum = Math.max(error.lineNum - 1, 0);
-        error.toLineNum = Math.max(error.toLineNum - 1, 0);
+    for (const [file, errors] of errorsByFiles) {
+      if (file !== '.') {
+        for (const error of errors) {
+          error.column = Math.max(error.column - 1, 0);
+          error.lineNum = Math.max(error.lineNum - 1, 0);
+          error.toLineNum = Math.max(error.toLineNum - 1, 0);
 
-        if (error.column === 0 && error.toColumn === 0) {
-          error.column = 0;
-          error.toColumn = 100;
-        }
+          if (error.column === 0 && error.toColumn === 0) {
+            error.column = 0;
+            error.toColumn = 100;
+          }
 
-        const diagnostic = new vscode.Diagnostic(
-          new vscode.Range(error.lineNum, error.column, error.toLineNum, error.toColumn),
-          `${error.text} (${error.sev})`,
-          diagnosticSeverity(error)
-        );
+          const diagnostic = new vscode.Diagnostic(
+            new vscode.Range(error.lineNum, error.column, error.toLineNum, error.toColumn),
+            `${error.text} (${error.sev})`,
+            diagnosticSeverity(error)
+          );
 
-        diagnostic.code = error.code;
+          diagnostic.code = error.code;
 
-        if (config) {
-          if (!config.hideCompileErrors.includes(error.code)) {
+          if (config) {
+            if (!config.hideCompileErrors.includes(error.code)) {
+              diagnostics.push(diagnostic);
+            }
+          } else {
             diagnostics.push(diagnostic);
           }
-        } else {
-          diagnostics.push(diagnostic);
         }
       }
 
@@ -186,7 +187,7 @@ export async function handleEvfeventLines(connection: IBMi, lines: string[], evf
       }
       else {
         const asp = await connection.getLibraryIAsp(file.split('/')[0]);
-        const memberUri = VscodeTools.findExistingDocumentUri(vscode.Uri.from({ scheme: `member`, path: `/${asp ? `${asp}/` : '' }${file}${evfeventInfo.extension ? `.` + evfeventInfo.extension : ``}` }));
+        const memberUri = VscodeTools.findExistingDocumentUri(vscode.Uri.from({ scheme: `member`, path: `/${asp ? `${asp}/` : ''}${file}${evfeventInfo.extension ? `.` + evfeventInfo.extension : ``}` }));
         ileDiagnostics.set(memberUri, diagnostics);
       }
     }

--- a/src/ui/diagnostics.ts
+++ b/src/ui/diagnostics.ts
@@ -69,7 +69,7 @@ export function refreshDiagnosticsFromServer(connection: IBMi, evfeventInfo: Evf
         .map(row => String(row.EVFEVENT));
 
       if (lines.length) {
-        handleEvfeventLines(connection, lines, e);
+        await handleEvfeventLines(connection, lines, e);
       }
     }
     finally{
@@ -94,7 +94,7 @@ export async function refreshDiagnosticsFromLocal(connection: IBMi, evfeventInfo
         const eol = content.includes(`\r\n`) ? `\r\n` : `\n`;
         const lines = content.split(eol);
 
-        handleEvfeventLines(connection, lines, evfeventInfo);
+        await handleEvfeventLines(connection, lines, evfeventInfo);
       }
 
     } else {
@@ -103,10 +103,8 @@ export async function refreshDiagnosticsFromLocal(connection: IBMi, evfeventInfo
   }
 }
 
-export function handleEvfeventLines(connection: IBMi, lines: string[], evfeventInfo: EvfEventInfo) {
+export async function handleEvfeventLines(connection: IBMi, lines: string[], evfeventInfo: EvfEventInfo) {
   const config = connection.getConfig();
-  const asp = evfeventInfo.asp ? `${connection.getLibraryIAsp(evfeventInfo.library)}/` : ``;
-
   const errorsByFiles = parseErrors(lines);
 
   const diagnostics: vscode.Diagnostic[] = [];
@@ -151,9 +149,9 @@ export function handleEvfeventLines(connection: IBMi, lines: string[], evfeventI
           let relativeCompilePath = (deployPathIndex !== -1 ? file.substring(0, deployPathIndex) + file.substring(deployPathIndex + workspaceDeployPath.length) : undefined);
 
           if (relativeCompilePath) {
-            if (asp) {
+            if (evfeventInfo.asp) {
               // Believe it or not, sometimes if the deploy directory is symlinked into an ASP, this can be a problem              
-              const aspRoot = `/${asp}`;
+              const aspRoot = `/${evfeventInfo.asp}`;
               if (relativeCompilePath.startsWith(aspRoot)) {
                 relativeCompilePath = relativeCompilePath.substring(aspRoot.length);
                 break;
@@ -187,7 +185,8 @@ export function handleEvfeventLines(connection: IBMi, lines: string[], evfeventI
         ileDiagnostics.set(VscodeTools.findExistingDocumentUri(vscode.Uri.from({ scheme: `streamfile`, path: file })), diagnostics);
       }
       else {
-        const memberUri = VscodeTools.findExistingDocumentUri(vscode.Uri.from({ scheme: `member`, path: `/${asp}${file}${evfeventInfo.extension ? `.` + evfeventInfo.extension : ``}` }));
+        const asp = await connection.getLibraryIAsp(file.split('/')[0]);
+        const memberUri = VscodeTools.findExistingDocumentUri(vscode.Uri.from({ scheme: `member`, path: `/${asp ? `${asp}/` : '' }${file}${evfeventInfo.extension ? `.` + evfeventInfo.extension : ``}` }));
         ileDiagnostics.set(memberUri, diagnostics);
       }
     }


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Fixes #3304
Fixes #3241

The logic used to identify the iasp of source members linked to compilation problems was wrong. On top of that, a Promise was not awaited and concatenated with a string which lead to the wrong path being created - as seen here:
<img width="373" height="52" alt="image" src="https://github.com/user-attachments/assets/bb406fa4-f293-4b4b-abf1-4395091076b0" />

This PR fixes this and also discards the problems returned by the parser for the `.` file.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Use a profile with an iASP
2. Compile a program with errors, using a source member located on this iASP 
3. The problems view should list all the issues for that member
4. Clicking on a problem should focus the right line if the member is opened
5. It should open the correct member and focus on the line if the member was closed  

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change