### PR TITLE
Add support for member locking

### DIFF
--- a/src/api/configuration/config/ConnectionManager.ts
+++ b/src/api/configuration/config/ConnectionManager.ts
@@ -39,6 +39,7 @@ function initialize(parameters: Partial<ConnectionConfig>): ConnectionConfig {
     readOnlyMode: (parameters.readOnlyMode === true),
     quickConnect: (parameters.quickConnect === true || parameters.quickConnect === undefined),
     defaultDeploymentMethod: parameters.defaultDeploymentMethod || ``,
+    lockMembers: (parameters.lockMembers === true),
     protectedPaths: (parameters.protectedPaths || []),
     showHiddenFiles: (parameters.showHiddenFiles === true || parameters.showHiddenFiles === undefined),
     secureSQL: (parameters.secureSQL === true),

--- a/src/api/configuration/config/types.ts
+++ b/src/api/configuration/config/types.ts
@@ -34,6 +34,7 @@ export interface ConnectionConfig extends ConnectionProfile {
   readOnlyMode: boolean;
   quickConnect: boolean;
   defaultDeploymentMethod: DeploymentMethod | '';
+  lockMembers: boolean;
   protectedPaths: string[];
   showHiddenFiles: boolean;
   secureSQL: boolean;

--- a/src/api/memberLocks.ts
+++ b/src/api/memberLocks.ts
@@ -1,5 +1,13 @@
 import IBMi, { MemberParts } from "./IBMi";
 
+export enum LockState {
+  SHARED_READ = `*SHRRD`, 
+  SHARED_UPDATE = `*SHRUPD`,
+  SHARED_NO_UPDATE = `*SHRNUP`,
+  EXCLUSIVE_ALLOW_READ = `*EXCLRD`,
+  EXCLUSIVE_NO_READ = `*EXCL`
+}
+
 export class MemberLocks {
   private readonly lockedMembers: Map<string, MemberParts> = new Map();
 
@@ -17,7 +25,7 @@ export class MemberLocks {
    */
   async allocate(connection: IBMi, memberParts: MemberParts): Promise<boolean> {
     const result = await connection.runCommand({
-      command: `QSYS/ALCOBJ OBJ((${memberParts.library}/${memberParts.file} *FILE *EXCL ${memberParts.name})) WAIT(0) SCOPE(*JOB)`,
+      command: `QSYS/ALCOBJ OBJ((${memberParts.library}/${memberParts.file} *FILE ${LockState.SHARED_UPDATE} ${memberParts.name})) SCOPE(*JOB)`,
       noLibList: true
     });
 
@@ -35,7 +43,7 @@ export class MemberLocks {
    */
   async deallocate(connection: IBMi, memberParts: MemberParts): Promise<boolean> {
     const result = await connection.runCommand({
-      command: `QSYS/DLCOBJ OBJ((${memberParts.library}/${memberParts.file} *FILE *EXCL ${memberParts.name})) SCOPE(*JOB)`,
+      command: `QSYS/DLCOBJ OBJ((${memberParts.library}/${memberParts.file} *FILE ${LockState.SHARED_UPDATE} ${memberParts.name})) SCOPE(*JOB)`,
       noLibList: true
     });
 
@@ -56,7 +64,7 @@ export class MemberLocks {
     if (connection) {
       await Promise.all(members.map(memberParts =>
         connection.runCommand({
-          command: `QSYS/DLCOBJ OBJ((${memberParts.library}/${memberParts.file} *FILE *EXCL ${memberParts.name})) SCOPE(*JOB)`,
+          command: `QSYS/DLCOBJ OBJ((${memberParts.library}/${memberParts.file} *FILE ${LockState.SHARED_UPDATE} ${memberParts.name})) SCOPE(*JOB)`,
           noLibList: true
         }).catch(() => { })
       ));

--- a/src/api/memberLocks.ts
+++ b/src/api/memberLocks.ts
@@ -1,0 +1,65 @@
+import IBMi, { MemberParts } from "./IBMi";
+
+export class MemberLocks {
+  private readonly lockedMembers: Map<string, MemberParts> = new Map();
+
+  private memberKey(memberParts: MemberParts): string {
+    return `${memberParts.library}/${memberParts.file}/${memberParts.name}`;
+  }
+
+  isLocked(memberParts: MemberParts): boolean {
+    return this.lockedMembers.has(this.memberKey(memberParts));
+  }
+
+  /**
+   * Allocates an exclusive lock on a member using ALCOBJ.
+   * @returns `true` if the lock was successfully acquired, `false` otherwise.
+   */
+  async allocate(connection: IBMi, memberParts: MemberParts): Promise<boolean> {
+    const result = await connection.runCommand({
+      command: `QSYS/ALCOBJ OBJ((${memberParts.library}/${memberParts.file} *FILE *EXCL ${memberParts.name})) WAIT(0) SCOPE(*JOB)`,
+      noLibList: true
+    });
+
+    if (result.code === 0) {
+      this.lockedMembers.set(this.memberKey(memberParts), memberParts);
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Deallocates an exclusive lock on a member using DLCOBJ.
+   * @returns `true` if the lock was successfully released, `false` otherwise.
+   */
+  async deallocate(connection: IBMi, memberParts: MemberParts): Promise<boolean> {
+    const result = await connection.runCommand({
+      command: `QSYS/DLCOBJ OBJ((${memberParts.library}/${memberParts.file} *FILE *EXCL ${memberParts.name})) SCOPE(*JOB)`,
+      noLibList: true
+    });
+
+    if (result.code === 0) {
+      this.lockedMembers.delete(this.memberKey(memberParts));
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Deallocates all currently held locks.
+   */
+  async deallocateAll(connection: IBMi | undefined): Promise<void> {
+    const members = [...this.lockedMembers.values()];
+    this.lockedMembers.clear();
+    if (connection) {
+      await Promise.all(members.map(memberParts =>
+        connection.runCommand({
+          command: `QSYS/DLCOBJ OBJ((${memberParts.library}/${memberParts.file} *FILE *EXCL ${memberParts.name})) SCOPE(*JOB)`,
+          noLibList: true
+        }).catch(() => { })
+      ));
+    }
+  }
+}

--- a/src/api/tests/suites/memberLocks.test.ts
+++ b/src/api/tests/suites/memberLocks.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { CONNECTION_TIMEOUT, disposeConnection, newConnection } from '../connection';
+import IBMi, { MemberParts } from '../../IBMi';
+import { MemberLocks } from '../../memberLocks';
+import { Tools } from '../../Tools';
+
+describe(`Member Lock Tests`, () => {
+  let connection: IBMi;
+  let tempLib: string;
+  let tempFile: string;
+
+  let qualifiedJobName: string;
+
+  beforeAll(async () => {
+    connection = await newConnection();
+    const config = connection.getConfig();
+
+    tempLib = connection.upperCaseName(config.tempLibrary);
+    tempFile = connection.upperCaseName(Tools.makeid(8));
+
+    const [jobRow] = await connection.runSQL(`VALUES QSYS2.JOB_NAME`);
+    qualifiedJobName = String(jobRow["00001"]);
+
+    const createFile = await connection.runCommand({
+      command: `QSYS/CRTSRCPF FILE(${tempLib}/${tempFile}) RCDLEN(112)`,
+      noLibList: true
+    });
+    expect(createFile.code).toBe(0);
+
+    for (const mbr of [`MBR1`, `MBR2`, `MBR3`, `MBR4`]) {
+      const addMember = await connection.runCommand({
+        command: `QSYS/ADDPFM FILE(${tempLib}/${tempFile}) MBR(${mbr}) SRCTYPE(RPGLE)`,
+        noLibList: true
+      });
+      if (addMember.code !== 0) {
+        throw new Error(`Failed to create member ${mbr}: ${addMember.stderr}`);
+      }
+    }
+  }, CONNECTION_TIMEOUT);
+
+  afterAll(async () => {
+    await connection.runCommand({
+      command: `QSYS/DLTF FILE(${tempLib}/${tempFile})`,
+      noLibList: true
+    });
+    await disposeConnection(connection);
+  });
+
+  function member(name: string): MemberParts {
+    return { library: tempLib, file: tempFile, name, extension: `RPGLE`, basename: `${name}.RPGLE` };
+  }
+
+  async function validateIsLocked(locks: MemberLocks, memberParts: MemberParts, expected: boolean): Promise<void> {
+    expect(locks.isLocked(memberParts)).toBe(expected);
+
+    const rows = await connection.runSQL([
+      `SELECT * FROM QSYS2.OBJECT_LOCK_INFO`,
+      `    WHERE SYSTEM_OBJECT_SCHEMA = '${memberParts.library}'`,
+      `    AND SYSTEM_OBJECT_NAME = '${memberParts.file}'`,
+      `    AND OBJECT_TYPE = '*FILE'`,
+      `    AND SYSTEM_TABLE_MEMBER = '${memberParts.name}'`,
+      `    AND JOB_NAME = '${qualifiedJobName}'`,
+    ].join(`\n`));
+
+    if (expected) {
+      expect(rows.length).toBeGreaterThan(0);
+    } else {
+      expect(rows.length).toBe(0);
+    }
+  }
+
+  it(`Standard allocate and deallocate lifecycle`, async () => {
+    const locks = new MemberLocks();
+
+    // Allocate MBR1, MBR2, MBR3 — skip MBR4
+    expect(await locks.allocate(connection, member(`MBR1`))).toBe(true);
+    expect(await locks.allocate(connection, member(`MBR2`))).toBe(true);
+    expect(await locks.allocate(connection, member(`MBR3`))).toBe(true);
+
+    await validateIsLocked(locks, member(`MBR1`), true);
+    await validateIsLocked(locks, member(`MBR2`), true);
+    await validateIsLocked(locks, member(`MBR3`), true);
+    await validateIsLocked(locks, member(`MBR4`), false);
+
+    // Deallocate MBR1
+    expect(await locks.deallocate(connection, member(`MBR1`))).toBe(true);
+
+    await validateIsLocked(locks, member(`MBR1`), false);
+    await validateIsLocked(locks, member(`MBR2`), true);
+    await validateIsLocked(locks, member(`MBR3`), true);
+    await validateIsLocked(locks, member(`MBR4`), false);
+
+    // Deallocate all
+    await locks.deallocateAll(connection);
+
+    await validateIsLocked(locks, member(`MBR1`), false);
+    await validateIsLocked(locks, member(`MBR2`), false);
+    await validateIsLocked(locks, member(`MBR3`), false);
+    await validateIsLocked(locks, member(`MBR4`), false);
+  });
+
+  it(`Allocate a non-existent member`, async () => {
+    const locks = new MemberLocks();
+
+    const result = await locks.allocate(connection, member(`NOEXIST`));
+
+    expect(result).toBe(false);
+    await validateIsLocked(locks, member(`NOEXIST`), false);
+  });
+
+  it(`Deallocate a non-existent member`, async () => {
+    const locks = new MemberLocks();
+
+    const result = await locks.deallocate(connection, member(`NOEXIST`));
+
+    expect(result).toBe(false);
+    await validateIsLocked(locks, member(`NOEXIST`), false);
+  });
+});

--- a/src/api/tests/suites/memberLocks.test.ts
+++ b/src/api/tests/suites/memberLocks.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { CONNECTION_TIMEOUT, disposeConnection, newConnection } from '../connection';
 import IBMi, { MemberParts } from '../../IBMi';
-import { MemberLocks } from '../../memberLocks';
+import { LockState, MemberLocks } from '../../memberLocks';
 import { Tools } from '../../Tools';
 
 describe(`Member Lock Tests`, () => {
@@ -54,7 +54,7 @@ describe(`Member Lock Tests`, () => {
     expect(locks.isLocked(memberParts)).toBe(expected);
 
     const rows = await connection.runSQL([
-      `SELECT * FROM QSYS2.OBJECT_LOCK_INFO`,
+      `SELECT MEMBER_LOCK_TYPE, LOCK_STATE FROM QSYS2.OBJECT_LOCK_INFO`,
       `    WHERE SYSTEM_OBJECT_SCHEMA = '${memberParts.library}'`,
       `    AND SYSTEM_OBJECT_NAME = '${memberParts.file}'`,
       `    AND OBJECT_TYPE = '*FILE'`,
@@ -63,7 +63,11 @@ describe(`Member Lock Tests`, () => {
     ].join(`\n`));
 
     if (expected) {
-      expect(rows.length).toBeGreaterThan(0);
+      const memberRow = rows.find(r => r.MEMBER_LOCK_TYPE === `MEMBER`);
+      expect(memberRow?.LOCK_STATE).toBe(`*SHRRD`);
+
+      const dataRow = rows.find(r => r.MEMBER_LOCK_TYPE === `DATA`);
+      expect(dataRow?.LOCK_STATE).toBe(LockState.SHARED_UPDATE);
     } else {
       expect(rows.length).toBe(0);
     }

--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -2,6 +2,7 @@ import { parse as parsePath } from "path";
 import { parse, ParsedUrlQueryInput, stringify } from "querystring";
 import vscode, { FilePermission, FileSystemError, l10n } from "vscode";
 import IBMi from "../../api/IBMi";
+import { MemberLocks } from "../../api/memberLocks";
 import { Tools } from "../../api/Tools";
 import { onCodeForIBMiConfigurationChange } from "../../config/Configuration";
 import { instance } from "../../instantiate";
@@ -48,6 +49,7 @@ export class QSysFS implements vscode.FileSystemProvider {
     private readonly savedAsMembers: Set<string> = new Set;
     private readonly sourceDateHandler: SourceDateHandler;
     private readonly extendedContent: ExtendedIBMiContent;
+    private readonly memberLocks = new MemberLocks();
     private extendedMemberSupport = false;
     private emitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
     onDidChangeFile: vscode.Event<vscode.FileChangeEvent[]> = this.emitter.event;
@@ -59,32 +61,112 @@ export class QSysFS implements vscode.FileSystemProvider {
         instance.subscribe(
             context,
             'connected',
-            `Update member support`,
-            () => this.updateMemberSupport());
+            `Update member support & lock open members`,
+            () => {
+                this.updateMemberSupport();
+                this.lockOpenMembers();
+            });
 
         instance.subscribe(
             context,
             'disconnected',
-            `Update member support & clear library ASP cache`,
+            `Update member support & release all locks`,
             () => {
                 this.updateMemberSupport();
+                this.memberLocks.deallocateAll(undefined);
             });
 
-        context.subscriptions.push(onCodeForIBMiConfigurationChange("connectionSettings", () => {
-            if (this.extendedMemberSupport !== instance.getConnection()?.getConfig().enableSourceDates) {
-                instance.getStorage()?.unmarkMessageAsShown(SOURCE_DATES_RESET_WARNING);
-                this.updateMemberSupport();
-                const openedMembers = vscode.window.tabGroups.all
-                    .flatMap(group => group.tabs)
-                    .filter(tab => tab.input instanceof vscode.TabInputText)
-                    .map(tab => (tab.input as vscode.TabInputText).uri)
-                    .filter(uri => uri.scheme === "member");
-                if (this.extendedMemberSupport === instance.getConnection()?.getConfig().enableSourceDates && openedMembers.length) {
-                    vscode.window.showWarningMessage(l10n.t("Source date support is now {0}. Please backup and then close opened IBM i source member(s):", this.extendedMemberSupport ? l10n.t("enabled") : l10n.t("disabled")),
-                        { modal: true, detail: openedMembers.map(e => `- ${e.path.substring(1)}`).join("\n") });
+        context.subscriptions.push(
+            vscode.workspace.onDidOpenTextDocument(async doc => {
+                if (doc.uri.scheme !== `member`) {
+                    return;
                 }
-            }
-        }));
+
+                const connection = instance.getConnection();
+                if (!connection) {
+                    return;
+                }
+
+                const config = connection.getConfig();
+                if (!config.lockMembers) {
+                    return;
+                }
+
+                try {
+                    const memberParts = connection.parserMemberPath(doc.uri.path);
+                    await this.memberLocks.allocate(connection, memberParts);
+                } catch { }
+            }),
+            vscode.workspace.onDidCloseTextDocument(async doc => {
+                if (doc.uri.scheme !== `member`) {
+                    return;
+                }
+
+                const connection = instance.getConnection();
+                if (!connection) {
+                    return;
+                }
+
+                const config = connection.getConfig();
+                if (!config.lockMembers) {
+                    return;
+                }
+
+                try {
+                    const memberParts = connection.parserMemberPath(doc.uri.path);
+                    if (this.memberLocks.isLocked(memberParts)) {
+                        await this.memberLocks.deallocate(connection, memberParts);
+                    }
+                } catch { }
+
+            }),
+            onCodeForIBMiConfigurationChange("connectionSettings", () => {
+                const connection = instance.getConnection();
+                const config = connection?.getConfig();
+
+                if (this.extendedMemberSupport !== config?.enableSourceDates) {
+                    instance.getStorage()?.unmarkMessageAsShown(SOURCE_DATES_RESET_WARNING);
+                    this.updateMemberSupport();
+                    const openedMembers = vscode.window.tabGroups.all
+                        .flatMap(group => group.tabs)
+                        .filter(tab => tab.input instanceof vscode.TabInputText)
+                        .map(tab => (tab.input as vscode.TabInputText).uri)
+                        .filter(uri => uri.scheme === "member");
+                    if (this.extendedMemberSupport === config?.enableSourceDates && openedMembers.length) {
+                        vscode.window.showWarningMessage(l10n.t("Source date support is now {0}. Please backup and then close opened IBM i source member(s):", this.extendedMemberSupport ? l10n.t("enabled") : l10n.t("disabled")),
+                            { modal: true, detail: openedMembers.map(e => `- ${e.path.substring(1)}`).join("\n") });
+                    }
+                }
+
+                if (config?.lockMembers) {
+                    this.lockOpenMembers();
+                }
+            })
+        );
+    }
+
+    private async lockOpenMembers(): Promise<void> {
+        const connection = instance.getConnection();
+        if (!connection) {
+            return;
+        }
+
+        const config = connection.getConfig();
+        if (!config.lockMembers) {
+            return;
+        }
+
+        const openMemberTextDocuments = vscode.workspace.textDocuments
+            .filter(doc => doc.uri.scheme === `member` && !doc.isClosed);
+
+        for (const doc of openMemberTextDocuments) {
+            try {
+                const memberParts = connection.parserMemberPath(doc.uri.path);
+                if (!this.memberLocks.isLocked(memberParts)) {
+                    await this.memberLocks.allocate(connection, memberParts);
+                }
+            } catch { }
+        }
     }
 
     private updateMemberSupport() {

--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -77,26 +77,6 @@ export class QSysFS implements vscode.FileSystemProvider {
             });
 
         context.subscriptions.push(
-            vscode.workspace.onDidOpenTextDocument(async doc => {
-                if (doc.uri.scheme !== `member`) {
-                    return;
-                }
-
-                const connection = instance.getConnection();
-                if (!connection) {
-                    return;
-                }
-
-                const config = connection.getConfig();
-                if (!config.lockMembers) {
-                    return;
-                }
-
-                try {
-                    const memberParts = connection.parserMemberPath(doc.uri.path);
-                    await this.memberLocks.allocate(connection, memberParts);
-                } catch { }
-            }),
             vscode.workspace.onDidCloseTextDocument(async doc => {
                 if (doc.uri.scheme !== `member`) {
                     return;
@@ -140,6 +120,8 @@ export class QSysFS implements vscode.FileSystemProvider {
 
                 if (config?.lockMembers) {
                     this.lockOpenMembers();
+                } else {
+                    this.memberLocks.deallocateAll(connection);
                 }
             })
         );
@@ -245,16 +227,27 @@ export class QSysFS implements vscode.FileSystemProvider {
         const connection = instance.getConnection();
         if (connection) {
             const contentApi = connection.getContent();
-            let { asp, library, file, name: member } = await this.parseMemberPath(connection, uri.path);
+            const memberParts = await this.parseMemberPath(connection, uri.path);
+            let { asp, library, file, name: member } = memberParts;
             asp = asp || await connection.getLibraryIAsp(library);
+
+            const config = connection.getConfig();
+            if (config.lockMembers) {
+                if (!this.memberLocks.isLocked(memberParts)) {
+                    await this.memberLocks.allocate(connection, memberParts);
+                }
+            }
 
             let memberContent;
             try {
                 memberContent = this.extendedMemberSupport ?
                     await this.extendedContent.downloadMemberContentWithDates(uri) :
                     await contentApi.downloadMemberContent(library, file, member);
-            } catch (error) {
-                if (!retrying && await this.stat(uri)) { //Check if exists on an iASP and retry if so
+            } catch (error: any) {
+                const messages = Tools.parseMessages(error.message);
+                if (messages.findId(`CPF5729`)) { // CPF5729 - Not able to allocate object
+                    throw new FileSystemError(error.message);
+                } else if (!retrying && await this.stat(uri)) { //Check if exists on an iASP and retry if so
                     return this.readFile(uri, true);
                 }
                 throw error;

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -220,6 +220,8 @@ export class SettingsUI {
             }
           ], `Set your Default Deployment Method. This is used when deploying from the local workspace to the server.`)
           .addHorizontalRule()
+          .addCheckbox(`lockMembers`, `Lock Members`, `When enabled, an exclusive lock (<code>ALCOBJ *EXCL</code>) will be allocated on a source member when it is opened and released (<code>DLCOBJ</code>) when it is closed.`, config.lockMembers)
+          .addHorizontalRule()
           .addInput(`protectedPaths`, `Protected paths`, `A comma separated list of libraries and/or IFS directories whose members will always be opened in read-only mode. (Example: <code>QGPL, /home/QSECOFR, MYLIB, /QIBM</code>)`, { default: config.protectedPaths.join(`, `) });
 
         setFieldsReadOnly(sourceTab);

--- a/src/webviews/settings/index.ts
+++ b/src/webviews/settings/index.ts
@@ -220,7 +220,7 @@ export class SettingsUI {
             }
           ], `Set your Default Deployment Method. This is used when deploying from the local workspace to the server.`)
           .addHorizontalRule()
-          .addCheckbox(`lockMembers`, `Lock Members`, `When enabled, an exclusive lock (<code>ALCOBJ *EXCL</code>) will be allocated on a source member when it is opened and released (<code>DLCOBJ</code>) when it is closed.`, config.lockMembers)
+          .addCheckbox(`lockMembers`, `Lock Members`, `When enabled, a shared-update lock (<code>*SHRUPD</code>) will be allocated on a source member when it is opened and deallocated when it is closed.`, config.lockMembers)
           .addHorizontalRule()
           .addInput(`protectedPaths`, `Protected paths`, `A comma separated list of libraries and/or IFS directories whose members will always be opened in read-only mode. (Example: <code>QGPL, /home/QSECOFR, MYLIB, /QIBM</code>)`, { default: config.protectedPaths.join(`, `) });
 


### PR DESCRIPTION
### Changes

This PR adds support for member locking using a shared-update lock (`*SHRUPD`) that is allocated on reads and deallocated when we close the editor. This is an opt in setting meaning it is disabled by default.

This has been requested in https://github.com/codefori/vscode-ibmi/issues/1688 and https://github.com/codefori/vscode-ibmi/issues/2409

### How to test this PR
1. Debug the extension using this branch.
1. Navigate to the connection settings and enable `Member Locking` under the `Source Code` tab.
2. Open a member.
3. Launch a separate VS Code window running the release version of Code4i.
4. Attempt to open the same member in this new window and observe the member is locked.
5. In the first window, disable the setting.
6. In the second window, reattempt to open the member and observe that it can be opened.

### Checklist
* [ ] have tested my change
* [x] have created one or more test cases
* [ ] updated relevant documentation
