### PR TITLE
Improve status bar color

### DIFF
--- a/src/api/configuration/config/types.ts
+++ b/src/api/configuration/config/types.ts
@@ -105,6 +105,7 @@ export interface ConnectionProfile {
   customVariables: CustomVariable[]
   setLibraryListCommand?: string
   iasp?: string
+  statusBarColor?: string
 }
 
 export interface StoredConnection {

--- a/src/api/connectionProfiles.ts
+++ b/src/api/connectionProfiles.ts
@@ -21,8 +21,9 @@ export async function updateConnectionProfile(profile: ConnectionProfile, option
     }
 
     if (isActiveProfile(profile)) {
-      //Only update the setLibraryListCommand in the current config since the editor is the only place it can be changed
+      //Only update the setLibraryListCommand and statusBarColor in the current config since the editor is the only place they can be changed
       config.setLibraryListCommand = profile.setLibraryListCommand;
+      config.statusBarColor = profile.statusBarColor || ``;
     }
 
     await IBMi.connectionManager.update(config);
@@ -80,6 +81,7 @@ export function assignProfile(fromProfile: ConnectionProfile, toProfile: Connect
   toProfile.ifsShortcuts = fromProfile.ifsShortcuts;
   toProfile.customVariables = fromProfile.customVariables;
   toProfile.setLibraryListCommand = fromProfile.setLibraryListCommand;
+  toProfile.statusBarColor = fromProfile.statusBarColor ?? toProfile.statusBarColor;
   return toProfile;
 }
 

--- a/src/editors/connectionProfileEditor.ts
+++ b/src/editors/connectionProfileEditor.ts
@@ -2,6 +2,7 @@ import vscode, { l10n } from "vscode";
 import { isActiveProfile, updateConnectionProfile } from "../api/connectionProfiles";
 import { instance } from "../instantiate";
 import { ConnectionProfile } from "../typings";
+import { VscodeTools } from "../ui/Tools";
 import { CustomEditor } from "./customEditorProvider";
 
 type ConnectionProfileData = {
@@ -10,6 +11,7 @@ type ConnectionProfileData = {
   libraryList: string
   setLibraryListCommand: string
   iasp: string
+  statusBarColor: string
 }
 
 const editedProfiles: Set<string> = new Set;
@@ -31,6 +33,7 @@ export function editConnectionProfile(profile: ConnectionProfile, doAfterSave?: 
     .addInput("libraryList", l10n.t("Library List"), l10n.t("A comma-separated list of libraries."), { default: profile.libraryList.join(","), readonly: activeProfile })
     .addInput("iasp", l10n.t("Current IASP"), l10n.t("The independent ASP to enable when using this profile. If the database name of this ASP is different from its name, make sure to use the database name here. Leave blank to use the system ASP."), { default: profile.iasp, readonly: activeProfile })
     .addInput("setLibraryListCommand", l10n.t("Library List Command"), l10n.t("Library List Command can be used to set your library list based on the result of a command like <code>CHGLIBL</code>, or your own command that sets the library list.<br/>Commands should be as explicit as possible.<br/>When refering to commands and objects, both should be qualified with a library.<br/>Put <code>?</code> in front of the command to prompt it before execution."), { default: profile.setLibraryListCommand })
+    .addInput("statusBarColor", l10n.t("Status bar color"), l10n.t("The color of the status bar items while this profile is active. Useful to tell your environments apart at a glance. Pick black to keep the color of the current theme."), { default: (profile.statusBarColor ?? config?.statusBarColor) || `#000000`, inputType: "color" })
     .addHorizontalRule()
     .addHeading(l10n.t("Object filters"), 3)
     .addParagraph(objectFilters.length ? `<ul>${objectFilters.map(filter => `<li>${filter.name}</li>`).join('')}</ul>` : l10n.t("None"))
@@ -53,6 +56,7 @@ async function save(profile: ConnectionProfile, data: ConnectionProfileData) {
     profile.homeDirectory = data.homeDirectory.trim();
     profile.iasp = data.iasp.trim() ? data.iasp.trim() : undefined;
     profile.setLibraryListCommand = data.setLibraryListCommand.trim();
+    profile.statusBarColor = VscodeTools.parseStatusBarColor(data.statusBarColor) || ``;
 
     const currentASP = connection.getCurrentASP();
     try {

--- a/src/filesystems/qsys/sourceDateHandler.ts
+++ b/src/filesystems/qsys/sourceDateHandler.ts
@@ -1,6 +1,8 @@
 import vscode from "vscode";
 import { DiffComputer } from "vscode-diff";
+import { onCodeForIBMiConfigurationChange } from "../../config/Configuration";
 import { instance } from "../../instantiate";
+import { VscodeTools } from "../../ui/Tools";
 
 const editedTodayColor = new vscode.ThemeColor(`gitDecoration.modifiedResourceForeground`);
 const seachGutterColor = new vscode.ThemeColor(`gitDecoration.addedResourceForeground`);
@@ -71,12 +73,22 @@ export class SourceDateHandler {
       vscode.commands.registerCommand(`code-for-ibmi.member.clearDateSearch`, () => this.clearDateSearch()),
       vscode.commands.registerCommand(`code-for-ibmi.member.newDateSearch`, () => this.newDateSearch()),
       vscode.commands.registerCommand(`code-for-ibmi.toggleSequenceNumbers`, () => this.toggleSequenceNumbers()),
+      onCodeForIBMiConfigurationChange(`connectionSettings`, () => this.updateStatusBarColor()),
       this.sourceDateSearchBarItem
     );
   }
 
+  /**
+   * Use the same status bar colour as the other Code for IBM i bar items.
+   */
+  private updateStatusBarColor() {
+    const config = instance.getConnection()?.getConfig();
+    this.sourceDateSearchBarItem.color = VscodeTools.parseStatusBarColor(config?.statusBarColor);
+  }
+
   setEnabled(enabled: boolean) {
     if (enabled) {
+      this.updateStatusBarColor();
       this.sourceDateSearchBarItem.show();
     } else {
       this.sourceDateSearchBarItem.hide();

--- a/src/ui/Tools.ts
+++ b/src/ui/Tools.ts
@@ -230,6 +230,7 @@ export namespace VscodeTools {
       "Object Filters": profile.objectFilters.length,
       "IFS Shortcuts": profile.ifsShortcuts.length,
       "Custom Variables": profile.customVariables.length,
+      "Status Bar Color": parseStatusBarColor(profile.statusBarColor),
     }));
     tooltip.supportHtml = true;
     return tooltip;

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -148,7 +148,7 @@ export class SettingsUI {
           .addCheckbox(`autoSaveBeforeAction`, `Auto Save for Actions`, `When current editor has unsaved changes, automatically save it before running an action.`, config.autoSaveBeforeAction)
           .addInput(`hideCompileErrors`, `Errors to ignore`, `A comma delimited list of errors to be hidden from the result of an Action in the EVFEVENT file. Useful for codes like <code>RNF5409</code>.`, { default: config.hideCompileErrors.join(`, `) })
           .addHorizontalRule()
-          .addInput(`statusBarColor`, vscode.l10n.t(`Status bar color`), vscode.l10n.t(`The color of this system's name in the status bar. Useful to tell your systems apart at a glance. Pick black to keep the color of the current theme.`), { default: config.statusBarColor || `#000000`, inputType: "color" })
+          .addInput(`statusBarColor`, vscode.l10n.t(`Status bar color`), vscode.l10n.t(`The color of this system's name in the status bar. Useful to tell your systems apart at a glance. Pick black to keep the color of the current theme.<br/>Each profile can carry its own color: when a profile is active, this is the color of that profile.`), { default: config.statusBarColor || `#000000`, inputType: "color" })
 
         setFieldsReadOnly(featuresTab);
 


### PR DESCRIPTION
### Changes
This pr improve color on status bar, in fact it now applies to the date handler as well. In addition, the option to set the color at the profile level has been introduced.

### How to test this PR
Connect to a system with a color specified, now you'll see that color in the date handler:
<img width="1917" height="31" alt="image" src="https://github.com/user-attachments/assets/a704b25e-0dce-471d-b26c-5af894b4365a" />

Set color on one of your profiles:
<img width="1614" height="515" alt="image" src="https://github.com/user-attachments/assets/1e3bbba1-a26d-472c-8049-d967c6681d9d" />

Switch to that profile and you'll see the selected color:
<img width="1916" height="28" alt="image" src="https://github.com/user-attachments/assets/4886e467-67e6-4a1a-9e57-0fb24980d83b" />

### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)

Close #3384 