### PR TITLE
Fixed "Compare" synch method not deleting files with whitespaces

### DIFF
--- a/src/filesystems/local/deployTools.ts
+++ b/src/filesystems/local/deployTools.ts
@@ -301,7 +301,7 @@ export namespace DeployTools {
         progress?.report({ message: `creating remote MD5 hash list` });
         const md5sumOut = await Deployment.getConnection().sendCommand({
           directory: parameters.remotePath,
-          command: `/QOpenSys/pkgs/bin/md5sum $(find . -type f)`
+          command: `find -type f -print0 | xargs -0 /QOpenSys/pkgs/bin/md5sum`
         });
 
         const remoteMD5: Deployment.MD5Entry[] = md5sumOut.stdout.split(`\n`).map(line => Deployment.toMD5Entry(line.trim()));
@@ -322,7 +322,7 @@ export namespace DeployTools {
 
         const toDelete: string[] = remoteMD5
           .filter(remote => !localFiles.some(local => remote.path === local.path))
-          .map(remote => remote.path);
+          .map(remote => `"${remote.path}"`);
 
         progress?.report({ message: `removing empty folders under ${parameters.remotePath}` });
         //PASE's find doesn't support the -empty flag so rmdir is run on every directory; not very clean, but it works

--- a/src/filesystems/local/deployment.ts
+++ b/src/filesystems/local/deployment.ts
@@ -235,8 +235,8 @@ export namespace Deployment {
   export function toMD5Entry(line: string): MD5Entry {
     const parts = line.split(/\s+/);
     return {
-      md5: parts[0].trim(),
-      path: parts[1].trim().substring(2) //these path starts with ./
+      md5: parts.shift()!,
+      path: parts.join(" ").trim().substring(2) //these path starts with ./
     };
   }
 


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
This PR fixes the `Compare` deployment method failing to delete files with whitespaces in their name.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Open a local workspace
2. Connect to an IBM i
3. Create a file in the workspace with whitespaces in its name (e.g. "my beautiful file.txt"
4. Run the `Compare` deployment method
5. Check the remote IFS folder: the file must be there
6. Delete the file with whitespaces in the local workspace
7. Run the `Compare` deployment method again
8. Check the remote IFS folder: the file must be gone
 
### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change