### PR TITLE
Fix: add DETAILED_INFO=>'NO' to QSYS2.LIBRARY_INFO table function calls

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -149,7 +149,7 @@ export default class IBMi {
   /**
    * getConfigFile can return pre-defined configuration files,
    * but can lazy load new configuration files as well.
-   * 
+   *
    * This does not load the configuration file from the server,
    * it only returns a ConfigFile instance. You should check the
    * state of the ConfigFile instance to see if it has been loaded,
@@ -288,7 +288,7 @@ export default class IBMi {
       if (connectionObject.useSshAgent) {
         // Determine the SSH agent path based on platform
         let agentPath: string;
-        
+
         if (process.platform === 'win32') {
           // On Windows, use the OpenSSH named pipe
           agentPath = '\\\\.\\pipe\\openssh-ssh-agent';
@@ -301,7 +301,7 @@ export default class IBMi {
           agentPath = process.env.SSH_AUTH_SOCK;
           this.appendOutput(`Using SSH Agent: ${agentPath}\n`);
         }
-        
+
         // Set agent and authentication options
         connectConfig.agent = agentPath;
         connectConfig.agentForward = true;
@@ -361,7 +361,7 @@ export default class IBMi {
       if (this.client.connection) {
         //end: Disconnected by the user
         this.client.connection.once(`end`, onDisconnected);
-        //error/tiemout: connection dropped for some reason (details given in the SSHError type) 
+        //error/tiemout: connection dropped for some reason (details given in the SSHError type)
         this.client.connection.once(`error`, onDisconnected);
         this.client.connection.once(`timeout`, onDisconnected);
       }
@@ -1537,7 +1537,7 @@ export default class IBMi {
     library = this.upperCaseName(library);
     let libraryIASP = this.libraryAsps.get(library);
     if (!libraryIASP) {
-      const [row] = await this.runSQL(`select IASP_NAME from table(QSYS2.LIBRARY_INFO('${library}'));`);
+      const [row] = await this.runSQL(`select IASP_NAME from table(QSYS2.LIBRARY_INFO('${library}', DETAILED_INFO => 'NO'));`);
       libraryIASP = row?.IASP_NAME ? String(row.IASP_NAME) : "*SYSBAS";
       this.libraryAsps.set(library, libraryIASP);
     }
@@ -1579,7 +1579,7 @@ export default class IBMi {
       this.ccsidCache.delete(cacheKey);
     }
 
-    // Call getAttributes to fetch CCSID 
+    // Call getAttributes to fetch CCSID
     const attrs = await this.getContent().getAttributes(lookupPath, 'CCSID');
     const ccsid = Number(attrs?.CCSID) || 0;
 

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -472,7 +472,7 @@ export default class IBMiContent {
           OBJTYPELIST => '*LIB',
           OBJECT_NAME => libs.ELEMENT
         )) AS os
-        CROSS JOIN TABLE(QSYS2.LIBRARY_INFO(library_name => os.OBJNAME)) AS li
+        CROSS JOIN TABLE(QSYS2.LIBRARY_INFO(library_name => os.OBJNAME, DETAILED_INFO => 'NO')) AS li
       `;
     const results = await this.ibmi.runSQL(statement);
 


### PR DESCRIPTION
## Problem

`QSYS2.LIBRARY_INFO` without `DETAILED_INFO => 'NO'` retrieves additional metadata columns that are not needed in either call site. This adds unnecessary overhead on every library lookup.

## Fix

Added `DETAILED_INFO => 'NO'` to both locations where `QSYS2.LIBRARY_INFO` is called:

- **`src/api/IBMi.ts`** — `getLibraryIAsp()`: only `IASP_NAME` is needed
- **`src/api/IBMiContent.ts`** — library list query: only the columns already referenced (`NAME`, `TYPE`, etc.) are needed; detailed info is not used