### PR TITLE
Add support for double-extension action matching

### DIFF
--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -670,9 +670,8 @@ export async function getAllAvailableActions(targets: ActionTarget[], scheme: st
   });
 
   // Then we get all the available Actions for the current context
-  const availableActions: AvailableAction[] = allActions.filter(action => action.type === scheme)
-    .filter(action => !action.extensions || action.extensions.every(e => !e) || targets.every(t => action.extensions!.includes(t.extension) || action.extensions!.includes(t.fragment)) || action.extensions.includes(`GLOBAL`))
-    .filter(action => action.runOnProtected || !targets.some(t => t.protected))
+  const availableActions: AvailableAction[] = allActions
+    .filter(action => isActionAvailable(action, scheme, targets))
     .sort((a, b) => (actionUsed.get(b.name) || 0) - (actionUsed.get(a.name) || 0))
     .map(action => ({
       label: action.name,
@@ -680,6 +679,41 @@ export async function getAllAvailableActions(targets: ActionTarget[], scheme: st
     }));
 
   return availableActions;
+}
+
+export function isActionAvailable(action: Action, scheme: string, targets: ActionTarget[]): boolean {
+  if (action.type !== scheme) return false;
+
+  // action isn't cleared to run on protected targets and some of them are 
+  if (!action.runOnProtected && targets.some(t => t.protected)) return false;
+
+  return targets.every((t) => targetMatchesExtensions(t, action.extensions));
+}
+
+export function targetMatchesExtensions(target: ActionTarget, extensions?: string[]): boolean {
+  // action has no extension requirements, or is global
+  if (!extensions || extensions.every(e => !e) || extensions.includes("GLOBAL")) return true;
+
+  const targetExtParts = [target.extension.toUpperCase(), target.fragment.toUpperCase()];
+
+  for (const e of extensions) {
+    const ext = e.toUpperCase();
+    const extDotCount = ext.split('.').length - 1;
+
+    if (extDotCount === 0) {
+      // match on single extension (myfile.a)
+      if (targetExtParts.includes(ext)) return true; // match
+    } else {
+      // match on multi-part extension (myfile.a.b)
+      const parsed = path.parse(target.uri.path);
+      const targetFile = (parsed.name + parsed.ext).toUpperCase();
+      const targetDotCount = targetFile.split('.').length - 1;
+
+      if ((targetDotCount > extDotCount) && targetFile.endsWith(ext)) return true; // match
+    }
+  }
+
+  return false; // no matches
 }
 
 function getObjectsFromJoblog(stderr: string): CommandObject[] | undefined {

--- a/src/ui/views/environment/actions.ts
+++ b/src/ui/views/environment/actions.ts
@@ -5,7 +5,7 @@ import { instance } from "../../../instantiate";
 import { Action, ActionType } from "../../../typings";
 import { VscodeTools } from "../../Tools";
 import { EnvironmentItem } from "./environmentItem";
-import { uriToActionTarget, isActionAvailable } from "../../actions";
+import { targetMatchesExtensions, uriToActionTarget } from "../../actions";
 
 type ActionContext = {
   canRun?: boolean
@@ -80,15 +80,30 @@ export class ActionsNode extends EnvironmentItem {
 
   async activeEditorChanged(editor?: vscode.TextEditor) {
     const uri = editor?.document.uri;
-
+    let activeEditorContext = undefined;
     let actionTarget = undefined;
+
     if (uri) {
       const connection = instance.getConnection();
       const workspace = vscode.workspace.getWorkspaceFolder(uri);
-      actionTarget = [uriToActionTarget(uri, workspace, connection)];
+
+      actionTarget = uriToActionTarget(uri, workspace, connection);
+
+      activeEditorContext = {
+        scheme: uri.scheme,
+        protected: actionTarget.protected,
+        workspace
+      };
     }
 
-    (await this.getAllActionItems()).forEach(item => item.setContext({ canRun: !!actionTarget && isActionAvailable(item.action, uri?.scheme || "", actionTarget) }));
+    const canRunOnEditor = (actionItem: ActionItem) => activeEditorContext !== undefined &&
+      actionTarget !== undefined &&
+      activeEditorContext.scheme === actionItem.action.type &&
+      activeEditorContext.workspace === actionItem.workspace &&
+      (actionItem.action.runOnProtected || !activeEditorContext.protected) &&
+      targetMatchesExtensions(actionTarget, actionItem.action.extensions);
+
+    (await this.getAllActionItems()).forEach(item => item.setContext({ canRun: canRunOnEditor(item) }));
     this.refresh();
   }
 

--- a/src/ui/views/environment/actions.ts
+++ b/src/ui/views/environment/actions.ts
@@ -1,12 +1,11 @@
-import { parse } from "path";
 import { stringify } from "querystring";
 import vscode, { l10n } from "vscode";
 import { ActionTools } from "../../../api/actions";
-import { parseFSOptions } from "../../../filesystems/qsys/QSysFs";
 import { instance } from "../../../instantiate";
 import { Action, ActionType } from "../../../typings";
 import { VscodeTools } from "../../Tools";
 import { EnvironmentItem } from "./environmentItem";
+import { uriToActionTarget, isActionAvailable } from "../../actions";
 
 type ActionContext = {
   canRun?: boolean
@@ -81,24 +80,15 @@ export class ActionsNode extends EnvironmentItem {
 
   async activeEditorChanged(editor?: vscode.TextEditor) {
     const uri = editor?.document.uri;
-    let activeEditorContext = undefined;
+
+    let actionTarget = undefined;
     if (uri) {
       const connection = instance.getConnection();
-      activeEditorContext = {
-        scheme: uri.scheme,
-        extension: parse(uri.path).ext.substring(1).toLocaleUpperCase(),
-        protected: parseFSOptions(uri).readonly || connection?.getConfig()?.readOnlyMode || connection?.getContent().isProtectedPath(uri.path),
-        workspace: vscode.workspace.getWorkspaceFolder(uri)
-      };
+      const workspace = vscode.workspace.getWorkspaceFolder(uri);
+      actionTarget = [uriToActionTarget(uri, workspace, connection)];
     }
 
-    const canRunOnEditor = (actionItem: ActionItem) => activeEditorContext !== undefined &&
-      activeEditorContext.scheme === actionItem.action.type &&
-      activeEditorContext.workspace === actionItem.workspace &&
-      (actionItem.action.runOnProtected || !activeEditorContext.protected) &&
-      (!actionItem.action.extensions?.length || actionItem.action.extensions.includes('GLOBAL') || actionItem.action.extensions.includes(activeEditorContext.extension));
-
-    (await this.getAllActionItems()).forEach(item => item.setContext({ canRun: canRunOnEditor(item) }));
+    (await this.getAllActionItems()).forEach(item => item.setContext({ canRun: !!actionTarget && isActionAvailable(item.action, uri?.scheme || "", actionTarget) }));
     this.refresh();
   }
 
@@ -163,7 +153,7 @@ export class ActionItem extends EnvironmentItem {
 
     this.iconPath = new vscode.ThemeIcon("github-action", this.context.matched ? new vscode.ThemeColor(ActionItem.matchedColor) : undefined);
     this.description = this.context.matched ? l10n.t("search match") : undefined;
-    this.tooltip = `${ this.action.command }\nExtensions: ${this.action.extensions?.join(`, `)}`;
+    this.tooltip = `${this.action.command}\nExtensions: ${this.action.extensions?.join(`, `)}`;
     this.resourceUri = vscode.Uri.from({
       scheme: ActionItem.context,
       authority: this.action.name,

--- a/src/ui/views/environment/environmentView.ts
+++ b/src/ui/views/environment/environmentView.ts
@@ -9,7 +9,7 @@ import { editAction, isActionEdited } from '../../../editors/actionEditor';
 import { editConnectionProfile, isProfileEdited } from '../../../editors/connectionProfileEditor';
 import { instance } from '../../../instantiate';
 import { Action, ActionEnvironment, BrowserItem, ConnectionProfile, CustomVariable, FocusOptions } from '../../../typings';
-import { uriToActionTarget } from '../../actions';
+import { uriToActionTarget, targetMatchesExtensions } from '../../actions';
 import { ActionItem, Actions, ActionsNode, ActionTypeNode } from './actions';
 import { ConnectionProfiles, ProfileItem, ProfilesNode } from './connectionProfiles';
 import { CustomVariableItem, CustomVariables, CustomVariablesNode } from './customVariables';
@@ -142,7 +142,7 @@ export function initializeEnvironmentView(context: vscode.ExtensionContext) {
         }
 
         const actionTarget = uriToActionTarget(uri);
-        if (action.extensions && !action.extensions.includes('GLOBAL') && !action.extensions.includes(actionTarget.extension) && !action.extensions.includes(actionTarget.fragment)) {
+        if (!targetMatchesExtensions(actionTarget, action.extensions)) {
           vscode.window.showErrorMessage(l10n.t("This action cannot run on a file with the {0} extension.", actionTarget.extension), editActionLabel).then(edit => edit ? editAction() : '');
           return;
         }


### PR DESCRIPTION
Fixes #2741
### Changes
- Added support for actions targeting double extensions such as PGM.RPGLE and PGM.CLLE.

### How to test this PR
1. Create actions for both RPGLE and PGM.RPGLE.
2. Verify that a file such as foo.pgm.rpgle matches the expected action.
3. Verify that existing single-extension actions still work.

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
