### PR TITLE
Fetch library ASP and include in member path for CCSID conversion

### DIFF
--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -187,7 +187,8 @@ export class ExtendedIBMiContent {
           }
 
           // Fetch source file CCSID and determine if conversion is needed
-          const memberPath = { library, name: file, member: name };
+          const asp = await connection.getLibraryIAsp(library);
+          const memberPath = { library, name: file, member: name, asp };
           const sourceCcsid = await connection.getFileCcsid(memberPath);
           const { requiresConversion, targetCcsid } = Tools.determineCcsidConversion(sourceCcsid, config);
 


### PR DESCRIPTION
### Changes
During the save, the iasp was not included in the calculation of the IFS path, so run the attr command failed.

### How to test this PR
1. open a source member on iASP
2. save it
3. in output log now you should see something similar:
```
[2026-07-18 15:38:47.627] /usr/bin/attr -p /WHATANIASP/QSYS.LIB/SAMPLEIASP.LIB/DUMMYSRCPF.FILE CCSID
[2026-07-18 15:38:47.930] {
    "code": 0,
    "signal": null,
    "stdout": "CCSID=280",
    "stderr": ""
}
```

### Checklist
* [X] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [X] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
