### PR TITLE
Replaced `HTTPS` with `Secure WebSocket` in Mapepire Settings page

### DIFF
--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -119,8 +119,8 @@ export class SettingsUI {
           .addHeading("SSH client (single mode)", 3)
           .addSelect(`mapepireJavaVersion`, `Mapepire Java Runtime`, ["default", "8", "11", "17", "21"].map((value, index) => ({ text: index ? `Java ${value}` : 'Default', value, description: index ? `Java ${value}` : 'Default', selected: value === config.mapepireJavaVersion })), "The Java version used to run Mapepire; it must be installed and available on the LPAR.")
           .addHorizontalRule()
-          .addHeading("HTTP client", 3)
-          .addCheckbox(`mapepireUseServer`, `Connect to remote Mapepire Server`, `When enabled, Code for IBM i will connect over HTTPS to a remote Mapepire server already running on the target IBM i instead uploading and running Mapepire in an SSH channel.`, config.mapepireUseServer)
+          .addHeading("WebSocket client", 3)
+          .addCheckbox(`mapepireUseServer`, `Connect to remote Mapepire Server`, `When enabled, Code for IBM i will connect over a secure WebSocket to a remote Mapepire server already running on the target IBM i instead uploading and running Mapepire in an SSH channel.`, config.mapepireUseServer)
           .addCheckbox(`mapepireAllowSelfCert`, `Allow all certificates`, `When enabled, allows either self-signed certificates or certificates from a CA when connecting to a remote Mapepire server.`, config.mapepireAllowSelfCert)
           .addInput(`mapepireServerPort`, `Remote Mapepire Server port`, `The TCP port number Code for IBM will use when connecting to a remote Mapepire server.`, { default: String(config.mapepireServerPort), inputType: "number", min: 1, max: 65535 })
 


### PR DESCRIPTION
### Changes
Following up on https://github.com/codefori/docs/pull/110

This PR replaces mentions to `HTTP` with `WebSocket` in the Mapepire Settings page.
<img width="733" height="146" alt="image" src="https://github.com/user-attachments/assets/4131c438-6f4e-4fc6-965e-c3a4d2f10bce" />


### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Open the connection settings
2. Check the Mapepire settings tab

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change