### PR TITLE
Creation/Modification date filters and tooltip review

### DIFF
--- a/package.json
+++ b/package.json
@@ -514,6 +514,21 @@
 					"default": true,
 					"description": "If enabled, objects will be sorted by object name. If disabled, objects will be sorted by object type (MI object type)."
 				},
+				"code-for-ibmi.ObjectBrowser.filterDetails": {
+					"type": "string",
+					"default": "both",
+					"enum": [
+						"both",
+						"tooltip",
+						"description"
+					],
+					"enumDescriptions": [
+						"Show the details next to the filter name and in its hover",
+						"Only show the details in the filter's hover",
+						"Only show the details next to the filter name"
+					],
+					"description": "Where the details of an object filter (libraries, objects, members, etc.) are shown in the Object Browser."
+				},
 				"code-for-ibmi.IfsBrowser.DragAndDropDefaultBehavior": {
 					"type": "string",
 					"default": "ask",

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -747,7 +747,7 @@ export default class IBMiContent {
    * @param filter: the criterias used to list the members
    * @returns
    */
-  async getMemberList(filter: { library: string, sourceFile: string, members?: string | string[], extensions?: string, memberText?: string, sort?: SortOptions, filterType?: FilterType }): Promise<IBMiMember[]> {
+  async getMemberList(filter: { library: string, sourceFile: string, members?: string | string[], extensions?: string, memberText?: string, memberCreated?: string, memberChanged?: string, sort?: SortOptions, filterType?: FilterType }): Promise<IBMiMember[]> {
     const sort = filter.sort || { order: 'name' };
     const library = this.ibmi.upperCaseName(filter.library);
     const sourceFile = this.ibmi.upperCaseName(filter.sourceFile);
@@ -761,6 +761,9 @@ export default class IBMiContent {
 
     const memberTextFilter = parseFilter(filter.memberText, filter.filterType);
     const singleMemberText = memberTextFilter.noFilter && filter.memberText && !filter.memberText.includes(",") ? filter.memberText.toUpperCase().replace(/[*]/g, `%`) : undefined;
+
+    const createdFrom = Tools.parseFilterDate(filter.memberCreated);
+    const changedFrom = Tools.parseFilterDate(filter.memberChanged);
 
     const statement = /* sql */
       `SELECT RTRIM(OBJ_STAT.OBJNAME) AS SOURCE_FILE,
@@ -777,6 +780,8 @@ export default class IBMiContent {
         ${singleMember ? `AND RTRIM(PART_STAT.SYSTEM_TABLE_MEMBER) like '${singleMember.replaceAll('_', '+_')}' escape '+'` : ``}
         ${singleMemberExtension && singleMemberExtension.trim() !== '%' ? `AND RTRIM(CAST(PART_STAT.SOURCE_TYPE AS VARCHAR(10))) like '${singleMemberExtension.replaceAll('_', '+_')}' escape '+'` : ``}
         ${singleMemberText && singleMemberText.trim() !== '%' ? `AND UPPER(RTRIM(VARCHAR(PART_STAT.TEXT))) like '${singleMemberText.replaceAll('+', '++').replaceAll('_', '+_').replaceAll(`'`, `''`)}' escape '+'` : ``}
+        ${createdFrom ? `AND DATE(PART_STAT.CREATE_TIMESTAMP) >= DATE('${createdFrom}')` : ``}
+        ${changedFrom ? `AND DATE(PART_STAT.LAST_SOURCE_UPDATE_TIMESTAMP) >= DATE('${changedFrom}')` : ``}
         ORDER BY ${sort.order === 'name' ? 'NAME' : 'CHANGED'} ${!sort.ascending ? 'DESC' : 'ASC'}`;
 
     const results = await this.ibmi.runSQL(statement);

--- a/src/api/Tools.ts
+++ b/src/api/Tools.ts
@@ -160,6 +160,23 @@ export namespace Tools {
   }
   
   /**
+   * Validates a date used in a filter and returns it in its `YYYY-MM-DD` canonical form.
+   * @param date a date string, expected to be in the `YYYY-MM-DD` format
+   * @returns the validated date, or `undefined` if it's blank or invalid
+   */
+  export function parseFilterDate(date?: string) {
+    const parts = /^(\d{4})-(\d{2})-(\d{2})$/.exec((date || ``).trim());
+    if (parts) {
+      const [year, month, day] = parts.slice(1).map(Number);
+      const parsed = new Date(Date.UTC(year, month - 1, day));
+      if (parsed.getUTCFullYear() === year && parsed.getUTCMonth() === month - 1 && parsed.getUTCDate() === day) {
+        return parts[0];
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Transforms a file path into an OS agnostic path.
    * - Replaces full home directory path by ~
    * - Replaces all \ into / on Windows

--- a/src/api/configuration/config/types.ts
+++ b/src/api/configuration/config/types.ts
@@ -3,6 +3,7 @@ import { Action, ConnectionData, DeploymentMethod } from "../../types";
 
 export type DefaultOpenMode = "browse" | "edit";
 export type ReconnectMode = "always" | "never" | "ask";
+export type FilterDetails = "tooltip" | "description" | "both";
 
 export interface ConnectionConfig extends ConnectionProfile {
   host: string;
@@ -69,6 +70,7 @@ export interface GlobalConfiguration {
   safeDeleteMode: boolean;
   'ObjectBrowser.showNamesInLowercase': boolean;
   'ObjectBrowser.sortObjectsByName': boolean;
+  'ObjectBrowser.filterDetails': FilterDetails;
   autoOpenFile: boolean;
   'terminals.5250.openInEditorArea': boolean;
   'terminals.pase.openInEditorArea': boolean;

--- a/src/api/configuration/config/types.ts
+++ b/src/api/configuration/config/types.ts
@@ -90,6 +90,8 @@ export interface ObjectFilters {
   member: string
   memberType: string
   memberText?: string
+  memberCreated?: string
+  memberChanged?: string
   protected: boolean
 }
 

--- a/src/api/tests/suites/tools.test.ts
+++ b/src/api/tests/suites/tools.test.ts
@@ -257,3 +257,34 @@ describe('Tools.parseLsPermissions tests', { concurrent: true }, () => {
     });
   });
 });
+describe('Tools.parseFilterDate tests', { concurrent: true }, () => {
+  it('should accept a valid date', () => {
+    expect(Tools.parseFilterDate('2024-02-29')).toBe('2024-02-29');
+  });
+
+  it('should trim surrounding spaces', () => {
+    expect(Tools.parseFilterDate('  2024-01-31  ')).toBe('2024-01-31');
+  });
+
+  it('should return undefined when no date is given', () => {
+    expect(Tools.parseFilterDate(undefined)).toBeUndefined();
+    expect(Tools.parseFilterDate('')).toBeUndefined();
+    expect(Tools.parseFilterDate('   ')).toBeUndefined();
+  });
+
+  it('should reject a wrong format', () => {
+    expect(Tools.parseFilterDate('31/01/2024')).toBeUndefined();
+    expect(Tools.parseFilterDate('2024-1-1')).toBeUndefined();
+    expect(Tools.parseFilterDate('2024-01-01 00:00:00')).toBeUndefined();
+  });
+
+  it('should reject a non existing date', () => {
+    expect(Tools.parseFilterDate('2023-02-29')).toBeUndefined();
+    expect(Tools.parseFilterDate('2024-13-01')).toBeUndefined();
+    expect(Tools.parseFilterDate('2024-04-31')).toBeUndefined();
+  });
+
+  it('should reject an SQL injection attempt', () => {
+    expect(Tools.parseFilterDate(`2024-01-01') OR 1=1 --`)).toBeUndefined();
+  });
+});

--- a/src/ui/Tools.ts
+++ b/src/ui/Tools.ts
@@ -228,7 +228,9 @@ export namespace VscodeTools {
       "Object types": escapeHtml(filter.types.join(`, `)),
       "Members": escapeHtml(filter.member),
       "Member type": escapeHtml(filter.memberType || `*`),
-      "Member text": escapeHtml(filter.memberText || `*`),
+      "Member text": filter.memberText ? escapeHtml(filter.memberText) : undefined,
+      "Member created from": filter.memberCreated ? escapeHtml(filter.memberCreated) : undefined,
+      "Member changed from": filter.memberChanged ? escapeHtml(filter.memberChanged) : undefined,
       "Protected": filter.protected ? vscode.l10n.t(`Yes`) : undefined
     }));
     tooltip.supportHtml = true;

--- a/src/ui/Tools.ts
+++ b/src/ui/Tools.ts
@@ -221,12 +221,15 @@ export namespace VscodeTools {
   }
 
   export function filterToToolTip(filter: ObjectFilters) {
-    const tooltip = new MarkdownString(generateTooltipHtmlTable(filter.name, {
-      "Object": filter.object,
-      "Library": filter.library,
-      "Member": filter.member,
-      "Type": filter.memberType || `*`,
-      "Text": filter.memberText || `*`
+    const tooltip = new MarkdownString(generateTooltipHtmlTable(escapeHtml(filter.name), {
+      "Filtering type": filter.filterType === `regex` ? vscode.l10n.t(`Regex`) : vscode.l10n.t(`Simple`),
+      "Libraries": escapeHtml(filter.library),
+      "Objects": escapeHtml(filter.object),
+      "Object types": escapeHtml(filter.types.join(`, `)),
+      "Members": escapeHtml(filter.member),
+      "Member type": escapeHtml(filter.memberType || `*`),
+      "Member text": escapeHtml(filter.memberText || `*`),
+      "Protected": filter.protected ? vscode.l10n.t(`Yes`) : undefined
     }));
     tooltip.supportHtml = true;
     return tooltip;

--- a/src/ui/views/objectBrowser.ts
+++ b/src/ui/views/objectBrowser.ts
@@ -7,6 +7,7 @@ import IBMi, { MemberParts } from "../../api/IBMi";
 import { SortOptions, SortOrder } from "../../api/IBMiContent";
 import { SearchTools } from "../../api/SearchTools";
 import { Tools } from "../../api/Tools";
+import { onCodeForIBMiConfigurationChange } from "../../config/Configuration";
 import { getMemberUri } from "../../filesystems/qsys/QSysFs";
 import { instance } from "../../instantiate";
 import { CommandResult, DefaultOpenMode, FilteredItem, FocusOptions, IBMiMember, IBMiObject, MemberItem, OBJECT_BROWSER_MIMETYPE, ObjectFilters, ObjectItem, WithLibrary } from "../../typings";
@@ -16,6 +17,7 @@ import { BrowserItem, BrowserItemParameters } from "../types";
 
 const objectNamesLower = () => IBMi.connectionManager.get<boolean>(`ObjectBrowser.showNamesInLowercase`);
 const objectSortOrder = () => IBMi.connectionManager.get<SortOrder>(`ObjectBrowser.sortObjectsByName`) ? `name` : `type`;
+const filterDetails = () => IBMi.connectionManager.get(`ObjectBrowser.filterDetails`) || `both`;
 
 const correctCase = (value: string) => {
   ;
@@ -176,9 +178,12 @@ class ObjectBrowserFilterItem extends ObjectBrowserItem implements WithLibrary {
     super(filter, filter.name, { icon: filter.protected ? `lock-small` : '', state: vscode.TreeItemCollapsibleState.Collapsed });
     this.library = parseFilter(filter.library, filter.filterType).noFilter ? filter.library : '';
     this.contextValue = `filter${this.library ? "_library" : ''}${this.isProtected() ? `_readonly` : ``}`;
-    const memberTextSuffix = filter.memberText && !/^\*(?:ALL)?$/.test(filter.memberText.trim()) ? ` [${filter.memberText}]` : ``;
-    this.description = `${filter.library}/${filter.object}/${filter.member}.${filter.memberType || `*`} (${filter.types.join(`, `)})${memberTextSuffix}`;
-    this.tooltip = VscodeTools.filterToToolTip(filter);
+    const details = filterDetails();
+    if (details !== `tooltip`) {
+      const memberTextSuffix = filter.memberText && !/^\*(?:ALL)?$/.test(filter.memberText.trim()) ? ` [${filter.memberText}]` : ``;
+      this.description = `${filter.library}/${filter.object}/${filter.member}.${filter.memberType || `*`} (${filter.types.join(`, `)})${memberTextSuffix}`;
+    }
+    this.tooltip = details !== `description` ? VscodeTools.filterToToolTip(filter) : ``;
 
     if (this.library) {
       this.resourceUri = vscode.Uri.from({
@@ -560,6 +565,8 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     objectTreeViewer,
+
+    onCodeForIBMiConfigurationChange(`ObjectBrowser.filterDetails`, () => objectBrowser.refresh()),
 
     vscode.commands.registerCommand(`code-for-ibmi.sortMembersByName`, (item: ObjectBrowserSourcePhysicalFileItem | ObjectBrowserMemberItem) => {
       item.sortBy({ order: "name" });

--- a/src/ui/views/objectBrowser.ts
+++ b/src/ui/views/objectBrowser.ts
@@ -181,7 +181,11 @@ class ObjectBrowserFilterItem extends ObjectBrowserItem implements WithLibrary {
     const details = filterDetails();
     if (details !== `tooltip`) {
       const memberTextSuffix = filter.memberText && !/^\*(?:ALL)?$/.test(filter.memberText.trim()) ? ` [${filter.memberText}]` : ``;
-      this.description = `${filter.library}/${filter.object}/${filter.member}.${filter.memberType || `*`} (${filter.types.join(`, `)})${memberTextSuffix}`;
+      const dateSuffix = [
+        filter.memberCreated ? `created ≥ ${filter.memberCreated}` : ``,
+        filter.memberChanged ? `changed ≥ ${filter.memberChanged}` : ``
+      ].filter(Boolean).join(`, `);
+      this.description = `${filter.library}/${filter.object}/${filter.member}.${filter.memberType || `*`} (${filter.types.join(`, `)})${memberTextSuffix}${dateSuffix ? ` {${dateSuffix}}` : ``}`;
     }
     this.tooltip = details !== `description` ? VscodeTools.filterToToolTip(filter) : ``;
 
@@ -289,6 +293,8 @@ class ObjectBrowserSourcePhysicalFileItem extends ObjectBrowserItem implements O
         members: this.filter.member,
         extensions: this.filter.memberType,
         memberText: this.filter.memberText,
+        memberCreated: this.filter.memberCreated,
+        memberChanged: this.filter.memberChanged,
         filterType: this.filter.filterType,
         sort: this.sort
       });

--- a/src/webviews/CustomUI.ts
+++ b/src/webviews/CustomUI.ts
@@ -46,7 +46,7 @@ interface WebviewMessageRequest {
   data?: any;
 }
 
-type InputType = "text" | "number" | "color";
+type InputType = "text" | "number" | "color" | "date";
 
 export class Section {
   readonly fields: Field[] = [];
@@ -204,6 +204,10 @@ export class CustomHTML extends Section {
 
             .short-input {
               width: 15%;
+            }
+
+            .date-input {
+              width: 12em;
             }
 
             :root{
@@ -595,7 +599,7 @@ export class Field {
       case `input`:
         const multiline = (this.rows || 1) > 1;
         const tag = multiline ? "vscode-textarea" : "vscode-textfield";
-        const inputClass = this.inputType === 'color' ? `short-input` : `long-input`;
+        const inputClass = this.inputType === 'color' ? `short-input` : this.inputType === 'date' ? `date-input` : `long-input`;
         return /* html */`
           <vscode-form-group variant="settings-group">
               ${this.renderLabel()}

--- a/src/webviews/filters/index.ts
+++ b/src/webviews/filters/index.ts
@@ -61,8 +61,8 @@ export async function editFilter(filter?: ObjectFilters, copy = false) {
       .addInput(`member`, `Members`, `Member names filter.`, { default: filter.member })
       .addInput(`memberType`, `Member type`, `Member types filter.`, { default: filter.memberType })
       .addInput(`memberText`, `Member text`, `Member text description filter.`, { default: filter.memberText || `*` })
-      .addInput(`memberCreated`, `Member created from`, `Only list members created on or after this date. Leave blank to list members whatever their creation date is.`, { default: filter.memberCreated || ``, inputType: `date` })
-      .addInput(`memberChanged`, `Member changed from`, `Only list members last changed on or after this date. Leave blank to list members whatever their last change date is.`, { default: filter.memberChanged || ``, inputType: `date` })
+      .addInput(`memberCreated`, `Member created from`, `Only list members created on or after this date. Leave blank to list members regardless of what their creation date is.`, { default: filter.memberCreated || ``, inputType: `date` })
+      .addInput(`memberChanged`, `Member changed from`, `Only list members last changed on or after this date. Leave blank to list members regardless of what their last changed date is.`, { default: filter.memberChanged || ``, inputType: `date` })
       .addCheckbox(`protected`, `Protected`, `Make this filter protected, preventing modifications and source members from being saved.`, filter.protected)
       .addButtons({ id: `save`, label: `Save settings` })
       .loadPage<any>(`Filter: ${newFilter ? `New` : filter.name}`);

--- a/src/webviews/filters/index.ts
+++ b/src/webviews/filters/index.ts
@@ -23,6 +23,8 @@ export async function editFilter(filter?: ObjectFilters, copy = false) {
           member: filter.member,
           memberType: filter.memberType,
           memberText: filter.memberText || `*`,
+          memberCreated: filter.memberCreated,
+          memberChanged: filter.memberChanged,
           protected: filter.protected
         }
 
@@ -39,6 +41,8 @@ export async function editFilter(filter?: ObjectFilters, copy = false) {
         member: `*`,
         memberType: `*`,
         memberText: `*`,
+        memberCreated: ``,
+        memberChanged: ``,
         protected: false
       }
 
@@ -57,6 +61,8 @@ export async function editFilter(filter?: ObjectFilters, copy = false) {
       .addInput(`member`, `Members`, `Member names filter.`, { default: filter.member })
       .addInput(`memberType`, `Member type`, `Member types filter.`, { default: filter.memberType })
       .addInput(`memberText`, `Member text`, `Member text description filter.`, { default: filter.memberText || `*` })
+      .addInput(`memberCreated`, `Member created from`, `Only list members created on or after this date. Leave blank to list members whatever their creation date is.`, { default: filter.memberCreated || ``, inputType: `date` })
+      .addInput(`memberChanged`, `Member changed from`, `Only list members last changed on or after this date. Leave blank to list members whatever their last change date is.`, { default: filter.memberChanged || ``, inputType: `date` })
       .addCheckbox(`protected`, `Protected`, `Make this filter protected, preventing modifications and source members from being saved.`, filter.protected)
       .addButtons({ id: `save`, label: `Save settings` })
       .loadPage<any>(`Filter: ${newFilter ? `New` : filter.name}`);
@@ -93,6 +99,11 @@ export async function editFilter(filter?: ObjectFilters, copy = false) {
             break;
           case `memberText`:
             data[key] = String(data[key].trim()) || `*`;
+            break;
+          case `memberCreated`:
+          case `memberChanged`:
+            // reset anything that isn't a valid date 
+            data[key] = Tools.parseFilterDate(String(data[key])) || ``;
             break;
           case `protected`:
             // Do nothing. It's a boolean


### PR DESCRIPTION
### Changes
This PR add new config parameter related to object filters, in this way you can choose to show the text near the filter name, the tooltip with filter definition or both.

Is now also possible to filter by creation/modification date:
<img width="1184" height="518" alt="image" src="https://github.com/user-attachments/assets/ed93713a-b66f-4764-bdb2-cb443783c519" />

### How to test this PR
Open preferences and look for **Code-for-ibmi.Object Browser: Filter Details**, if you choose both you'll have tooltip and filter detail, tooltip only tooltip and description only filter detail near filter name.
Create a new filter with creation or modification date, you'll see only members that have been created or changed after that date.

### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)

Close #1903 