### PR TITLE
Improvements to IFS Permission Control

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -465,9 +465,9 @@ export default class IBMi {
 
         // Check if permissions need updating
         const needsPermissionUpdate =
-          (homePerms !== 'error' && homePerms !== '750') ||
+          (homePerms !== 'error' && !Tools.checkPermissionsValue(homePerms, 750)) ||
           !vscodeExists ||
-          (vscodeExists && vscodePerms !== 'error' && vscodePerms !== '700');
+          (vscodeExists && vscodePerms !== 'error' && !Tools.checkPermissionsValue(vscodePerms, 700));
 
         if (needsPermissionUpdate && !options.reconnecting) {
           await callbacks.uiErrorHandler(this, `home_directory_permissions`, {

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -465,9 +465,9 @@ export default class IBMi {
 
         // Check if permissions need updating
         const needsPermissionUpdate =
-          (homePerms !== 'error' && !Tools.checkPermissionsValue(homePerms, 750)) ||
+          (homePerms !== 'error' && homePerms !== '750' && homePerms !== '700') ||
           !vscodeExists ||
-          (vscodeExists && vscodePerms !== 'error' && !Tools.checkPermissionsValue(vscodePerms, 700));
+          (vscodeExists && vscodePerms !== 'error' && vscodePerms !== '700');
 
         if (needsPermissionUpdate && !options.reconnecting) {
           await callbacks.uiErrorHandler(this, `home_directory_permissions`, {

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -278,21 +278,4 @@ export namespace Tools {
     }
     return permissions.map(String).join("");
   }
-
-  /**
-   * Checks whether a permission string in octal format is within the allowed
-   * target permission limits.
-   * The expected input is a three-digit octal permission string such as `777`.
-   *
-   * @param permission current permissions as a three-digit octal string
-   * @param target optional target permission value to compare against
-   * @returns `true` if each digit of `permission` is less than or equal to the
-   *          corresponding digit of `target`, otherwise `false`
-   */
-  export function checkPermissionsValue(permission: string, target: number = 750): boolean | undefined {
-    const curPermission = Array.from(permission).map(Number);
-    const curTarget = Array.from(target.toString()).map(Number);
-
-    return curPermission.every((val, i) => val <= curTarget[i]);
-  }
 }

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -278,4 +278,21 @@ export namespace Tools {
     }
     return permissions.map(String).join("");
   }
+
+  /**
+   * Checks whether a permission string in octal format is within the allowed
+   * target permission limits.
+   * The expected input is a three-digit octal permission string such as `777`.
+   *
+   * @param permission current permissions as a three-digit octal string
+   * @param target optional target permission value to compare against
+   * @returns `true` if each digit of `permission` is less than or equal to the
+   *          corresponding digit of `target`, otherwise `false`
+   */
+  export function checkPermissionsValue(permission: string, target: number = 750): boolean | undefined {
+    const curPermission = Array.from(permission).map(Number);
+    const curTarget = Array.from(target.toString()).map(Number);
+
+    return curPermission.every((val, i) => val <= curTarget[i]);
+  }
 }

--- a/src/ui/connection.ts
+++ b/src/ui/connection.ts
@@ -67,7 +67,7 @@ export async function handleConnectionResults(connection: IBMi, error: Connectio
       let message = `Security recommendation: Update directory permissions?\n\n`;
       let needsUpdate = false;
       
-      if (homePerms && homePerms !== '750') {
+      if (homePerms && homePerms !== '750' && homePerms !== '700') {
         message += `• Home directory (${homeDir}) has permissions ${homePerms}, recommended: 750\n`;
         needsUpdate = true;
       }


### PR DESCRIPTION
### Changes
This PR introduces a dynamic mechanism for controlling IFS permissions.

### How to test this PR

If you connect to a system with a home directory set to 700 permissions, you will no longer receive warnings about incorrect permissions.

### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)

Closes #3316