### PR TITLE
Fix confirmation message for multiple downloads

### DIFF
--- a/src/ui/views/ifsBrowser.ts
+++ b/src/ui/views/ifsBrowser.ts
@@ -939,8 +939,7 @@ Please type "{0}" to confirm deletion.`, dirName);
                   }
                   else {
                     if (!existsSync(target) || await vscode.window.showWarningMessage(l10n.t(`{0} already exists.
-Do you want to replace it?`, target), { modal: true }, l10n.t(`{0} already exists.
-Do you want to replace it?`, target))) {
+Do you want to replace it?`, target), { modal: true }, l10n.t(`Yes`))) {
                       await ibmi.getContent().downloadFile(target, targetPath);
                     }
                   }


### PR DESCRIPTION
### Changes
With this PR, the modal for confirming file overwrites in multiple downloads has now been fixed. Before this fix, the entire message was displayed in the confirmation button 

### How to test this PR
1. Connect to an IBM i, open the IFS Browser.
2. Go to an IFS folder containing at least 2 files (streamfiles).
3. Select two or more files using Ctrl/Shift+click.
4. Right-click → Download, then choose a local destination folder.
5. Let the download complete (those files now exist locally in the folder you chose).
6. Repeat steps 3–4 by selecting the same files again and choosing the same destination folder. Now you'll have a modal with YES

### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
