### PR TITLE
Use a single method to get or prompt for connection's password

### DIFF
--- a/src/commands/password.ts
+++ b/src/commands/password.ts
@@ -2,6 +2,7 @@ import { commands, Disposable, ExtensionContext, extensions, l10n, ProgressLocat
 import Instance from "../Instance";
 import { Password } from "../api/password";
 import { getStoredPassword, setStoredPassword } from "../config/passwords";
+import { getPassword } from "../extension";
 import { CustomUI } from "../webviews/CustomUI";
 
 const access: {
@@ -35,7 +36,7 @@ export function registerPasswordCommands(context: ExtensionContext, instance: In
     commands.registerCommand(`code-for-ibmi.getPassword.disable`, () => {
       access.enabled = false;
     }),
-    commands.registerCommand(`code-for-ibmi.getPassword`, async (extensionId: string, reason?: string) => {
+    commands.registerCommand(`code-for-ibmi.getPassword`, async (extensionId: string, reason?: string, prompt?:string) => {
       if (access.enabled && extensionId) {
         const extension = extensions.getExtension(extensionId);
         const isValid = (extension && extension.isActive);
@@ -51,7 +52,7 @@ export function registerPasswordCommands(context: ExtensionContext, instance: In
               throw new Error(`Password request denied for extension ${displayName}.`);
             }
 
-            const storedPassword = await getStoredPassword(context, instance.getConnection()!.currentConnectionName);
+            const storedPassword = await getPassword(instance.getConnection()!, prompt || `IBM i password requeted by ${displayName}`);
 
             if (storedPassword) {
               let isAuthed = storage.getExtensionAuthorisation(extension.id) !== undefined;

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { ILELibrarySettings } from "../api/CompileTools";
 import { getDebugServiceDetails, ORIGINAL_DEBUG_CONFIG_FILE, resetDebugServiceDetails } from "../api/configuration/DebugConfiguration";
 import IBMi from "../api/IBMi";
-import { getStoredPassword } from "../config/passwords";
+import { clearPassword, getPassword } from "../extension";
 import { Env, getEnvConfig } from "../filesystems/local/env";
 import { instance } from "../instantiate";
 import { ObjectItem } from "../typings";
@@ -52,7 +52,7 @@ export async function initialize(context: ExtensionContext) {
       if (connection) {
         const config = connection.getConfig();
         if (connection.remoteFeatures[`startDebugService.sh`]) {
-          const password = await getPassword();
+          const password = await getPassword(connection, `Password for user profile ${connection.currentUser} is required to debug. Password is not stored on device, but is stored temporarily for this connection.`);
 
           const libraries: ILELibrarySettings = {
             currentLibrary: config?.currentLibrary,
@@ -172,28 +172,6 @@ export async function initialize(context: ExtensionContext) {
     }
 
     return qualifiedPath;
-  }
-
-  const getPassword = async () => {
-    const connection = instance.getConnection();
-
-    let password = await getStoredPassword(context, connection!.currentConnectionName);
-
-    if (!password) {
-      password = temporaryPassword;
-    }
-
-    if (!password) {
-      password = await vscode.window.showInputBox({
-        password: true,
-        prompt: `Password for user profile ${connection!.currentUser} is required to debug. Password is not stored on device, but is stored temporarily for this connection.`
-      });
-
-      // Store for later
-      temporaryPassword = password;
-    }
-
-    return password;
   }
 
   const validateWorkspaceFolder = (maybeFolder?: vscode.WorkspaceFolder) => {
@@ -382,7 +360,7 @@ export async function startDebug(instance: Instance, options: DebugOptions) {
   const port = config?.debugPort;
   const updateProductionFiles = config?.debugUpdateProductionFiles;
   const enableDebugTracing = config?.debugEnableDebugTracing;
-  const debugIgnoreCertificateErrors= config?.debugIgnoreCertificateErrors;
+  const debugIgnoreCertificateErrors = config?.debugIgnoreCertificateErrors;
 
   let secure = true;
 
@@ -447,10 +425,8 @@ export async function startDebug(instance: Instance, options: DebugOptions) {
 
       if (debugResult) {
         connectionConfirmed = true;
-      } else {
-        if (!connectionConfirmed) {
-          temporaryPassword = undefined;
-        }
+      } else if (!connectionConfirmed) {
+        clearPassword();
       }
     }
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,10 @@ import { initializeSandbox, sandboxURIHandler } from "./uri/handlers/sandbox";
 import { CustomUI } from "./webviews/CustomUI";
 import { SettingsUI } from "./webviews/settings";
 
+let temporaryPassword: string | undefined;
+export let getPassword: (connection: IBMi, prompt: string) => Promise<string | undefined>;
+export const clearPassword = () => temporaryPassword = undefined;
+
 export async function activate(context: ExtensionContext): Promise<CodeForIBMi> {
   // Use the console to output diagnostic information (console.log) and errors (console.error)
   // This line of code will only be executed once when your extension is activated
@@ -125,12 +129,23 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
       commands.executeCommand("code-for-ibmi.environment.refresh");
     });
 
+  getPassword = async (connection, prompt) => {
+    let password = temporaryPassword ?? await getStoredPassword(context, connection.currentConnectionName);
+
+    if (password) {
+      return password;
+    }
+  
+    return temporaryPassword = await window.showInputBox({
+      password: true,
+      prompt
+    });
+  }
+
+  instance.subscribe(context, "disconnected", "Clear temporary password", clearPassword);
+
   const mapepire = new Mapepire(path.join(context.extensionPath, `dist`), async (connection) => {
-    return await getStoredPassword(context, connection.currentConnectionName) ||
-      await window.showInputBox({
-        password: true,
-        prompt: l10n.t(`Password for user profile {0} on {1} is required to connect to Mapepire Server.`, connection.currentUser, connection.currentConnectionName)
-      });
+    return await getPassword(connection, l10n.t(`Password for user profile {0} on {1} is required to connect to Mapepire Server.`, connection.currentUser, connection.currentConnectionName));
   });
   extensionComponentRegistry.registerComponent(context, mapepire);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,6 +44,7 @@ import { SettingsUI } from "./webviews/settings";
 
 let temporaryPassword: string | undefined;
 export let getPassword: (connection: IBMi, prompt: string) => Promise<string | undefined>;
+export const setTemporaryPassword = (password:string) => temporaryPassword = password;
 export const clearPassword = () => temporaryPassword = undefined;
 
 export async function activate(context: ExtensionContext): Promise<CodeForIBMi> {

--- a/src/webviews/login/index.ts
+++ b/src/webviews/login/index.ts
@@ -1,7 +1,8 @@
 import vscode, { l10n, ThemeIcon } from "vscode";
 import IBMi from "../../api/IBMi";
 import { Tools } from "../../api/Tools";
-import { deleteStoredPassword, deleteStoredPassphrase, getStoredPassphrase, getStoredPassword, setStoredPassphrase, setStoredPassword } from "../../config/passwords";
+import { deleteStoredPassphrase, deleteStoredPassword, getStoredPassphrase, getStoredPassword, setStoredPassphrase, setStoredPassword } from "../../config/passwords";
+import { setTemporaryPassword } from "../../extension";
 import { instance, safeDisconnect } from "../../instantiate";
 import { ConnectionData } from '../../typings';
 import { CustomUI, Section } from "../CustomUI";
@@ -228,6 +229,7 @@ async function promptPassword(connection: ConnectionData) {
       savePassword = true;
     }
     connection.password = passwordBox.value;
+    setTemporaryPassword(passwordBox.value);
     passwordBox.dispose();
   };
   passwordBox.onDidTriggerButton(onClose);


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Resolves #3327 

This PR provides a single internal method to retrieve the connection stored password or prompt and temporary store it for the duration of the connection if there's no stored password.

This avoids prompting multiple times for the password in case it's not stored or if the connection uses a private key or an SSH agent.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Update connection settings to connect to a Mapepire server
2. Connect using a private key
3. A prompt to provide the password for Mapepire should show up once
4. The connection must succeed
5. Db2 for i connection should not prompt for a password
6. Starting another Db2 for i DB job should not prompt for a password

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change