### PR TITLE
Fix diagnotics matched only on name + extension

### DIFF
--- a/src/ui/diagnostics.ts
+++ b/src/ui/diagnostics.ts
@@ -170,8 +170,7 @@ export async function handleEvfeventLines(connection: IBMi, lines: string[], evf
         // findExistingDocumentByName searches all open tabs — no workspace needed — so this works for
         // member-type actions too (where evfeventInfo.workspace is not set).
         if (!file.startsWith(`/`) && evfeventInfo.extension) {
-          const baseName = file.split(`/`).pop();
-          const lookupName = `${baseName}.${evfeventInfo.extension}`;
+          const lookupName = `${file}.${evfeventInfo.extension}`;
           const openFile = VscodeTools.findExistingDocumentByName(lookupName);
           if (openFile) {
             ileDiagnostics.set(openFile, diagnostics);


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
Fixes #3405 

This PR fixes the diagnostics mismatch reported in #3405.

The issue happens when a member includes another member with the exact same name, regardless of its extension or source file.

The process looked up for the member in the opened editors using the member name and the extension from the `eventf` object. In the present use case, both the issues reported for the main member and the included one would be set on the opened editor, the diagnostics from the included member would replace the ones from the main member, effectively hiding them.

The lookup for the opened member is now done using the full member path (library, file and name + extension) and it fixes the issue.

### How to test this PR

1. Create a copybook member named `TEST` inside a source file.
2. Create an SQLRPGLE program member also named `TEST` in a different source file.
3. Include the copybook in the program using `/COPY TEST`
4. Introduce a syntax error in the main `TEST` member
5. Compile using CRTSQLRPGI with RPGPPOPT(*LVL2) and OPTION(*EVENTF).
6. The issue for the main `TEST` member must be reported

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change