### PR TITLE
Add member text description filter to member list

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,11 @@
 											"description": "Member type filter",
 											"maxLength": 10,
 											"default": "*"
+										},
+										"memberText": {
+											"type": "string",
+											"description": "Member text description filter",
+											"default": "*"
 										}
 									}
 								},

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -776,7 +776,7 @@ export default class IBMiContent {
         WHERE TRIM(PART_STAT.SYSTEM_TABLE_MEMBER) <> ''
         ${singleMember ? `AND RTRIM(PART_STAT.SYSTEM_TABLE_MEMBER) like '${singleMember.replaceAll('_', '+_')}' escape '+'` : ``}
         ${singleMemberExtension && singleMemberExtension.trim() !== '%' ? `AND RTRIM(CAST(PART_STAT.SOURCE_TYPE AS VARCHAR(10))) like '${singleMemberExtension.replaceAll('_', '+_')}' escape '+'` : ``}
-        ${singleMemberText && singleMemberText.trim() !== '%' ? `AND UPPER(RTRIM(VARCHAR(PART_STAT.TEXT))) like '${singleMemberText.replaceAll('_', '+_')}' escape '+'` : ``}
+        ${singleMemberText && singleMemberText.trim() !== '%' ? `AND UPPER(RTRIM(VARCHAR(PART_STAT.TEXT))) like '${singleMemberText.replaceAll('+', '++').replaceAll('_', '+_').replaceAll(`'`, `''`)}' escape '+'` : ``}
         ORDER BY ${sort.order === 'name' ? 'NAME' : 'CHANGED'} ${!sort.ascending ? 'DESC' : 'ASC'}`;
 
     const results = await this.ibmi.runSQL(statement);

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -747,7 +747,7 @@ export default class IBMiContent {
    * @param filter: the criterias used to list the members
    * @returns
    */
-  async getMemberList(filter: { library: string, sourceFile: string, members?: string | string[], extensions?: string, sort?: SortOptions, filterType?: FilterType }): Promise<IBMiMember[]> {
+  async getMemberList(filter: { library: string, sourceFile: string, members?: string | string[], extensions?: string, memberText?: string, sort?: SortOptions, filterType?: FilterType }): Promise<IBMiMember[]> {
     const sort = filter.sort || { order: 'name' };
     const library = this.ibmi.upperCaseName(filter.library);
     const sourceFile = this.ibmi.upperCaseName(filter.sourceFile);
@@ -758,6 +758,9 @@ export default class IBMiContent {
 
     const memberExtensionFilter = parseFilter(filter.extensions, filter.filterType);
     const singleMemberExtension = memberExtensionFilter.noFilter && filter.extensions && !filter.extensions.includes(",") ? this.ibmi.upperCaseName(filter.extensions).replace(/[*]/g, `%`) : undefined;
+
+    const memberTextFilter = parseFilter(filter.memberText, filter.filterType);
+    const singleMemberText = memberTextFilter.noFilter && filter.memberText && !filter.memberText.includes(",") ? filter.memberText.toUpperCase().replace(/[*]/g, `%`) : undefined;
 
     const statement = /* sql */
       `SELECT RTRIM(OBJ_STAT.OBJNAME) AS SOURCE_FILE,
@@ -773,6 +776,7 @@ export default class IBMiContent {
         WHERE TRIM(PART_STAT.SYSTEM_TABLE_MEMBER) <> ''
         ${singleMember ? `AND RTRIM(PART_STAT.SYSTEM_TABLE_MEMBER) like '${singleMember.replaceAll('_', '+_')}' escape '+'` : ``}
         ${singleMemberExtension && singleMemberExtension.trim() !== '%' ? `AND RTRIM(CAST(PART_STAT.SOURCE_TYPE AS VARCHAR(10))) like '${singleMemberExtension.replaceAll('_', '+_')}' escape '+'` : ``}
+        ${singleMemberText && singleMemberText.trim() !== '%' ? `AND UPPER(RTRIM(VARCHAR(PART_STAT.TEXT))) like '${singleMemberText.replaceAll('_', '+_')}' escape '+'` : ``}
         ORDER BY ${sort.order === 'name' ? 'NAME' : 'CHANGED'} ${!sort.ascending ? 'DESC' : 'ASC'}`;
 
     const results = await this.ibmi.runSQL(statement);
@@ -791,7 +795,8 @@ export default class IBMiContent {
         changed: new Date(result.CHANGED ? Number(result.CHANGED) : 0)
       } as IBMiMember))
         .filter(member => memberFilter.test(member.name))
-        .filter(member => memberExtensionFilter.test(member.extension));
+        .filter(member => memberExtensionFilter.test(member.extension))
+        .filter(member => memberTextFilter.test(member.text || ``));
     }
     else {
       return [];
@@ -1166,7 +1171,7 @@ export default class IBMiContent {
    * @param library
    * @param name
    * @param type
-   * 
+   *
    * @returns the routine program if it's external, the sha256 hash of the routine's body otherwise
    */
   async getSQLRoutineSignature(library: string, name: string, type: "PROCEDURE" | "FUNCTION") {

--- a/src/api/configuration/config/types.ts
+++ b/src/api/configuration/config/types.ts
@@ -87,6 +87,7 @@ export interface ObjectFilters {
   types: string[]
   member: string
   memberType: string
+  memberText?: string
   protected: boolean
 }
 

--- a/src/ui/Tools.ts
+++ b/src/ui/Tools.ts
@@ -5,7 +5,7 @@ import vscode, { MarkdownString } from "vscode";
 import IBMi from '../api/IBMi';
 import { Tools } from '../api/Tools';
 import { API, GitExtension } from "../filesystems/local/gitApi";
-import { ConnectionProfile, IBMiMember, IBMiObject, IFSFile } from '../typings';
+import { ConnectionProfile, IBMiMember, IBMiObject, IFSFile, ObjectFilters } from '../typings';
 
 let gitLookedUp: boolean;
 let gitAPI: API | undefined;
@@ -215,6 +215,18 @@ export namespace VscodeTools {
       "Size": ifsFile.size,
       "Modified": ifsFile.modified ? safeIsoValue(new Date(ifsFile.modified.getTime() - ifsFile.modified.getTimezoneOffset() * 60 * 1000)) : ``,
       "Owner": ifsFile.owner ? ifsFile.owner.toUpperCase() : ``
+    }));
+    tooltip.supportHtml = true;
+    return tooltip;
+  }
+
+  export function filterToToolTip(filter: ObjectFilters) {
+    const tooltip = new MarkdownString(generateTooltipHtmlTable(filter.name, {
+      "Object": filter.object,
+      "Library": filter.library,
+      "Member": filter.member,
+      "Type": filter.memberType || `*`,
+      "Text": filter.memberText || undefined
     }));
     tooltip.supportHtml = true;
     return tooltip;

--- a/src/ui/Tools.ts
+++ b/src/ui/Tools.ts
@@ -226,7 +226,7 @@ export namespace VscodeTools {
       "Library": filter.library,
       "Member": filter.member,
       "Type": filter.memberType || `*`,
-      "Text": filter.memberText || undefined
+      "Text": filter.memberText || `*`
     }));
     tooltip.supportHtml = true;
     return tooltip;

--- a/src/ui/views/objectBrowser.ts
+++ b/src/ui/views/objectBrowser.ts
@@ -282,6 +282,7 @@ class ObjectBrowserSourcePhysicalFileItem extends ObjectBrowserItem implements O
         sourceFile: this.object.name,
         members: this.filter.member,
         extensions: this.filter.memberType,
+        memberText: this.filter.memberText,
         filterType: this.filter.filterType,
         sort: this.sort
       });
@@ -1249,7 +1250,7 @@ Do you want to replace it?`, item.name), { modal: true }, skipAllLabel, overwrit
           IBMi.connectionManager.update(config);
           const autoRefresh = objectBrowser.autoRefresh();
 
-          if(!existsInLibl) {
+          if (!existsInLibl) {
             // Add to library list ?
             await vscode.window.showInformationMessage(vscode.l10n.t(`Would you like to add the new library to the library list?`), vscode.l10n.t(`Yes`))
               .then(async result => {
@@ -1354,12 +1355,12 @@ Do you want to replace it?`, item.name), { modal: true }, skipAllLabel, overwrit
 
           newPathOK = true;
 
-          let command:string;
+          let command: string;
 
-          if(node.object.type.toLocaleLowerCase() === `*lib`){
-            command= `QSYS/CPYLIB FROMLIB(${oldObject}) TOLIB(${newObject})`;
+          if (node.object.type.toLocaleLowerCase() === `*lib`) {
+            command = `QSYS/CPYLIB FROMLIB(${oldObject}) TOLIB(${newObject})`;
           } else {
-            command=`QSYS/CRTDUPOBJ OBJ(${oldObject}) FROMLIB(${oldLibrary}) OBJTYPE(${node.object.type}) TOLIB(${newLibrary}) NEWOBJ(${newObject}) ${node.object.type.toLocaleLowerCase() === '*file' ? 'DATA(*YES)' : ''}`
+            command = `QSYS/CRTDUPOBJ OBJ(${oldObject}) FROMLIB(${oldLibrary}) OBJTYPE(${node.object.type}) TOLIB(${newLibrary}) NEWOBJ(${newObject}) ${node.object.type.toLocaleLowerCase() === '*file' ? 'DATA(*YES)' : ''}`
           }
 
           const commandRes = await connection.runCommand({

--- a/src/ui/views/objectBrowser.ts
+++ b/src/ui/views/objectBrowser.ts
@@ -176,8 +176,9 @@ class ObjectBrowserFilterItem extends ObjectBrowserItem implements WithLibrary {
     super(filter, filter.name, { icon: filter.protected ? `lock-small` : '', state: vscode.TreeItemCollapsibleState.Collapsed });
     this.library = parseFilter(filter.library, filter.filterType).noFilter ? filter.library : '';
     this.contextValue = `filter${this.library ? "_library" : ''}${this.isProtected() ? `_readonly` : ``}`;
-    this.description = `${filter.library}/${filter.object}/${filter.member}.${filter.memberType || `*`} (${filter.types.join(`, `)})`;
-    this.tooltip = ``;
+    const memberTextSuffix = filter.memberText && !/^\*(?:ALL)?$/.test(filter.memberText.trim()) ? ` [${filter.memberText}]` : ``;
+    this.description = `${filter.library}/${filter.object}/${filter.member}.${filter.memberType || `*`} (${filter.types.join(`, `)})${memberTextSuffix}`;
+    this.tooltip = VscodeTools.filterToToolTip(filter);
 
     if (this.library) {
       this.resourceUri = vscode.Uri.from({

--- a/src/webviews/filters/index.ts
+++ b/src/webviews/filters/index.ts
@@ -22,6 +22,7 @@ export async function editFilter(filter?: ObjectFilters, copy = false) {
           types: [...filter.types],
           member: filter.member,
           memberType: filter.memberType,
+          memberText: filter.memberText || `*`,
           protected: filter.protected
         }
 
@@ -37,6 +38,7 @@ export async function editFilter(filter?: ObjectFilters, copy = false) {
         types: [`*SRCPF`],
         member: `*`,
         memberType: `*`,
+        memberText: `*`,
         protected: false
       }
 
@@ -54,6 +56,7 @@ export async function editFilter(filter?: ObjectFilters, copy = false) {
       .addInput(`types`, `Object types`, `A comma delimited list of object types. For example <code>*ALL</code>, or <code>*PGM</code>, <code>*SRVPGM</code>. <code>*SRCPF</code> is a special type which will return only source files.`, { default: filter.types.join(`, `) })
       .addInput(`member`, `Members`, `Member names filter.`, { default: filter.member })
       .addInput(`memberType`, `Member type`, `Member types filter.`, { default: filter.memberType })
+      .addInput(`memberText`, `Member text`, `Member text description filter.`, { default: filter.memberText || `*` })
       .addCheckbox(`protected`, `Protected`, `Make this filter protected, preventing modifications and source members from being saved.`, filter.protected)
       .addButtons({ id: `save`, label: `Save settings` })
       .loadPage<any>(`Filter: ${newFilter ? `New` : filter.name}`);
@@ -86,6 +89,9 @@ export async function editFilter(filter?: ObjectFilters, copy = false) {
             data[key] = connection.upperCaseName(String(data[key]));
             break;
           case `memberType`:
+            data[key] = String(data[key].trim()) || `*`;
+            break;
+          case `memberText`:
             data[key] = String(data[key].trim()) || `*`;
             break;
           case `protected`:


### PR DESCRIPTION
## Summary

Adds a `memberText` filter field to the Object Browser filter system, allowing users to filter source file members by their text description — the same field displayed as "Member Text" or "Description" in IBM i tools like PDM.

## How It Works

The implementation follows the exact same two-phase pattern already used by the `memberType` (source type) filter:

1. **SQL-level optimization** — When the filter is a single simple pattern (e.g. `PAY*` or `*RPG*`), a `WHERE` clause is pushed down into the `PARTITION_STATISTICS` query to reduce rows returned from IBM i:
   ```sql
   AND UPPER(RTRIM(VARCHAR(PART_STAT.TEXT))) like 'PAY%' escape '+'
   ```
   `UPPER()` is applied on both sides for case-insensitive matching (unlike `memberType` / `member` which are always uppercase system names).

2. **Client-side filtering** — The full `parseFilter()` logic (supporting comma-separated multi-generic values and regex) is applied to `member.text` after the SQL result is received, consistent with how `memberFilter` and `memberExtensionFilter` work.

## Changes

| File | What changed |
|---|---|
| `src/api/configuration/config/types.ts` | Added `memberText?: string` to `ObjectFilters` (optional for backward compat) |
| `src/api/IBMiContent.ts` | Added `memberText` param to `getMemberList`, SQL LIKE clause, and client-side filter chain |
| `src/webviews/filters/index.ts` | Added "Member text" input to the filter editor UI; default value `*` |
| `src/ui/views/objectBrowser.ts` | Passes `filter.memberText` through to `getMemberList` |
| `package.json` | Added `memberText` property to the `objectFilters` JSON schema (not required, for backward compat) |

## Similarity to Source Type Filter

`memberText` is the direct parallel of `memberType` (`PART_STAT.SOURCE_TYPE`):

| Field | Filters on | SQL column | Case handling |
|---|---|---|---|
| `memberType` | Source type (e.g. `RPGLE`, `CLLE`) | `PART_STAT.SOURCE_TYPE` | Always uppercase (system names) |
| `memberText` | Text description | `PART_STAT.TEXT` | `UPPER()` for case-insensitive match |

Existing saved filter configs without `memberText` are unaffected — `undefined` maps to `noFilter: true` via `parseFilter`, passing all members through.

Close #2683