### PR TITLE
Added Mapepire settings to settings shema

### DIFF
--- a/package.json
+++ b/package.json
@@ -391,6 +391,23 @@
 									"21"
 								],
 								"description": "The Java version used to run Mapepire."
+							},
+							"mapepireUseServer": {
+								"type": "boolean",
+								"default": false,
+								"description": "Connect to a remote Mapepire Server over HTTPS instead of running it in single mode."
+							},
+							"mapepireServerPort": {
+								"type": "number",
+								"default": 8076,
+								"maximum": 65535,
+								"minimum": 1,
+								"description": "Remote Mapepire Server port."
+							},
+							"mapepireAllowSelfCert": {
+								"type": "boolean",
+								"default": false,
+								"description": "Allow all self-signed certificates or certificates from a CA when connecting to Mapepire."
 							}
 						}
 					}

--- a/schemas/settings.json
+++ b/schemas/settings.json
@@ -142,6 +142,23 @@
             "21"
           ],
           "description": "The Java version used to run Mapepire."
+        },
+        "mapepireUseServer": {
+          "type": "boolean",
+          "default": false,
+          "description": "Connect to a remote Mapepire Server over HTTPS instead of running it in single mode."
+        },
+        "mapepireServerPort": {
+          "type": "number",
+          "default": 8076,
+          "maximum": 65535,
+          "minimum": 1,
+          "description": "Remote Mapepire Server port."
+        },
+        "mapepireAllowSelfCert": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow all self-signed certificates or certificates from a CA when connecting to Mapepire."
         }
       }
     },


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
This PR adds the JSON schema definitions for Mapepire settings recently added to the connection settings.

<img width="875" height="369" alt="image" src="https://github.com/user-attachments/assets/7d3efef8-e7e0-496f-a2fb-826674ce2ee0" />

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Open a remote `/etc/vscode/settings.json` file
2. Mapepire settings must show up in the content assist

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change