### PR TITLE
feat: expose getSystemVersion() in CodeForIBMi public API

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -153,7 +153,8 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
     actionTools: ActionTools,
     componentRegistry: extensionComponentRegistry,
     connectionManager: IBMi.connectionManager,
-    searchTools: SearchTools
+    searchTools: SearchTools,
+    getSystemVersion: () => instance.getConnection()?.getSystemVersion(),
   };
 }
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -21,7 +21,8 @@ export interface CodeForIBMi {
   actionTools: typeof ActionTools,
   componentRegistry: ComponentRegistry,
   connectionManager: ConnectionManager,
-  searchTools: typeof SearchTools
+  searchTools: typeof SearchTools,
+  getSystemVersion: () => number | undefined,
 }
 
 export interface DeploymentParameters {


### PR DESCRIPTION
## Summary

Exposes `getSystemVersion()` as a first-class member of the `CodeForIBMi` public API interface, allowing consumer extensions (e.g. `vscode-db2i`) to retrieve the IBM i OS version without accessing internal implementation details.

## Changes

- **`src/typings.ts`** — Added `getSystemVersion: () => number | undefined` to the `CodeForIBMi` interface
- **`src/extension.ts`** — Wired up the implementation in the `activate()` return object via `instance.getConnection()?.getSystemVersion()`

## Usage (from a consumer extension)

```typescript
const api = vscode.extensions.getExtension<CodeForIBMi>('halcyontechltd.code-for-ibmi')?.exports;
const version = api?.getSystemVersion(); // e.g. 7.5
```

Returns `undefined` if no connection is active, consistent with other connection-dependent API members.