### PR TITLE
updated processEvent to process dispatching of events in parallel

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -298,23 +298,25 @@ export default class Instance {
   }
 
   async processEvent(event: IBMiEvent) {
-    const eventSubscribers = this.getSubscribers(event)
+    const eventSubscribers = this.getSubscribers(event);
     console.time(event);
-    for (const [identity, callable] of eventSubscribers.entries()) {
-      try {
-        console.time(identity);
-        await callable.func();
-        console.timeEnd(identity);
-      }
-      catch (error) {
-        console.error(`${event} event function ${identity} failed`, error);
-      }
-      finally {
-        if (callable.transient) {
-          eventSubscribers.delete(identity);
+    await Promise.allSettled(
+      Array.from(eventSubscribers.entries()).map(async ([identity, callable]) => {
+        try {
+          console.time(identity);
+          await callable.func();
+          console.timeEnd(identity);
         }
-      }
-    }
+        catch (error) {
+          console.error(`${event} event function ${identity} failed`, error);
+        }
+        finally {
+          if (callable.transient) {
+            eventSubscribers.delete(identity);
+          }
+        }
+      })
+    );
     console.timeEnd(event);
   }
 }


### PR DESCRIPTION
### Changes
Currently once event is fired then order in which notifications are dispatched is sequential so some subscribers face delay in receiving notifications . Hence this pr will provide the changes that will make the processing parallelly not just one or two subscribers facing delay. This will resolve issue https://github.ibm.com/bob-for-ibm-i/vscode-ibmi-bob/issues/679

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
