### PR TITLE
Moved frontend from FS extension and added Joblog command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@ibm/ibmi-eventf-parser": "2.0.2",
 				"@ibm/mapepire-js": "0.6.1",
 				"@vscode-elements/elements": "2.5.1",
+				"@vscode/codicons": "0.0.45",
 				"adm-zip": "0.5.16",
 				"crc-32": "https://cdn.sheetjs.com/crc-32-latest/crc-32-latest.tgz",
 				"csv": "6.4.1",
@@ -2070,8 +2071,7 @@
 			"version": "0.0.45",
 			"resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45.tgz",
 			"integrity": "sha512-1KAZ7XCMagp5Gdrlr4bbbcAqgcIL623iO1wW6rfcSVGAVUQvR0WP7bQx1SbJ11gmV3fdQTSEFIJQ/5C+HuVasw==",
-			"license": "CC-BY-4.0",
-			"peer": true
+			"license": "CC-BY-4.0"
 		},
 		"node_modules/@vscode/vsce": {
 			"version": "3.9.1",

--- a/package.json
+++ b/package.json
@@ -3401,6 +3401,7 @@
 		"@ibm/ibmi-eventf-parser": "2.0.2",
 		"@ibm/mapepire-js": "0.6.1",
 		"@vscode-elements/elements": "2.5.1",
+		"@vscode/codicons": "0.0.45",
 		"adm-zip": "0.5.16",
 		"crc-32": "https://cdn.sheetjs.com/crc-32-latest/crc-32-latest.tgz",
 		"csv": "6.4.1",

--- a/package.json
+++ b/package.json
@@ -1067,6 +1067,12 @@
 				"category": "IBM i"
 			},
 			{
+				"command": "code-for-ibmi.showJobLog",
+				"enablement": "code-for-ibmi:connected",
+				"title": "Display Job Log",
+				"category": "IBM i"
+			},
+			{
 				"command": "code-for-ibmi.launchTerminalPicker",
 				"enablement": "code-for-ibmi:connected && !code-for-ibmi:isSystemReadonly",
 				"title": "Launch Terminal Picker",
@@ -2231,6 +2237,10 @@
 				},
 				{
 					"command": "code-for-ibmi.showAdditionalSettings",
+					"when": "code-for-ibmi:connected"
+				},
+				{
+					"command": "code-for-ibmi.showJobLog",
 					"when": "code-for-ibmi:connected"
 				},
 				{

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import { mergeCommandProfiles } from "./mergeProfiles";
 import { initialise } from "./testing";
 import { CodeForIBMi } from "./typings";
 import { VscodeTools } from "./ui/Tools";
+import { FrontendTables } from "./ui/frontendTables";
 import { registerActionTools } from "./ui/actions";
 import { initializeConnectionBrowser } from "./ui/views/ConnectionBrowser";
 import { initializeLibraryListView } from "./ui/views/LibraryListView";
@@ -41,6 +42,7 @@ import { openURIHandler } from "./uri/handlers/open";
 import { initializeSandbox, sandboxURIHandler } from "./uri/handlers/sandbox";
 import { CustomUI } from "./webviews/CustomUI";
 import { SettingsUI } from "./webviews/settings";
+import { JobLogUI } from "./webviews/wrkjob";
 
 let temporaryPassword: string | undefined;
 export let getPassword: (connection: IBMi, prompt: string) => Promise<string | undefined>;
@@ -69,6 +71,7 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
   };
 
   SettingsUI.init(context);
+  JobLogUI.init(context);
   initializeConnectionBrowser(context);
   initializeObjectBrowser(context)
   initializeIFSBrowser(context);
@@ -165,6 +168,7 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
     customEditor: (target, onSave, onClosed) => new CustomEditor(target, onSave, onClosed),
     evfeventParser: parseErrors,
     tools: VscodeTools,
+    frontendTables: FrontendTables,
     deployTools: DeployTools,
     actionTools: ActionTools,
     componentRegistry: extensionComponentRegistry,

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -8,6 +8,7 @@ import { CustomEditor } from "./editors/customEditorProvider";
 import { DeployTools } from "./filesystems/local/deployTools";
 import { ActionTools } from "./api/actions";
 import { VscodeTools } from "./ui/Tools";
+import { FrontendTables } from "./ui/frontendTables";
 import { SearchTools } from "./api/SearchTools";
 import { CustomUI } from "./webviews/CustomUI";
 
@@ -17,6 +18,7 @@ export interface CodeForIBMi {
   customEditor: <T>(target: string, onSave: (data: T) => Promise<void>, onClosed?: () => void) => CustomEditor<T>,
   evfeventParser: (lines: string[]) => Map<string, FileError[]>,
   tools: typeof VscodeTools,
+  frontendTables: typeof FrontendTables,
   deployTools: typeof DeployTools,
   actionTools: typeof ActionTools,
   componentRegistry: ComponentRegistry,

--- a/src/ui/frontendTables.ts
+++ b/src/ui/frontendTables.ts
@@ -1,0 +1,1043 @@
+import * as vscode from 'vscode';
+
+export namespace FrontendTables {
+
+  const EMPTY_VALUE_PLACEHOLDER = '<span style="color: var(--vscode-descriptionForeground); font-style: italic;">—</span>';
+
+  /** Escape a value for safe interpolation into the generated HTML. */
+  function escapeHtml(text: string | number): string {
+    if (text === 0) return '0';
+    if (text === null || text === undefined || text === '') return '-';
+    const str = String(text);
+    if (str === 'null' || str === 'undefined' || str.trim() === '') return '-';
+    const map: { [key: string]: string } = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#039;'
+    };
+    return str.replace(/[&<>"']/g, m => map[m]);
+  }
+
+  /** Renders YES/NO as colored badges and integers with locale formatting; undefined if the value is neither. */
+  function formatYesNoOrNumber(strValue: string, skipNumeric: boolean): string | undefined {
+    if (strValue === 'YES') {
+      return '<span style="color: var(--vscode-testing-iconPassed, #73c991); font-weight: 600;">✓ YES</span>';
+    }
+    if (strValue === 'NO') {
+      return '<span style="color: var(--vscode-testing-iconFailed, #f48771); font-weight: 600;">✗ NO</span>';
+    }
+    if (!skipNumeric && !isNaN(Number(strValue)) && strValue !== '') {
+      const num = Number(strValue);
+      if (Number.isInteger(num)) {
+        return `<span style="font-family: var(--vscode-editor-font-family); color: var(--vscode-charts-blue);">${num.toLocaleString()}</span>`;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Column definition for FastTable
+   */
+  export interface FastTableColumn<T> {
+    /** Column title in header */
+    title: string;
+    /** Function to extract value from row */
+    getValue: (row: T) => string | number;
+    /** Column width - supports: "100px", "20%", "1fr", "2fr", "auto", "minmax(100px, 1fr)" */
+    width?: string;
+    /** Custom CSS class for cells (optional) */
+    cellClass?: string;
+    /** If true, this column will be collapsible (hidden by default, shown in code format when expanded) */
+    collapsible?: boolean;
+    /** If true, shows the column title in the table header even when collapsible (default: false) */
+    showTitle?: boolean;
+  }
+
+  /**
+   * Options for generating a FastTable
+   */
+  export interface FastTableOptions<T> {
+    /** Page title */
+    title: string;
+    /** Subtitle or additional info (optional) */
+    subtitle?: string;
+    /** Table columns */
+    columns: FastTableColumn<T>[];
+    /** Data to display */
+    data: T[];
+    /** Sticky header (default: true) */
+    stickyHeader?: boolean;
+    /** Message when no data (optional) */
+    emptyMessage?: string;
+    /** Additional custom CSS (optional) */
+    customStyles?: string;
+    /** Custom JavaScript (optional) */
+    customScript?: string;
+    /** Enable search bar (default: false) */
+    enableSearch?: boolean;
+    /** Search placeholder text (optional) */
+    searchPlaceholder?: string;
+    /** Enable pagination (default: false) */
+    enablePagination?: boolean;
+    /** Items per page (default: 50) */
+    itemsPerPage?: number;
+    /** Total items count (for server-side pagination) */
+    totalItems?: number;
+    /** Current page (for server-side pagination, default: 1) */
+    currentPage?: number;
+    /** Current search term (for server-side search) */
+    searchTerm?: string;
+    /** Table identifier for multi-table documents (e.g., SaveFile with objects/members/spools) */
+    tableId?: string;
+  }
+
+  /**
+   * Options for generating a detail table (key-value pairs)
+   */
+  export interface DetailTableOptions {
+    /** Page title */
+    title?: string;
+    /** Subtitle or additional info (optional) */
+    subtitle?: string;
+    /** Column definitions (keys and labels) */
+    columns: Map<string, string>;
+    /** Data object to display */
+    data: any;
+    /** Array of column names to format as code (optional) */
+    codeColumns?: string[];
+    /** Additional custom CSS (optional) */
+    customStyles?: string;
+    /** Custom JavaScript (optional) */
+    customScript?: string;
+    /** Show action buttons (optional) */
+    actions?: DetailTableAction[];
+    /** Hide fields with null values (optional, default: false) */
+    hideNullValues?: boolean;
+  }
+
+  /**
+   * Action button configuration for detail tables
+   */
+  export interface DetailTableAction {
+    /** Button label */
+    label: string;
+    /** Action identifier */
+    action: string;
+    /** Button appearance (primary, secondary, etc.) */
+    appearance?: string;
+    /** Custom CSS style */
+    style?: string;
+  }
+
+  /**
+   * Generate an enhanced detail table (key-value pairs) using Fast components
+   * This is a modern replacement for generateTableHtml and generateTableHtmlCode
+   * @param options - Detail table configuration options
+   * @returns Complete HTML page string
+   */
+  export function generateDetailTable(options: DetailTableOptions): string {
+    const {
+      title = '',
+      subtitle = '',
+      columns,
+      data,
+      codeColumns = [],
+      customStyles = '',
+      customScript = '',
+      actions = [],
+      hideNullValues = false
+    } = options;
+
+    // Format value with icons and styling
+    const formatValue = (value: any, isCodeColumn: boolean): string => {
+      if (value === null || value === undefined || value.toString().trim() === '') {
+        return EMPTY_VALUE_PLACEHOLDER;
+      }
+
+      const strValue = String(value).trim();
+
+      const commonFormat = formatYesNoOrNumber(strValue, isCodeColumn);
+      if (commonFormat) return commonFormat;
+
+      // Handle code columns
+      if (isCodeColumn) {
+        return `<code style="background: var(--vscode-textCodeBlock-background); padding: 4px 8px; border-radius: 4px; font-family: var(--vscode-editor-font-family); border: 1px solid var(--vscode-panel-border); display: block; width: 100%; white-space: pre-wrap; word-break: break-all; overflow-wrap: break-word; box-sizing: border-box;">${escapeHtml(value)}</code>`;
+      }
+
+      return escapeHtml(value);
+    };
+
+    // Generate table rows
+    const rows: string[] = [];
+    columns.forEach((label, key) => {
+      if (key in data[0]) {
+        let value = data[0][key as keyof typeof data];
+
+        // Skip null/undefined/empty values if hideNullValues is enabled
+        if (hideNullValues && (value === null || value === undefined || value.toString().trim() === '')) {
+          return;
+        }
+
+        const displayValue = formatValue(value, codeColumns.includes(key));
+
+        rows.push(`
+        <vscode-table-row>
+          <vscode-table-cell style="font-weight: 600; color: var(--vscode-descriptionForeground);">${escapeHtml(label)}</vscode-table-cell>
+          <vscode-table-cell>${displayValue}</vscode-table-cell>
+        </vscode-table-row>`);
+      }
+    });
+
+    // Generate action buttons as raw vscode-button markup (click handling is wired up
+    // by the webview's own footer script via a `[href^="action:"]` selector).
+    const actionButtons = actions.map((action, index) => {
+      const marginTop = index === 0 ? '0' : '10px';
+      const appearance = action.appearance || 'primary';
+      return `<vscode-button appearance="${appearance}" style="width: 100%; text-align: center; display: block; margin-top: ${marginTop};" href="action:${action.action}">${escapeHtml(action.label)}</vscode-button>`;
+    }).join('\n');
+
+    return /*html*/`
+    <div class="detail-table-container">
+      <style>
+        .detail-table-container {
+          display: flex;
+          flex-direction: column;
+          align-items: stretch;
+          padding: 0 20px;
+          max-width: 1200px;
+          margin: 0 auto;
+          width: 100%;
+          box-sizing: border-box;
+        }
+
+        .detail-table-container vscode-table {
+          width: 100%;
+          min-width: 100%;
+          border-radius: 6px;
+          overflow: visible;
+          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+        }
+
+        .detail-table-container vscode-table-row {
+          display: grid !important;
+          grid-template-columns: 30% 70% !important;
+          width: 100% !important;
+          min-height: 36px;
+          align-items: stretch;
+          position: relative;
+        }
+
+        .detail-table-container vscode-table-row:nth-child(odd) {
+          background-color: rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.06);
+        }
+
+        .detail-table-container vscode-table-row:nth-child(even) {
+          background-color: rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.20);
+        }
+
+        .detail-table-container vscode-table-row:hover {
+          background-color: inherit !important;
+          transform: none !important;
+        }
+
+        .detail-table-container vscode-table-cell:hover {
+          background-color: inherit !important;
+        }
+
+        .detail-table-container vscode-table-cell:first-child {
+          padding: 12px 16px;
+          font-weight: 600;
+          color: var(--vscode-descriptionForeground);
+          white-space: normal;
+          word-wrap: break-word;
+          background-color: rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.05);
+          border-right: 2px solid var(--vscode-panel-border);
+          min-height: 36px;
+          display: block;
+          height: auto;
+        }
+
+        .detail-table-container vscode-table-cell:last-child {
+          padding: 12px 16px;
+          word-break: break-word;
+          white-space: normal;
+          word-wrap: break-word;
+          font-family: var(--vscode-font-family);
+          min-height: 36px;
+          display: block;
+          min-width: 0;
+          overflow-wrap: break-word;
+          height: auto;
+          position: relative;
+          z-index: 1;
+        }
+
+        .detail-table-container code {
+          font-family: var(--vscode-editor-font-family);
+          font-size: 0.95em;
+          background: var(--vscode-textCodeBlock-background);
+          padding: 4px 8px;
+          border-radius: 4px;
+          border: 1px solid var(--vscode-panel-border);
+          max-width: 100%;
+          white-space: pre-wrap;
+          word-break: break-all;
+          overflow-wrap: break-word;
+          display: block;
+          width: 100%;
+        }
+
+        .detail-table-actions {
+          margin-top: 20px;
+          padding-top: 20px;
+          border-top: 1px solid var(--vscode-panel-border);
+          clear: both;
+        }
+
+        ${customStyles}
+      </style>
+
+      ${title || subtitle ? `
+      <div style="margin-top: 20px; margin-bottom: 24px; padding: 16px 20px; background: linear-gradient(135deg, var(--vscode-editor-background) 0%, rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.03) 100%); border-left: 4px solid var(--vscode-focusBorder); border-radius: 4px; width: 100%; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);">
+        ${title ? `<h1 style="margin: 0 0 8px 0; font-size: 1.8em; font-weight: 600; color: var(--vscode-foreground);">${escapeHtml(title)}</h1>` : ''}
+        ${subtitle ? `<div style="color: var(--vscode-descriptionForeground); font-size: 0.95em; margin-top: 4px;">${escapeHtml(subtitle)}</div>` : ''}
+      </div>
+      ` : ''}
+
+      <vscode-table columns='["35%", "65%"]'>
+        ${rows.join('')}
+      </vscode-table>
+
+      ${actions.length > 0 ? `
+      <div class="detail-table-actions">
+        ${actionButtons}
+      </div>
+      ` : ''}
+    </div>
+  `;
+  }
+
+  /**
+   * Generate a complete HTML page with FAST Element table
+   * Optimized for displaying large datasets with better performance
+   * @param options - Table configuration options
+   * @returns Complete HTML page string
+   */
+  export function generateFastTable<T>(options: FastTableOptions<T>): string {
+    const {
+      title,
+      subtitle,
+      columns,
+      data,
+      stickyHeader = true,
+      emptyMessage = 'No data available.',
+      customStyles = '',
+      customScript = '',
+      enableSearch = false,
+      searchPlaceholder = 'Search...',
+      enablePagination = false,
+      itemsPerPage = 50,
+      totalItems = data.length,
+      currentPage = 1,
+      searchTerm = '',
+      tableId = undefined
+    } = options;
+
+    // Format value with icons and styling for FastTable.
+    // NOTE: unlike generateDetailTable, cell values here are NOT html-escaped —
+    // several callers intentionally return raw HTML (e.g. <vscode-button> action
+    // markup) from a column's getValue(), which must render as real elements.
+    const formatFastValue = (value: string | number): string => {
+      if (value === null || value === undefined || value === '') {
+        return EMPTY_VALUE_PLACEHOLDER;
+      }
+
+      const strValue = String(value).trim();
+      if (strValue === 'null' || strValue === 'undefined' || strValue === '') {
+        return EMPTY_VALUE_PLACEHOLDER;
+      }
+
+      return formatYesNoOrNumber(strValue, false) ?? String(value);
+    };
+
+    // Fixed pixel width assigned per 1fr unit, and an absolute floor so no
+    // column becomes too narrow to read. Columns get an actual fixed size
+    // instead of a percentage, so resizing the window never squashes them —
+    // the wrapper scrolls horizontally instead (see .table-scroll-wrapper below).
+    // The floor is intentionally low relative to MIN_PX_PER_FR so 'fr' weights
+    // stay visually distinct instead of every small-weight column clamping to
+    // the same floor value; wide tables (many columns) are expected to scroll.
+    const MIN_PX_PER_FR = 140;
+    const MIN_COLUMN_WIDTH = 90;
+
+    // Fixed pixel width for each column
+    const columnMinWidths = columns.map(col => {
+      if (!col.width) return MIN_COLUMN_WIDTH;
+      if (col.width.includes('fr')) {
+        return Math.max(MIN_COLUMN_WIDTH, parseFloat(col.width) * MIN_PX_PER_FR);
+      }
+      if (col.width.endsWith('px')) {
+        return Math.max(MIN_COLUMN_WIDTH, parseFloat(col.width));
+      }
+      // For %, minmax(), or other values we can't easily measure — use the floor
+      return MIN_COLUMN_WIDTH;
+    });
+
+    // Total fixed width for the whole table. When the viewport is narrower than
+    // this, the wrapper scrolls horizontally instead of squashing columns.
+    const tableMinWidth = columnMinWidths.reduce((sum, w) => sum + w, 0);
+
+    // Fixed pixel width per column, passed to the vscode-table 'columns' attribute
+    const columnsArray = columnMinWidths.map(w => `${w}px`);
+
+    // Check if there are any collapsible columns
+    const hasCollapsibleColumns = columns.some(col => col.collapsible);
+    const collapsibleIndices = columns.map((col, idx) => col.collapsible ? idx : -1).filter(idx => idx !== -1);
+
+    // Store collapsible data for modal
+    const collapsibleData = hasCollapsibleColumns ? data.map((row, rowIndex) => {
+      return collapsibleIndices.map(colIdx => {
+        const col = columns[colIdx];
+        return {
+          title: col.title,
+          value: col.getValue(row)
+        };
+      });
+    }) : [];
+
+    // Generate table rows with width styles and collapsible support
+    const rows = data.map((row, rowIndex) => {
+      const visibleCells = columns.map((col, index) => {
+        if (col.collapsible) {
+          // For collapsible columns, check if value is empty/null before showing button
+          const value = col.getValue(row);
+          const isEmpty = value === null || value === undefined || value === '' || String(value).trim() === '' || String(value) === 'null' || String(value) === 'undefined';
+
+          if (isEmpty) {
+            // Show empty cell if no content
+            return `<vscode-table-cell style="width: ${columnsArray[index]}; text-align: center;"></vscode-table-cell>`;
+          } else {
+            // Show button to open modal if content exists
+            const colIndex = collapsibleIndices.indexOf(index);
+            return `<vscode-table-cell style="width: ${columnsArray[index]}; text-align: center;">
+              <vscode-button appearance="secondary" class="show-modal-btn" data-row="${rowIndex}" data-col="${colIndex}" aria-label="Show details">
+                +
+              </vscode-button>
+            </vscode-table-cell>`;
+          }
+        }
+        const value = col.getValue(row);
+        const cellClass = col.cellClass ? ` class="${col.cellClass}"` : '';
+        const widthStyle = columnsArray[index] !== 'auto' ? ` style="width: ${columnsArray[index]};"` : '';
+        return `<vscode-table-cell${cellClass}${widthStyle}>${formatFastValue(value)}</vscode-table-cell>`;
+      }).join('\n        ');
+
+      return `<vscode-table-row class="main-row" data-row="${rowIndex}">
+          ${visibleCells}
+        </vscode-table-row>`;
+    }).join('\n      ');
+
+    // Generate table header with width styles (skip collapsible columns)
+    const headerCells = columns.map((col, index) => {
+      if (col.collapsible) {
+        const widthStyle = columnsArray[index] !== 'auto' ? ` style="width: ${columnsArray[index]};"` : '';
+        const title = col.showTitle ? escapeHtml(col.title) : '';
+        return `<vscode-table-header-cell${widthStyle}>${title}</vscode-table-header-cell>`;
+      }
+      const widthStyle = columnsArray[index] !== 'auto' ? ` style="width: ${columnsArray[index]};"` : '';
+      return `<vscode-table-header-cell${widthStyle}>${escapeHtml(col.title)}</vscode-table-header-cell>`;
+    }).join('\n        ');
+
+    return /*html*/`
+    <style>
+      body {
+        padding: 0;
+        margin: 0;
+        font-family: var(--vscode-font-family);
+        font-size: var(--vscode-font-size);
+        color: var(--vscode-foreground);
+        background-color: var(--vscode-editor-background);
+      }
+
+      .container {
+        padding: 20px;
+      }
+
+      .header {
+        margin-top: 0;
+        margin-bottom: 24px;
+        padding: 16px 20px;
+        background: linear-gradient(135deg, var(--vscode-editor-background) 0%, rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.03) 100%);
+        border-left: 4px solid var(--vscode-focusBorder);
+        border-radius: 4px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+      }
+
+      .header h1 {
+        margin: 0 0 8px 0;
+        font-size: 1.8em;
+        font-weight: 600;
+        color: var(--vscode-foreground);
+      }
+
+      .header .info {
+        color: var(--vscode-descriptionForeground);
+        font-size: 0.95em;
+        margin-top: 4px;
+      }
+
+      .search-bar {
+        margin-bottom: 20px;
+        padding: 16px;
+        background: rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.03);
+        border-radius: 6px;
+        border: 1px solid rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.1);
+      }
+
+      .search-bar-label {
+        display: block;
+        margin-bottom: 8px;
+        font-weight: 600;
+        font-size: 0.9em;
+        color: var(--vscode-foreground);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+
+      .search-bar vscode-text-field {
+        width: 100%;
+      }
+
+      .pagination-controls {
+        margin-top: 16px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 12px 16px;
+        background: rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.03);
+        border-radius: 4px;
+      }
+
+      .pagination-info {
+        color: var(--vscode-descriptionForeground);
+        font-size: 0.9em;
+      }
+
+      .pagination-buttons {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+      }
+
+      .page-input-container {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .page-input-container vscode-text-field {
+        width: 80px;
+      }
+
+      .table-scroll-wrapper {
+        overflow-x: auto;
+        width: 100%;
+      }
+
+      vscode-table {
+        min-width: ${tableMinWidth}px;
+        width: 100%;
+        border-radius: 6px;
+        overflow: hidden;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+        table-layout: fixed;
+      }
+
+      vscode-table-header {
+        background: linear-gradient(180deg, rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.08) 0%, rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.05) 100%);
+        border-bottom: 2px solid var(--vscode-focusBorder);
+      }
+
+      vscode-table-header-cell {
+        white-space: normal;
+        word-wrap: break-word;
+        padding: 14px 16px;
+        font-weight: 700;
+        font-size: 0.95em;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--vscode-foreground);
+      }
+
+      vscode-table-row {
+        transition: background-color 0.2s ease, transform 0.1s ease;
+      }
+
+      vscode-table-row:nth-child(odd) {
+        background-color: rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.06);
+      }
+
+      vscode-table-row:nth-child(even) {
+        background-color: rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.20);
+      }
+
+      vscode-table-row:hover {
+        background-color: var(--vscode-list-hoverBackground);
+        transform: translateX(2px);
+      }
+
+      vscode-table-cell {
+        white-space: normal;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
+        padding: 12px 16px;
+        border-bottom: 1px solid rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.08);
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      vscode-table-header-cell,
+      vscode-table-cell {
+        box-sizing: border-box;
+      }
+
+      /* Add spacing between buttons in action columns */
+      vscode-table-cell vscode-button {
+        margin-right: 8px;
+      }
+
+      vscode-table-cell vscode-button:last-child {
+        margin-right: 0;
+      }
+
+      .empty-state {
+        text-align: center;
+        padding: 40px;
+        color: var(--vscode-descriptionForeground);
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      /* Modal button styles */
+      .show-modal-btn {
+        background: transparent !important;
+        border: none !important;
+        padding: 4px !important;
+      }
+
+      .show-modal-btn:hover {
+        background: rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.1) !important;
+      }
+
+      /* Modal styles */
+      .modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 1000;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .modal-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.5);
+        backdrop-filter: blur(2px);
+      }
+
+      .modal-content {
+        position: relative;
+        background: var(--vscode-editor-background);
+        border: 1px solid var(--vscode-panel-border);
+        border-radius: 6px;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+        max-width: 90%;
+        max-height: 80%;
+        width: 800px;
+        display: flex;
+        flex-direction: column;
+        animation: modalFadeIn 0.2s ease-out;
+      }
+
+      @keyframes modalFadeIn {
+        from {
+          opacity: 0;
+          transform: scale(0.95);
+        }
+        to {
+          opacity: 1;
+          transform: scale(1);
+        }
+      }
+
+      .modal-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 16px 20px;
+        border-bottom: 1px solid var(--vscode-panel-border);
+      }
+
+      .modal-header h3 {
+        margin: 0;
+        font-size: 1.2em;
+        font-weight: 600;
+        color: var(--vscode-foreground);
+      }
+
+      .modal-body {
+        padding: 20px;
+        overflow-y: auto;
+        flex: 1;
+      }
+
+      .modal-body pre {
+        background: var(--vscode-textCodeBlock-background);
+        padding: 16px;
+        border-radius: 4px;
+        overflow-x: auto;
+        margin: 0;
+        border: 1px solid rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.1);
+        font-family: var(--vscode-editor-font-family);
+        font-size: 0.95em;
+        line-height: 1.6;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+      }
+
+      ${customStyles}
+    </style>
+    <div class="container">
+      ${title || subtitle ? `
+      <div class="header">
+        ${title ? `<h1>${escapeHtml(title)}</h1>` : ''}
+        ${subtitle ? `<div class="info" id="subtitle-info">${escapeHtml(subtitle)}</div>` : ''}
+      </div>
+      ` : ''}
+
+      ${enableSearch ? `
+      <div class="search-bar">
+        <label class="search-bar-label" for="search-input">
+          <span class="codicon codicon-search"></span> ${vscode.l10n.t('Search')}
+        </label>
+        <div style="display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--vscode-input-background); border: 1px solid var(--vscode-input-border); border-radius: 4px;">
+          <span class="codicon codicon-search" style="color: var(--vscode-input-placeholderForeground);"></span>
+          <input
+            type="text"
+            id="search-input"
+            placeholder="${escapeHtml(searchPlaceholder)}"
+            value="${searchTerm && searchTerm !== '-' ? escapeHtml(searchTerm) : ''}"
+            style="flex: 1; background: transparent; border: none; outline: none; color: var(--vscode-input-foreground); font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); padding: 4px 0;">
+        </div>
+      </div>
+      ` : ''}
+
+      ${data.length > 0 ? `
+        <div class="table-scroll-wrapper">
+          <vscode-table
+            id="data-table"
+            bordered-rows
+            columns='${JSON.stringify(columnsArray)}'
+            aria-label="${escapeHtml(title)}">
+            <vscode-table-header>
+              ${headerCells}
+            </vscode-table-header>
+            <vscode-table-body id="table-body">
+              ${rows}
+            </vscode-table-body>
+          </vscode-table>
+
+          ${hasCollapsibleColumns ? `
+          <!-- Modal for collapsible content -->
+          <div id="collapsible-modal" class="modal" style="display: none;">
+            <div class="modal-overlay"></div>
+            <div class="modal-content">
+              <div class="modal-header">
+                <h3 id="modal-title"></h3>
+                <vscode-button appearance="icon" id="modal-close" aria-label="Close">
+                  <span class="codicon codicon-close"></span>
+                </vscode-button>
+              </div>
+              <div class="modal-body" id="modal-body"></div>
+            </div>
+          </div>
+          ` : ''}
+
+          ${enablePagination ? `
+          <div class="pagination-controls">
+          <div class="pagination-info" id="pagination-info${tableId ? `-${tableId}` : ''}"></div>
+          <div class="pagination-buttons">
+            <vscode-button id="first-page${tableId ? `-${tableId}` : ''}" appearance="icon" aria-label="First page">
+              <span class="codicon codicon-chevron-left"></span>
+              <span class="codicon codicon-chevron-left"></span>
+            </vscode-button>
+            <vscode-button id="prev-page${tableId ? `-${tableId}` : ''}" appearance="icon" aria-label="Previous page">
+              <span class="codicon codicon-chevron-left"></span>
+            </vscode-button>
+            <div class="page-input-container">
+              <span>Page</span>
+              <input
+                type="number"
+                id="page-input${tableId ? `-${tableId}` : ''}"
+                min="1"
+                style="width: 60px; padding: 4px 8px; background: var(--vscode-input-background); border: 1px solid var(--vscode-input-border); border-radius: 3px; color: var(--vscode-input-foreground); font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); text-align: center;">
+              <span id="total-pages-label${tableId ? `-${tableId}` : ''}"></span>
+            </div>
+            <vscode-button id="next-page${tableId ? `-${tableId}` : ''}" appearance="icon" aria-label="Next page">
+              <span class="codicon codicon-chevron-right"></span>
+            </vscode-button>
+            <vscode-button id="last-page${tableId ? `-${tableId}` : ''}" appearance="icon" aria-label="Last page">
+              <span class="codicon codicon-chevron-right"></span>
+              <span class="codicon codicon-chevron-right"></span>
+            </vscode-button>
+          </div>
+        </div>
+          ` : ''}
+        </div>
+      ` : `
+        <div class="empty-state">
+          <p>${escapeHtml(emptyMessage)}</p>
+        </div>
+      `}
+    </div>
+
+    <script defer>
+      ${tableId ? `(function() {` : ''}
+      // Use the global vscode API acquired by webviewToolkit
+      // Note: This script runs after the footer script from webviewToolkit.ts
+
+      // State management${tableId ? ` for table: ${tableId}` : ''}
+      let currentPage = ${currentPage};
+      let currentSearchTerm = '${escapeHtml(searchTerm)}';
+      const itemsPerPage = ${itemsPerPage};
+      const totalItems = ${totalItems};
+      const enableSearch = ${enableSearch};
+      const enablePagination = ${enablePagination};
+
+      // Get DOM elements
+      const searchInput = document.getElementById('search-input${tableId ? `-${tableId}` : ''}');
+      const paginationInfo = document.getElementById('pagination-info${tableId ? `-${tableId}` : ''}');
+      const pageInput = document.getElementById('page-input${tableId ? `-${tableId}` : ''}');
+      const totalPagesLabel = document.getElementById('total-pages-label${tableId ? `-${tableId}` : ''}');
+      const firstPageBtn = document.getElementById('first-page${tableId ? `-${tableId}` : ''}');
+      const prevPageBtn = document.getElementById('prev-page${tableId ? `-${tableId}` : ''}');
+      const nextPageBtn = document.getElementById('next-page${tableId ? `-${tableId}` : ''}');
+      const lastPageBtn = document.getElementById('last-page${tableId ? `-${tableId}` : ''}');
+
+      // Calculate total pages
+      const totalPages = enablePagination ? Math.ceil(totalItems / itemsPerPage) : 1;
+
+      // Search functionality - sends message to extension
+      let searchTimeout;
+      function performSearch(searchTerm) {
+        clearTimeout(searchTimeout);
+        searchTimeout = setTimeout(() => {
+          currentSearchTerm = searchTerm;
+          currentPage = 1;
+          // Set flag to indicate this is a search/pagination operation (preserve tab)
+          // IMPORTANT: Save BOTH the flag AND the current tab index BEFORE sending message
+          const state = vscode.getState() || {};
+          state.isSearchRestore = true;
+
+          // Save the current active tab index
+          const tabs = document.querySelector('vscode-tabs');
+          if (tabs) {
+            const currentTabIndex = tabs.getAttribute('selected-index');
+            if (currentTabIndex !== null) {
+              state.activeTabIndex = parseInt(currentTabIndex);
+            }
+          }
+
+          vscode.setState(state);
+          const message = {
+            command: 'search',
+            searchTerm: searchTerm,
+            page: 1,
+            itemsPerPage: itemsPerPage
+          };
+          ${tableId ? `message.tableId = '${tableId}';` : ''}
+          vscode.postMessage(message);
+        }, 500); // Debounce 500ms
+      }
+
+      // Pagination functionality - sends message to extension
+      function changePage(newPage) {
+        if (newPage < 1 || newPage > totalPages) return;
+        currentPage = newPage;
+        // Set flag to indicate this is a search/pagination operation (preserve tab)
+        // IMPORTANT: Save BOTH the flag AND the current tab index BEFORE sending message
+        const state = vscode.getState() || {};
+        state.isSearchRestore = true;
+
+        // Save the current active tab index
+        const tabs = document.querySelector('vscode-tabs');
+        if (tabs) {
+          const currentTabIndex = tabs.getAttribute('selected-index');
+          if (currentTabIndex !== null) {
+            state.activeTabIndex = parseInt(currentTabIndex);
+          }
+        }
+
+        vscode.setState(state);
+        const message = {
+          command: 'paginate',
+          searchTerm: currentSearchTerm,
+          page: newPage,
+          itemsPerPage: itemsPerPage
+        };
+        ${tableId ? `message.tableId = '${tableId}';` : ''}
+        vscode.postMessage(message);
+      }
+
+      // Update pagination display
+      function updatePaginationDisplay() {
+        if (enablePagination && paginationInfo) {
+          const displayStart = totalItems > 0 ? (currentPage - 1) * itemsPerPage + 1 : 0;
+          const displayEnd = Math.min(currentPage * itemsPerPage, totalItems);
+          paginationInfo.textContent = \`Showing \${displayStart}-\${displayEnd} of \${totalItems} items\`;
+
+          if (pageInput) {
+            pageInput.value = currentPage;
+            pageInput.max = totalPages;
+          }
+
+          if (totalPagesLabel) {
+            totalPagesLabel.textContent = \`of \${totalPages}\`;
+          }
+
+          // Update button states
+          if (firstPageBtn) firstPageBtn.disabled = currentPage === 1;
+          if (prevPageBtn) prevPageBtn.disabled = currentPage === 1;
+          if (nextPageBtn) nextPageBtn.disabled = currentPage === totalPages || totalPages === 0;
+          if (lastPageBtn) lastPageBtn.disabled = currentPage === totalPages || totalPages === 0;
+        }
+      }
+
+      // Event listeners
+      if (enableSearch && searchInput) {
+        searchInput.addEventListener('input', (e) => {
+          performSearch(e.target.value);
+        });
+      }
+
+      if (enablePagination) {
+        if (firstPageBtn) {
+          firstPageBtn.addEventListener('click', () => {
+            changePage(1);
+          });
+        }
+
+        if (prevPageBtn) {
+          prevPageBtn.addEventListener('click', () => {
+            changePage(currentPage - 1);
+          });
+        }
+
+        if (nextPageBtn) {
+          nextPageBtn.addEventListener('click', () => {
+            changePage(currentPage + 1);
+          });
+        }
+
+        if (lastPageBtn) {
+          lastPageBtn.addEventListener('click', () => {
+            changePage(totalPages);
+          });
+        }
+
+        if (pageInput) {
+          pageInput.addEventListener('change', (e) => {
+            const newPage = parseInt(e.target.value);
+            if (newPage >= 1 && newPage <= totalPages) {
+              changePage(newPage);
+            } else {
+              e.target.value = currentPage;
+            }
+          });
+        }
+      }
+
+      // Initial display update
+      updatePaginationDisplay();
+
+      // Modal functionality for collapsible content
+      const collapsibleDataArray = ${JSON.stringify(collapsibleData)};
+      const modal = document.getElementById('collapsible-modal');
+      const modalTitle = document.getElementById('modal-title');
+      const modalBody = document.getElementById('modal-body');
+      const modalClose = document.getElementById('modal-close');
+      const modalOverlay = modal ? modal.querySelector('.modal-overlay') : null;
+
+      function openModal(rowIndex, colIndex) {
+        if (!modal || !modalTitle || !modalBody) return;
+
+        const rowData = collapsibleDataArray[rowIndex];
+        if (!rowData || rowData.length === 0) return;
+
+        const item = rowData[colIndex];
+        if (!item) return;
+
+        // Helper function to escape HTML
+        const escapeHtml = (text) => {
+          const div = document.createElement('div');
+          div.textContent = text;
+          return div.innerHTML;
+        };
+
+        modalTitle.textContent = item.title;
+        modalBody.innerHTML = \`<pre>\${escapeHtml(item.value || '')}</pre>\`;
+        modal.style.display = 'flex';
+      }
+
+      function closeModal() {
+        if (modal) {
+          modal.style.display = 'none';
+        }
+      }
+
+      // Show modal buttons
+      const showModalButtons = document.querySelectorAll('.show-modal-btn');
+      showModalButtons.forEach(button => {
+        button.addEventListener('click', (e) => {
+          e.stopPropagation();
+          const rowIndex = parseInt(button.getAttribute('data-row'));
+          const colIndex = parseInt(button.getAttribute('data-col'));
+          openModal(rowIndex, colIndex);
+        });
+      });
+
+      // Close modal handlers
+      if (modalClose) {
+        modalClose.addEventListener('click', closeModal);
+      }
+      if (modalOverlay) {
+        modalOverlay.addEventListener('click', closeModal);
+      }
+
+      // Close modal on Escape key
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && modal && modal.style.display === 'flex') {
+          closeModal();
+        }
+      });
+
+      // Custom script
+      ${customScript}
+      ${tableId ? `})();` : ''}
+    </script>
+    </div>
+  `;
+  }
+
+}

--- a/src/ui/frontendTables.ts
+++ b/src/ui/frontendTables.ts
@@ -1,23 +1,17 @@
 import * as vscode from 'vscode';
+import { VscodeTools } from './Tools';
 
 export namespace FrontendTables {
 
   const EMPTY_VALUE_PLACEHOLDER = '<span style="color: var(--vscode-descriptionForeground); font-style: italic;">—</span>';
 
-  /** Escape a value for safe interpolation into the generated HTML. */
+  /** Escape a value for safe interpolation into the generated HTML; empty/null-ish values render as '-'. */
   function escapeHtml(text: string | number): string {
     if (text === 0) return '0';
     if (text === null || text === undefined || text === '') return '-';
     const str = String(text);
     if (str === 'null' || str === 'undefined' || str.trim() === '') return '-';
-    const map: { [key: string]: string } = {
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      "'": '&#039;'
-    };
-    return str.replace(/[&<>"']/g, m => map[m]);
+    return VscodeTools.escapeHtml(str);
   }
 
   /** Renders YES/NO as colored badges and integers with locale formatting; undefined if the value is neither. */
@@ -133,7 +127,7 @@ export namespace FrontendTables {
 
   /**
    * Generate an enhanced detail table (key-value pairs) using Fast components
-   * This is a modern replacement for generateTableHtml and generateTableHtmlCode
+   * Replaces the legacy table generators (generateTableHtml/generateTableHtmlCode) from the FS extension
    * @param options - Detail table configuration options
    * @returns Complete HTML page string
    */
@@ -423,7 +417,7 @@ export namespace FrontendTables {
             const colIndex = collapsibleIndices.indexOf(index);
             return `<vscode-table-cell style="width: ${columnsArray[index]}; text-align: center;">
               <vscode-button appearance="secondary" class="show-modal-btn" data-row="${rowIndex}" data-col="${colIndex}" aria-label="Show details">
-                +
+                <span style="font-size: 1.2em;">ⓘ</span>
               </vscode-button>
             </vscode-table-cell>`;
           }

--- a/src/ui/frontendTables.ts
+++ b/src/ui/frontendTables.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { codiconStyles } from '../webviews/codicons';
 import { VscodeTools } from './Tools';
 
 export namespace FrontendTables {
@@ -416,9 +417,9 @@ export namespace FrontendTables {
             // Show button to open modal if content exists
             const colIndex = collapsibleIndices.indexOf(index);
             return `<vscode-table-cell style="width: ${columnsArray[index]}; text-align: center;">
-              <vscode-button appearance="secondary" class="show-modal-btn" data-row="${rowIndex}" data-col="${colIndex}" aria-label="Show details">
-                <span style="font-size: 1.2em;">ⓘ</span>
-              </vscode-button>
+              <button type="button" class="show-modal-btn" data-row="${rowIndex}" data-col="${colIndex}" title="${vscode.l10n.t('Show details')}" aria-label="${vscode.l10n.t('Show details')}">
+                <span class="codicon codicon-info"></span>
+              </button>
             </vscode-table-cell>`;
           }
         }
@@ -446,6 +447,8 @@ export namespace FrontendTables {
 
     return /*html*/`
     <style>
+      ${codiconStyles}
+
       body {
         padding: 0;
         margin: 0;
@@ -618,13 +621,22 @@ export namespace FrontendTables {
 
       /* Modal button styles */
       .show-modal-btn {
-        background: transparent !important;
-        border: none !important;
-        padding: 4px !important;
+        background: transparent;
+        border: none;
+        border-radius: 4px;
+        color: var(--vscode-foreground);
+        cursor: pointer;
+        line-height: 1;
+        padding: 4px;
       }
 
       .show-modal-btn:hover {
-        background: rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.1) !important;
+        background: rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.15);
+      }
+
+      .show-modal-btn:focus-visible {
+        outline: 1px solid var(--vscode-focusBorder);
+        outline-offset: 2px;
       }
 
       /* Modal styles */
@@ -688,6 +700,27 @@ export namespace FrontendTables {
         font-size: 1.2em;
         font-weight: 600;
         color: var(--vscode-foreground);
+      }
+
+      .modal-close-btn {
+        background: transparent;
+        border: none;
+        border-radius: 4px;
+        color: var(--vscode-foreground);
+        cursor: pointer;
+        font-family: var(--vscode-font-family);
+        font-size: 1.1em;
+        line-height: 1;
+        padding: 4px 8px;
+      }
+
+      .modal-close-btn:hover {
+        background: rgba(var(--vscode-editor-foreground-rgb, 204, 204, 204), 0.15);
+      }
+
+      .modal-close-btn:focus-visible {
+        outline: 1px solid var(--vscode-focusBorder);
+        outline-offset: 2px;
       }
 
       .modal-body {
@@ -759,9 +792,9 @@ export namespace FrontendTables {
             <div class="modal-content">
               <div class="modal-header">
                 <h3 id="modal-title"></h3>
-                <vscode-button appearance="icon" id="modal-close" aria-label="Close">
+                <button type="button" class="modal-close-btn" id="modal-close" title="${vscode.l10n.t('Close')}" aria-label="${vscode.l10n.t('Close')}">
                   <span class="codicon codicon-close"></span>
-                </vscode-button>
+                </button>
               </div>
               <div class="modal-body" id="modal-body"></div>
             </div>

--- a/src/webviews/CustomUI.ts
+++ b/src/webviews/CustomUI.ts
@@ -1,5 +1,6 @@
 /* eslint-disable indent */
 import vscode, { ProviderResult } from 'vscode';
+import { codiconStyles } from './codicons';
 
 //Webpack is returning this as a string
 const vscodeweb = require(`@vscode-elements/elements/dist/bundled`);
@@ -180,6 +181,8 @@ export class CustomHTML extends Section {
 
         <script type="module">${vscodeweb}</script>
         <style>
+            ${codiconStyles}
+
             @media only screen and (min-width: 750px) {
               #laforma {
                 padding-left: ${this.options?.fullWidth || this.options?.fullPage ? '0' : '15'}%;

--- a/src/webviews/codicons.ts
+++ b/src/webviews/codicons.ts
@@ -1,0 +1,13 @@
+//Webpack is returning these as strings
+const codiconCss = require(`@vscode/codicons/dist/codicon.css`);
+const codiconFont = require(`@vscode/codicons/dist/codicon.ttf`);
+
+function assetString(asset: any): string {
+  return typeof asset === `string` ? asset : asset.default;
+}
+
+/** Codicon stylesheet with the font embedded, since webviews cannot load it from disk. */
+export const codiconStyles = assetString(codiconCss).replace(
+  /url\(["']?[^)"']*codicon\.ttf[^)"']*["']?\)/,
+  `url("${assetString(codiconFont)}")`
+);

--- a/src/webviews/wrkjob/index.ts
+++ b/src/webviews/wrkjob/index.ts
@@ -1,0 +1,230 @@
+import vscode from "vscode";
+import { Tools } from "../../api/Tools";
+import { instance } from "../../instantiate";
+import { FrontendTables } from "../../ui/frontendTables";
+
+const vscodeElements = require(`@vscode-elements/elements/dist/bundled`);
+
+interface JoblogEntry {
+  msgid: string;
+  msgtext: string;
+  msgtext2: string;
+  severity: number;
+  fromProgram: string;
+  msgFile: string;
+  timestamp: string;
+}
+
+/**
+ * Displays the job log for a given job in a webview panel.
+ */
+export namespace JobLogUI {
+  /** Auto-refresh interval in milliseconds. */
+  const AUTO_REFRESH_INTERVAL = 30000;
+
+  interface PanelState {
+    panel: vscode.WebviewPanel;
+    /** Whether auto-refresh is currently enabled for this panel. */
+    autoRefresh: boolean;
+    /** Active auto-refresh timer, if any. */
+    timer?: NodeJS.Timeout;
+  }
+
+  const activePanels = new Map<string, PanelState>();
+
+  export function init(context: vscode.ExtensionContext) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(`code-for-ibmi.showJobLog`, async (jobName?: string) => {
+        const connection = instance.getConnection();
+        if (!connection) {
+          vscode.window.showErrorMessage(vscode.l10n.t("Not connected to IBM i"));
+          return;
+        }
+
+        if (!jobName) {
+          const currentJob = await connection.runSQL(`select JOB_NAME as JOBNAME from table(qsys2.active_job_info(job_name_filter => '*', detailed_info => 'NONE'))`);
+
+          jobName = await vscode.window.showInputBox({
+            placeHolder: vscode.l10n.t("000000/USER/MYJOB"),
+            title: vscode.l10n.t("Enter job name (number/user/name)"),
+            value: currentJob.length ? String(currentJob[0].JOBNAME) : undefined,
+            validateInput: (value) => {
+              if (value.split(`/`).length !== 3) {
+                return vscode.l10n.t("Job name must be in format: number/user/name");
+              }
+            }
+          });
+        }
+
+        if (jobName) {
+          await openJobLog(jobName);
+        }
+      })
+    );
+  }
+
+  async function fetchJoblog(jobName: string): Promise<JoblogEntry[]> {
+    const connection = instance.getConnection();
+    if (!connection) {
+      return [];
+    }
+
+    const rows = await connection.runSQL(
+      `SELECT MESSAGE_ID,
+         MESSAGE_TEXT,
+         MESSAGE_SECOND_LEVEL_TEXT,
+         SEVERITY,
+         FROM_LIBRARY CONCAT '/' CONCAT FROM_PROGRAM AS FROM_PROGRAM,
+         MESSAGE_LIBRARY CONCAT '/' CONCAT MESSAGE_FILE AS MESSAGE_FILE,
+         TO_CHAR(MESSAGE_TIMESTAMP, 'YYYY-MM-DD HH24:MI:SS') AS MESSAGE_TIMESTAMP
+       FROM TABLE(QSYS2.JOBLOG_INFO('${jobName}'))
+       ORDER BY ORDINAL_POSITION DESC`
+    );
+
+    return rows.map((row: Tools.DB2Row): JoblogEntry => ({
+      msgid: String(row.MESSAGE_ID),
+      msgtext: String(row.MESSAGE_TEXT),
+      msgtext2: String(row.MESSAGE_SECOND_LEVEL_TEXT),
+      severity: Number(row.SEVERITY),
+      fromProgram: String(row.FROM_PROGRAM),
+      msgFile: String(row.MESSAGE_FILE),
+      timestamp: String(row.MESSAGE_TIMESTAMP)
+    }));
+  }
+
+  async function openJobLog(jobName: string) {
+    const existing = activePanels.get(jobName);
+    if (existing) {
+      existing.panel.reveal();
+      await render(existing.panel, jobName);
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      `jobLogView`,
+      vscode.l10n.t("Job Log: {0}", jobName),
+      vscode.ViewColumn.One,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true
+      }
+    );
+
+    const state: PanelState = { panel, autoRefresh: false };
+    activePanels.set(jobName, state);
+
+    panel.onDidDispose(() => {
+      stopAutoRefresh(state);
+      activePanels.delete(jobName);
+    });
+
+    panel.webview.onDidReceiveMessage(async (message: { command?: string }) => {
+      switch (message?.command) {
+        case `refresh`:
+          await render(panel, jobName);
+          break;
+        case `toggleAutoRefresh`:
+          state.autoRefresh = !state.autoRefresh;
+          if (state.autoRefresh) {
+            startAutoRefresh(state, jobName);
+          } else {
+            stopAutoRefresh(state);
+          }
+          await render(panel, jobName);
+          break;
+      }
+    });
+
+    await render(panel, jobName);
+  }
+
+  function startAutoRefresh(state: PanelState, jobName: string) {
+    stopAutoRefresh(state);
+    state.timer = setInterval(async () => {
+      try {
+        await render(state.panel, jobName);
+      } catch (error) {
+        console.error(`Job log auto-refresh error:`, error);
+      }
+    }, AUTO_REFRESH_INTERVAL);
+  }
+
+  function stopAutoRefresh(state: PanelState) {
+    if (state.timer) {
+      clearInterval(state.timer);
+      state.timer = undefined;
+    }
+  }
+
+  async function render(panel: vscode.WebviewPanel, jobName: string) {
+    const joblog = await fetchJoblog(jobName);
+    const autoRefresh = activePanels.get(jobName)?.autoRefresh ?? false;
+    const lastUpdated = new Date().toLocaleTimeString();
+
+    const columns: FrontendTables.FastTableColumn<JoblogEntry>[] = [
+      { title: vscode.l10n.t("MSGID"), width: "0.7fr", getValue: e => e.msgid },
+      { title: vscode.l10n.t("Message"), width: "2fr", getValue: e => e.msgtext },
+      { title: vscode.l10n.t("Second Level"), width: "0.3fr", getValue: e => e.msgtext2.replaceAll(`&N`, `\n`).replaceAll(`&B`, `\n\t`).replaceAll(`&P`, `\n\t`), collapsible: true },
+      { title: vscode.l10n.t("Sev."), width: "0.3fr", getValue: e => String(e.severity) },
+      { title: vscode.l10n.t("From Program"), width: "1.5fr", getValue: e => e.fromProgram },
+      { title: vscode.l10n.t("Timestamp"), width: "1.2fr", getValue: e => e.timestamp }
+    ];
+
+    const body = FrontendTables.generateFastTable({
+      title: vscode.l10n.t("Job Log"),
+      subtitle: vscode.l10n.t("Job {0} - Total messages: {1}", jobName, String(joblog.length)),
+      columns,
+      data: joblog,
+      stickyHeader: true,
+      emptyMessage: vscode.l10n.t("No job log messages found.")
+    });
+
+    panel.webview.html = /*html*/`
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>${vscode.l10n.t("Job Log: {0}", jobName)}</title>
+      <script type="module">${vscodeElements}</script>
+      <style>
+        .joblog-toolbar {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          padding: 12px 20px;
+          border-bottom: 1px solid var(--vscode-panel-border);
+        }
+        .joblog-toolbar .last-updated {
+          margin-left: auto;
+          color: var(--vscode-descriptionForeground);
+          font-size: 0.9em;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="joblog-toolbar">
+        <vscode-button id="joblog-refresh-btn" appearance="primary">
+          ${vscode.l10n.t("Refresh")}
+        </vscode-button>
+        <vscode-button id="joblog-autorefresh-btn" appearance="${autoRefresh ? `primary` : `secondary`}">
+          ${autoRefresh
+            ? vscode.l10n.t("Auto-refresh: ON ({0}s)", String(AUTO_REFRESH_INTERVAL / 1000))
+            : vscode.l10n.t("Auto-refresh: OFF")}
+        </vscode-button>
+        <span class="last-updated">${vscode.l10n.t("Last updated: {0}", lastUpdated)}</span>
+      </div>
+      ${body}
+      <script>
+        const vscode = acquireVsCodeApi();
+        document.getElementById('joblog-refresh-btn')?.addEventListener('click', () => {
+          vscode.postMessage({ command: 'refresh' });
+        });
+        document.getElementById('joblog-autorefresh-btn')?.addEventListener('click', () => {
+          vscode.postMessage({ command: 'toggleAutoRefresh' });
+        });
+      </script>
+    </body>
+    </html>`;
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,6 +90,18 @@ const config = {
         type: `asset/source`
       },
       {
+        // Codicon stylesheet, inlined into the webviews as a string
+        test: /\.css$/,
+        include: path.resolve(__dirname, `node_modules/@vscode/codicons/dist`),
+        type: `asset/source`
+      },
+      {
+        // Codicon font, inlined into the stylesheet above as a base64 data URI
+        test: /\.ttf$/,
+        include: path.resolve(__dirname, `node_modules/@vscode/codicons/dist`),
+        type: `asset/inline`
+      },
+      {
         test: /\.(ts|tsx)$/i,
         exclude: /node_modules/,
         use: [


### PR DESCRIPTION
### Changes
This PR moves the table generation functions from the FS extension to the core. The FS extension now imports the methods exported by the core. Exporting the table generation also ensures a consistent UI even when other extensions are used.
In addition, the ‘IBM i: Display Job Log’ command has been added, which allows you to view the job log of an active job. The command is pre-populated by default with the name of the current job. 
@NicolasSchindler this PR allows you to proceed with #3346.

### How to test this PR
1. CTRL + SHIFT + P (or COMMAND + SHIFT + P) and choose **IBM i: Display Job Log**
<img width="603" height="88" alt="image" src="https://github.com/user-attachments/assets/54eca639-64eb-4d06-818b-0183b6edc15a" />

2. You'll see Core joblog:
<img width="1221" height="935" alt="image" src="https://github.com/user-attachments/assets/f07e95f2-c2d2-41b7-99e2-f77767586a72" />

### Checklist
* [X] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
