### PR TITLE
Fix extraction of `sqlstate` when using `runSQL` API

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -1486,9 +1486,16 @@ export default class IBMi {
             error = new Tools.SqlError(e.message);
             error.cause = statement
 
-            const parts: string[] = e.message.split(`,`);
-            if (parts.length >= 3) {
-              error.sqlstate = parts[parts.length - 2].trim();
+            // First attempt to extract sqlstate using a regex
+            const sqlstateMatch = /,\s*([0-9A-Z]{5}),\s*-?\d+\s*$/.exec(e.message);
+            if (sqlstateMatch) {
+              error.sqlstate = sqlstateMatch[1];
+            } else {
+              // Fallback to splitting the message by commas and taking the second to last part
+              const parts: string[] = e.message.split(`,`);
+              if (parts.length >= 3) {
+                error.sqlstate = parts[parts.length - 2].trim();
+              }
             }
 
             this.appendOutput(`${log}-> Failed: ${error.sqlstate ? `[${error.sqlstate}] ` : ''}${error.message}`);

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -1487,7 +1487,7 @@ export default class IBMi {
             error.cause = statement
 
             const parts: string[] = e.message.split(`,`);
-            if (parts.length > 3) {
+            if (parts.length >= 3) {
               error.sqlstate = parts[parts.length - 2].trim();
             }
 

--- a/src/api/tests/suites/content.test.ts
+++ b/src/api/tests/suites/content.test.ts
@@ -245,6 +245,16 @@ describe('Content Tests', { concurrent: true }, () => {
     }
   });
 
+  it('Test runSQL (column not found)', async () => {
+    try {
+      await connection.runSQL(`SELECT DOES_NOT_EXIST FROM QSYS2.PROGRAM_INFO WHERE PROGRAM_LIBRARY = 'RPGUNIT' AND PROGRAM_NAME = 'RUTESTCASE' AND OBJECT_TYPE = '*SRVPGM'`);
+      expect.fail('Should have thrown an error');
+    } catch (e: any) {
+      expect(e.message.endsWith('not found., 42703, -206')).toBeTruthy();
+      expect(e.sqlstate).toBe('42703');
+    }
+  });
+
   it('Test runSQL (with comments)', async () => {
 
     const rows = await connection.runSQL([

--- a/src/api/tests/suites/content.test.ts
+++ b/src/api/tests/suites/content.test.ts
@@ -250,7 +250,7 @@ describe('Content Tests', { concurrent: true }, () => {
       await connection.runSQL(`SELECT DOES_NOT_EXIST FROM QSYS2.PROGRAM_INFO WHERE PROGRAM_LIBRARY = 'RPGUNIT' AND PROGRAM_NAME = 'RUTESTCASE' AND OBJECT_TYPE = '*SRVPGM'`);
       expect.fail('Should have thrown an error');
     } catch (e: any) {
-      expect(e.message.endsWith('not found., 42703, -206')).toBeTruthy();
+      expect(e.message.endsWith('42703, -206')).toBeTruthy();
       expect(e.sqlstate).toBe('42703');
     }
   });


### PR DESCRIPTION
### Changes

Currently, `runSQL` has logic to extract the `sqlstate`, but this would only work if the message also contained a `,`. This is not always the case such as for `[SQL0206] Column or global variable COPYRIGHT_STRINGS not found., 42703, -206`.

### How to test this PR
1. Run the test cases

### Checklist
* [x] have tested my change
* [x] have created one or more test cases
* [x] Remove any/all `console.log`s I added
