### PR TITLE
Managing Actions by Name or Usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -405,6 +405,19 @@
 					],
 					"description": "Determine which view should be shown when running Actions"
 				},
+				"code-for-ibmi.sortActionsBy": {
+					"type": "string",
+					"default": "usage",
+					"enum": [
+						"usage",
+						"name"
+					],
+					"enumDescriptions": [
+						"Sort actions by most recently used",
+						"Sort actions alphabetically by name"
+					],
+					"description": "Determine how actions should be sorted in the action selection menu"
+				},
 				"code-for-ibmi.clearErrorsBeforeBuild": {
 					"type": "boolean",
 					"default": true,

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -669,11 +669,22 @@ export async function getAllAvailableActions(targets: ActionTarget[], scheme: st
     };
   });
 
+  // Get the sort preference from settings
+  const sortBy = IBMi.connectionManager.get<string>(`sortActionsBy`) || `usage`;
+
   // Then we get all the available Actions for the current context
   const availableActions: AvailableAction[] = allActions.filter(action => action.type === scheme)
     .filter(action => !action.extensions || action.extensions.every(e => !e) || targets.every(t => action.extensions!.includes(t.extension) || action.extensions!.includes(t.fragment)) || action.extensions.includes(`GLOBAL`))
     .filter(action => action.runOnProtected || !targets.some(t => t.protected))
-    .sort((a, b) => (actionUsed.get(b.name) || 0) - (actionUsed.get(a.name) || 0))
+    .sort((a, b) => {
+      if (sortBy === `name`) {
+        // Sort alphabetically by name
+        return a.name.localeCompare(b.name);
+      } else {
+        // Sort by most recently used (default behavior)
+        return (actionUsed.get(b.name) || 0) - (actionUsed.get(a.name) || 0);
+      }
+    })
     .map(action => ({
       label: action.name,
       action


### PR DESCRIPTION
### Changes
With this PR, you'll be able to choose whether to display actions in alphabetical order or based on most recent use

### How to test this PR
Open the VS Code settings and select “Code-for-ibmi: Sort Actions By,” then set it to “name.”
Execute a command that isn't the first one in the list of actions; if you reopen that menu now, you'll see that the actions remain in alphabetical order.

<img width="620" height="99" alt="image" src="https://github.com/user-attachments/assets/1aa135bb-0538-4d13-84ea-c94e90362baa" />


### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)

Closes #3309
