### PR TITLE
Validate if library in system portion before adding to user portion in libl

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -535,6 +535,21 @@ export default class IBMiContent {
   }
 
   /**
+   * Returns the names of libraries currently in the system portion of the library list.
+   * @returns Array of library names in the system portion
+   */
+  async getSystemLibraries(): Promise<string[]> {
+    try {
+      const result = await this.ibmi.runSQL(
+        `SELECT SYSTEM_SCHEMA_NAME FROM TABLE(QSYS2.QSQLIBL()) WHERE TYPE = 'SYSTEM'`
+      );
+      return result.map(row => String(row.SYSTEM_SCHEMA_NAME));
+    } catch {
+      return [];
+    }
+  }
+
+  /**
    * Validates a list of libraries
    * @param newLibl Array of libraries to validate
    * @returns Bad libraries

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -47,6 +47,7 @@ export default class IBMiContent {
   constructor(readonly ibmi: IBMi) { }
 
   private dummyDSPF = false;
+  private systemLibraries?: string[];
 
   private get config() {
     return this.ibmi.getConfig();
@@ -54,6 +55,7 @@ export default class IBMiContent {
 
   reset() {
     this.dummyDSPF = false;
+    this.systemLibraries = undefined;
   }
 
   private getTempRemote(path: string) {
@@ -536,17 +538,22 @@ export default class IBMiContent {
 
   /**
    * Returns the names of libraries currently in the system portion of the library list.
+   * We use cache because SYSLIBL cannot change (the only way is to run chgsyslibl)
    * @returns Array of library names in the system portion
    */
   async getSystemLibraries(): Promise<string[]> {
-    try {
-      const result = await this.ibmi.runSQL(
-        `SELECT SYSTEM_SCHEMA_NAME FROM TABLE(QSYS2.QSQLIBL()) WHERE TYPE = 'SYSTEM'`
-      );
-      return result.map(row => String(row.SYSTEM_SCHEMA_NAME));
-    } catch {
-      return [];
+    if (!this.systemLibraries) {
+      try {
+        const result = await this.ibmi.runSQL(
+          `SELECT SYSTEM_SCHEMA_NAME FROM TABLE(QSYS2.QSQLIBL()) WHERE TYPE = 'SYSTEM'`
+        );
+        this.systemLibraries = result.map(row => String(row.SYSTEM_SCHEMA_NAME));
+      } catch {
+        return [];
+      }
     }
+
+    return this.systemLibraries;
   }
 
   /**

--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -549,7 +549,7 @@ export default class IBMiContent {
         );
         this.systemLibraries = result.map(row => String(row.SYSTEM_SCHEMA_NAME));
       } catch {
-        return [];
+        this.systemLibraries = [];
       }
     }
 

--- a/src/editors/connectionProfileEditor.ts
+++ b/src/editors/connectionProfileEditor.ts
@@ -67,7 +67,15 @@ async function save(profile: ConnectionProfile, data: ConnectionProfileData) {
         }
       }
 
-      const libraryList = data.libraryList.split(',').map(library => library.trim());
+      let libraryList = data.libraryList.split(',').map(library => library.trim());
+
+      const systemLibraries = await content.getSystemLibraries();
+      const librariesInSystemPortion = libraryList.filter(library => systemLibraries.includes(connection.upperCaseName(library)));
+      if (librariesInSystemPortion.length) {
+        libraryList = libraryList.filter(library => !librariesInSystemPortion.includes(library));
+        vscode.window.showWarningMessage(l10n.t("The following libraries are already in the system portion of the library list and were removed: {0}", librariesInSystemPortion.sort().join(', ')));
+      }
+
       const badLibraries = await content.validateLibraryList(libraryList);
       if (badLibraries.length && !await vscode.window.showWarningMessage(l10n.t("The following libraries are invalid. Do you still want to save that profile?"), {
         modal: true,

--- a/src/ui/views/LibraryListView.ts
+++ b/src/ui/views/LibraryListView.ts
@@ -113,6 +113,15 @@ export function initializeLibraryListView(context: vscode.ExtensionContext) {
               .split(` `)
               .map(lib => connection.upperCaseName(lib))
               .filter((lib, idx, libl) => lib && libl.indexOf(lib) === idx);
+
+            // Validate no library is already in the system portion
+            const sysLibs = await content.getSystemLibraries();
+            const sysLibsFound = newLibraryList.filter(lib => sysLibs.includes(lib));
+            if (sysLibsFound.length > 0) {
+              newLibraryList = newLibraryList.filter(lib => !sysLibsFound.includes(lib));
+              vscode.window.showWarningMessage(l10n.t(`The following libraries are already in the system portion of the library list and were removed: {0}`, sysLibsFound.join(', ')));
+            }
+
             const badLibs = await content.validateLibraryList(newLibraryList);
 
             if (badLibs.length > 0) {
@@ -158,20 +167,19 @@ export function initializeLibraryListView(context: vscode.ExtensionContext) {
         }
 
         // Validate library exists
-        let badLibs = await content.validateLibraryList([addingLib]);
+        const badLibs = await content.validateLibraryList([addingLib]);
         if (badLibs.length > 0) {
-          usrLibs = usrLibs.filter(lib => !badLibs.includes(lib));
           vscode.window.showWarningMessage(l10n.t(`Library {0} does not exist.`, badLibs.join(', ')));
-        } else {
-          usrLibs.push(addingLib);
-          vscode.window.showInformationMessage(l10n.t(`Library {0} was added to the library list.`, addingLib));
+          return;
         }
 
-        badLibs = await content.validateLibraryList(usrLibs);
+        usrLibs.push(addingLib);
+        vscode.window.showInformationMessage(l10n.t(`Library {0} was added to the library list.`, addingLib));
 
-        if (badLibs.length > 0) {
-          usrLibs = usrLibs.filter(lib => !badLibs.includes(lib));
-          vscode.window.showWarningMessage(l10n.t(`The following libraries were removed from the updated library list as they are invalid: {0}`, badLibs.join(', ')));
+        const invalidLibs = await content.validateLibraryList(usrLibs);
+        if (invalidLibs.length > 0) {
+          usrLibs = usrLibs.filter(lib => !invalidLibs.includes(lib));
+          vscode.window.showWarningMessage(l10n.t(`The following libraries were removed from the updated library list as they are invalid: {0}`, invalidLibs.join(', ')));
         }
 
         config.libraryList = usrLibs;
@@ -372,7 +380,7 @@ class LibraryListView implements vscode.TreeDataProvider<LibraryListNode> {
 
       items.push(...curAndUsrLibs.map((lib, index) => {
         const upperCaseLibName = connection.upperCaseName(lib.name);
-        const isSystemLib = index > 0 && sysLibs.includes(upperCaseLibName);
+        const isSystemLib = sysLibs.includes(upperCaseLibName);
         return new LibraryListNode(upperCaseLibName, lib, (index === 0 ? `currentLibrary` : `library`), config.showDescInLibList, isSystemLib);
       }));
     }

--- a/src/ui/views/LibraryListView.ts
+++ b/src/ui/views/LibraryListView.ts
@@ -143,31 +143,38 @@ export function initializeLibraryListView(context: vscode.ExtensionContext) {
           return;
         }
 
-        let libraryList = [...config.libraryList];
+        // Validate library is not in the system portion
+        const sysLibs = await content.getSystemLibraries();
+        if (sysLibs.includes(addingLib)) {
+          vscode.window.showErrorMessage(l10n.t(`Library {0} is already in the system portion of the library list.`, addingLib));
+          return;
+        }
 
-        if (libraryList.includes(addingLib)) {
+        // Validate library is not already in the user portion
+        let usrLibs = [...config.libraryList];
+        if (usrLibs.includes(addingLib)) {
           vscode.window.showWarningMessage(l10n.t(`Library {0} was already in the library list.`, addingLib));
           return;
         }
 
+        // Validate library exists
         let badLibs = await content.validateLibraryList([addingLib]);
-
         if (badLibs.length > 0) {
-          libraryList = libraryList.filter(lib => !badLibs.includes(lib));
+          usrLibs = usrLibs.filter(lib => !badLibs.includes(lib));
           vscode.window.showWarningMessage(l10n.t(`Library {0} does not exist.`, badLibs.join(', ')));
         } else {
-          libraryList.push(addingLib);
+          usrLibs.push(addingLib);
           vscode.window.showInformationMessage(l10n.t(`Library {0} was added to the library list.`, addingLib));
         }
 
-        badLibs = await content.validateLibraryList(libraryList);
+        badLibs = await content.validateLibraryList(usrLibs);
 
         if (badLibs.length > 0) {
-          libraryList = libraryList.filter(lib => !badLibs.includes(lib));
+          usrLibs = usrLibs.filter(lib => !badLibs.includes(lib));
           vscode.window.showWarningMessage(l10n.t(`The following libraries were removed from the updated library list as they are invalid: {0}`, badLibs.join(', ')));
         }
 
-        config.libraryList = libraryList;
+        config.libraryList = usrLibs;
         await updateConfig(config);
       }
     }),
@@ -358,10 +365,15 @@ class LibraryListView implements vscode.TreeDataProvider<LibraryListNode> {
       const config = connection.getConfig();
       const currentLibrary = connection.upperCaseName(config.currentLibrary);
 
-      const libraries = await content.getLibraryList([currentLibrary, ...config.libraryList]);
+      const [curAndUsrLibs, sysLibs] = await Promise.all([
+        content.getLibraryList([currentLibrary, ...config.libraryList]),
+        content.getSystemLibraries()
+      ]);
 
-      items.push(...libraries.map((lib, index) => {
-        return new LibraryListNode(connection.upperCaseName(lib.name), lib, (index === 0 ? `currentLibrary` : `library`), config.showDescInLibList);
+      items.push(...curAndUsrLibs.map((lib, index) => {
+        const upperCaseLibName = connection.upperCaseName(lib.name);
+        const isSystemLib = index > 0 && sysLibs.includes(upperCaseLibName);
+        return new LibraryListNode(upperCaseLibName, lib, (index === 0 ? `currentLibrary` : `library`), config.showDescInLibList, isSystemLib);
       }));
     }
     return items;
@@ -369,13 +381,13 @@ class LibraryListView implements vscode.TreeDataProvider<LibraryListNode> {
 }
 
 class LibraryListNode extends vscode.TreeItem implements WithLibrary {
-  constructor(readonly library: string, readonly object: IBMiObject, context: 'currentLibrary' | 'library' = `library`, showDescInLibList: boolean) {
+  constructor(readonly library: string, readonly object: IBMiObject, context: 'currentLibrary' | 'library' = `library`, showDescInLibList: boolean, isSystemLib: boolean = false) {
     super(library, vscode.TreeItemCollapsibleState.None);
 
     this.contextValue = context;
     this.iconPath = new ThemeIcon('library');
     const isFound = object.text !== `*** NOT FOUND ***`;
-    this.resourceUri = Uri.parse(`${context}:${library}?isFound=${isFound}`);
+    this.resourceUri = Uri.parse(`${context}:${library}?isFound=${isFound}&isSystemLib=${isSystemLib}`);
     this.description =
       ((context === `currentLibrary` ? `${l10n.t(`(current library)`)}` : ``)
         + (object.text !== `` && showDescInLibList ? ` ${object.text}` : ``)
@@ -414,7 +426,8 @@ export class LiblDecorationProvider implements FileDecorationProvider {
 
     if (uri.scheme === 'currentLibrary' || uri.scheme === 'library') {
       const isNotFound = params.get('isFound') === 'false';
-      if (isNotFound) {
+      const isSystemLib = params.get('isSystemLib') === 'true';
+      if (isNotFound || isSystemLib) {
         return {
           badge: '⚠',
           color: new ThemeColor('errorForeground')


### PR DESCRIPTION
### Changes

Recently Scott had noticed that if you add a system library to the user library list (which Code4i does not prevent), it ends up breaking filters listing source physical files:

<img width="2925" height="857" alt="image" src="https://github.com/user-attachments/assets/25b80048-7c08-47a4-b27f-b4ea2d663aa6" />

This PR addresses this by:
1. Adding a check to validate any libraries being added to the user library list are not in the system portion.
2. Adding a red error decoration for any existing system libraries that have been added.


### How to test this PR
1. Attempt to add a system library to Code4i's user library list.
2. Manually add a system library (via settings.json), refresh the user library list view, and validate that it is highlighted in red.

### Checklist
* [x] have tested my change