### PR TITLE
Clear temporary password when actually disconnecting

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -6,6 +6,7 @@ import { BaseStorage } from "./api/configuration/storage/BaseStorage";
 import { CodeForIStorage } from "./api/configuration/storage/CodeForIStorage";
 import { ConnectionStorage } from "./api/configuration/storage/ConnectionStorage";
 import { VsCodeConfig } from "./config/Configuration";
+import { clearPassword } from "./extension";
 import { getEnvConfig } from "./filesystems/local/env";
 import { ConnectionConfig, ConnectionData, IBMiEvent } from "./typings";
 import { VscodeTools } from "./ui/Tools";
@@ -181,9 +182,10 @@ export default class Instance {
     return this.connected;
   }
 
-  async disconnect(keepTabsOpened?: boolean) {
+  async disconnect(reconnect?: boolean) {
     delete this.connected;
-    if (!keepTabsOpened) {
+    if (!reconnect) {
+      clearPassword();
       vscode.window.tabGroups.close(
         vscode.window.tabGroups.all
           .flatMap(group => group.tabs)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,8 +27,8 @@ import { mergeCommandProfiles } from "./mergeProfiles";
 import { initialise } from "./testing";
 import { CodeForIBMi } from "./typings";
 import { VscodeTools } from "./ui/Tools";
-import { FrontendTables } from "./ui/frontendTables";
 import { registerActionTools } from "./ui/actions";
+import { FrontendTables } from "./ui/frontendTables";
 import { initializeConnectionBrowser } from "./ui/views/ConnectionBrowser";
 import { initializeLibraryListView } from "./ui/views/LibraryListView";
 import { initializeDebugBrowser } from "./ui/views/debugView";
@@ -145,8 +145,6 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
       prompt
     });
   }
-
-  instance.subscribe(context, "disconnected", "Clear temporary password", clearPassword);
 
   const mapepire = new Mapepire(path.join(context.extensionPath, `dist`), async (connection) => {
     return await getPassword(connection, l10n.t(`Password for user profile {0} on {1} is required to connect to Mapepire Server.`, connection.currentUser, connection.currentConnectionName));


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
This PR follows up on #3329.
The temporary password used to be cleared in response to the `disconnected` event. This would clear it unconditionally, even if the connection dropped, as reported here https://github.com/codefori/vscode-ibmi/issues/3327#issuecomment-4986756891 by @SJLennon .

This PR changes this behavior and clears the temporary password only when an actual disconnection occurs. Reconnecting after a connection drop will not ask for the password again. 

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Connect to a system with a private key or without saving the password
2. Fill in the prompt when asked for a password
3. Once connected, kill your connection (pull the plug or turn off WiFi)
4. Wait for the reconnection dialog to show up
5. Clicking on reconnect must not ask for the password again

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change