### PR TITLE
Add test cases to validate retrieval of symlinks

### DIFF
--- a/src/api/tests/suites/content.test.ts
+++ b/src/api/tests/suites/content.test.ts
@@ -353,6 +353,39 @@ describe('Content Tests', { concurrent: true }, () => {
     }
   });
 
+  it('Test getFileList (with symlink)', async () => {
+    const content = connection.getContent();
+    const dir = `/tmp/${Date.now()}`;
+    const targetFileName = `targetfile.txt`;
+    const targetDirName = `targetdir`;
+    const linkFileName = `linktofile`;
+    const linkDirName = `linktodir`;
+
+    let result;
+    result = await connection?.sendCommand({ command: `mkdir -p "${dir}/${targetDirName}" && touch "${dir}/${targetFileName}"` });
+    expect(result?.code).toBe(0);
+    try {
+      result = await connection?.sendCommand({ command: `ln -s "${dir}/${targetFileName}" "${dir}/${linkFileName}" && ln -s "${dir}/${targetDirName}" "${dir}/${linkDirName}"` });
+      expect(result?.code).toBe(0);
+
+      const objects = await content?.getFileList(dir);
+
+      const fileLink = objects?.find(obj => obj.name === linkFileName);
+      expect(fileLink).toBeDefined();
+      expect(fileLink?.type).toBe('streamfile');
+      expect(fileLink?.symlink).toBe(`${dir}/${targetFileName}`);
+
+      const dirLink = objects?.find(obj => obj.name === linkDirName);
+      expect(dirLink).toBeDefined();
+      expect(dirLink?.type).toBe('directory');
+      expect(dirLink?.symlink).toBe(`${dir}/${targetDirName}`);
+    }
+    finally {
+      result = await connection?.sendCommand({ command: `rm -r "${dir}"` });
+      expect(result?.code).toBe(0);
+    }
+  });
+
   it('Test getObjectList (all objects)', async () => {
     const content = connection.getContent();
 

--- a/src/api/tests/suites/content.test.ts
+++ b/src/api/tests/suites/content.test.ts
@@ -370,15 +370,25 @@ describe('Content Tests', { concurrent: true }, () => {
 
       const objects = await content?.getFileList(dir);
 
-      const fileLink = objects?.find(obj => obj.name === linkFileName);
-      expect(fileLink).toBeDefined();
-      expect(fileLink?.type).toBe('streamfile');
-      expect(fileLink?.symlink).toBe(`${dir}/${targetFileName}`);
+      const targetFile = objects?.find(obj => obj.name === targetFileName);
+      expect(targetFile).toBeDefined();
+      expect(targetFile?.type).toBe('streamfile');
+      expect(targetFile?.symlink).toBeUndefined();
 
-      const dirLink = objects?.find(obj => obj.name === linkDirName);
-      expect(dirLink).toBeDefined();
-      expect(dirLink?.type).toBe('directory');
-      expect(dirLink?.symlink).toBe(`${dir}/${targetDirName}`);
+      const targetDir = objects?.find(obj => obj.name === targetDirName);
+      expect(targetDir).toBeDefined();
+      expect(targetDir?.type).toBe('directory');
+      expect(targetDir?.symlink).toBeUndefined();
+
+      const linkFile = objects?.find(obj => obj.name === linkFileName);
+      expect(linkFile).toBeDefined();
+      expect(linkFile?.type).toBe('streamfile');
+      expect(linkFile?.symlink).toBe(`${dir}/${targetFileName}`);
+
+      const linkDir = objects?.find(obj => obj.name === linkDirName);
+      expect(linkDir).toBeDefined();
+      expect(linkDir?.type).toBe('directory');
+      expect(linkDir?.symlink).toBe(`${dir}/${targetDirName}`);
     }
     finally {
       result = await connection?.sendCommand({ command: `rm -r "${dir}"` });


### PR DESCRIPTION
### Changes

Follow up to PR https://github.com/codefori/vscode-ibmi/pull/3395 to add test cases to validate we can retrieve symlinks for stream files and directories in the IFS.

### How to test this PR

Run the test cases.

### Checklist
* [x] have tested my change
* [x] have created one or more test cases
