### PR TITLE
Fix Mapepire NotInstalled detection when no remote jars are found

### DIFF
--- a/src/api/components/mapepire/index.ts
+++ b/src/api/components/mapepire/index.ts
@@ -53,7 +53,7 @@ export class Mapepire implements IBMiComponent {
       .map(line => new RegExp(`${SERVER_FILE_PREFIX}(\\d+)\\.(\\d+)\\.(\\d+)\\.jar$`).exec(line))
       .filter(Boolean)
       .map(version => ({ major: Number(version![1]), minor: Number(version![2]), patch: Number(version![3]) } as SemanticVersion));
-    if (!remoteVersions) {
+    if (remoteVersions.length === 0) {
       return { status: "NotInstalled" };
     }
     else if (remoteVersions.every(remoteVersion => remoteVersion.major < this.version.major || (remoteVersion.major === this.version.major && remoteVersion.minor < this.version.minor) || (remoteVersion.major === this.version.major && remoteVersion.minor === this.version.minor && remoteVersion.patch < this.version.patch))) {


### PR DESCRIPTION
## Summary
Fixes Mapepire remote state detection when no remote server JARs exist.

## Problem
`remoteVersions` is always an array. The previous check used `if (!remoteVersions)`, which never evaluates to true, so the no-results case could not be classified as `NotInstalled`.

## Change
- In `src/api/components/mapepire/index.ts`, changed:
  - `if (!remoteVersions)`
  - to `if (remoteVersions.length === 0)`

## Impact
- Correctly reports `NotInstalled` when no matching remote Mapepire JARs are present.
- No behavior changes for `NeedsUpdate` or `Installed` paths.

## Validation
- TypeScript diagnostics for `src/api/components/mapepire/index.ts`: no errors.
