### PR TITLE
Use node's SHA256 to hash routines body and add 1 minute cooldown between components check

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { parse } from 'csv-parse/sync';
 import fs from 'fs';
 import * as node_ssh from "node-ssh";
@@ -538,7 +539,7 @@ export default class IBMiContent {
   async getObjectList(filters: { library: string; object?: string; types?: string[]; filterType?: FilterType }, sortOrder?: SortOrder): Promise<IBMiObject[]> {
     const localLibrary = this.ibmi.upperCaseName(filters.library);
 
-     // Libraries (*LIB) can only be listed from QSYS
+    // Libraries (*LIB) can only be listed from QSYS
     const isListingLibraries = !!filters?.types?.some(type => type === '*LIB');
 
     if (isListingLibraries && localLibrary !== `QSYS`) {
@@ -1165,16 +1166,27 @@ export default class IBMiContent {
    * @param library
    * @param name
    * @param type
-   * @returns
+   * 
+   * @returns the routine program if it's external, the sha256 hash of the routine's body otherwise
    */
   async getSQLRoutineSignature(library: string, name: string, type: "PROCEDURE" | "FUNCTION") {
-    return (await this.ibmi.runSQL(
-      /* sql */`select HASH_SHA256(ROUTINEDEF) SIGNATURE from qsys2.sysroutines where routine_type = '${type}' and rtnschema = '${library}' and RTNNAME = '${name}' fetch first row only`
-    )).at(0)?.SIGNATURE as string;
+    const [row] = await this.ibmi.runSQL(/* sql */`
+      select ROUTINE_BODY, EXTERNAL_NAME, ROUTINEDEF
+      from QSYS2.SYSROUTINES
+      where ROUTINE_TYPE = '${type}' and
+            RTNSCHEMA = '${library}' and
+            RTNNAME = '${name}'
+      fetch first row only`
+    );
+    if (row?.ROUTINE_BODY === "EXTERNAL") {
+      return row.EXTERNAL_NAME as string
+    }
+    else if (row?.ROUTINEDEF) {
+      return crypto.createHash('sha256').update(row.ROUTINEDEF as string).digest('hex').toUpperCase();
+    }
   }
 
   async getSHA256FileHash(remoteFile: string) {
-
     //We use OPENSSL that is already build in inside os
     if (this.ibmi.remoteFeatures.openssl) {
       const objhash = await this.ibmi.sendCommand({ command: `${this.ibmi.remoteFeatures.openssl} dgst -sha256 ${remoteFile} ` });

--- a/src/api/components/manager.ts
+++ b/src/api/components/manager.ts
@@ -61,6 +61,7 @@ export const extensionComponentRegistry = new ComponentRegistry();
 
 export class ComponentManager {
   private readonly registered: IBMiComponentRuntime[] = [];
+  private readonly statesCheckTimeout = new Map<string, Date>();
 
   constructor(private readonly connection: IBMi) { }
 
@@ -187,7 +188,7 @@ export class ComponentManager {
   async get<T extends IBMiComponent>(id: string, options: ComponentSearchProps = {}): Promise<T | undefined> {
     const componentEngine = this.registered.find(c => c.component.getIdentification().name === id);
     if (componentEngine && (options.ignoreState || componentEngine.getState().status === `Installed`)) {
-      if (componentEngine.getState().status === `Installed`) {
+      if (componentEngine.getState().status === `Installed` && this.mustCheck(id)) {
         const currentState = await componentEngine.getCurrentState();
         if (currentState.remoteSignature !== componentEngine.getState().remoteSignature) {
           const identification = componentEngine.component.getIdentification();
@@ -196,6 +197,16 @@ export class ComponentManager {
       }
       return componentEngine.component as T;
     }
+  }
+
+  private mustCheck(id:string){
+    const checkDate = this.statesCheckTimeout.get(id);
+    if(!checkDate || checkDate.valueOf() + 60000 < new Date().valueOf() ){
+      //never checked or checked less than one minute ago
+      this.statesCheckTimeout.set(id, new Date())
+      return true;
+    }
+    return false;
   }
 }
 


### PR DESCRIPTION
, ### Changes
<!-- Describe your change here. -->
The Db2 for i `HASH_SHA256` built-in function is not available on 7.3.
Therefor, the ValidateStatement SQL function from Db2 for i isn't checked on 7.3 but can still be used, unsecurely. 

This PR enhance the `getSQLRoutineSignature` method to fix that:
- The method will now return the routine's external program for an external routine
- It will return the routine's body hashed locally using node's crypto sha256 algorithm

It also adds a one minute cooldown between two component's state check to reduce the workload for some component that were checked every seconde or (like Db2 syntax checker).

NB: once this is released, Db2 extension will have to be updated and released right after with the new SHA256 hash as the result from the local hash differs from remote's.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change