### PR TITLE
Fix MFA support using `additionalAuthenticationFactor` JDBC option

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -264,6 +264,7 @@ export default class IBMi {
         this.client = new node_ssh.NodeSSH;
       }
 
+      let additionalAuthenticationFactor: string | undefined;
       if (connectionObject.enableMfa) {
         delete connectionObject.enableMfa;
 
@@ -271,9 +272,9 @@ export default class IBMi {
           callbacks.progress({
             message: `Prompting for additional factor.`
           });
-          const additionalFactor = await options.callbacks.inputBox(`Enter your additional factor or press "Enter" if within your TOTP interval`, `Additional Factor`, true);
-          if (additionalFactor) {
-            connectionObject.password = `${connectionObject.password}:${additionalFactor}`;
+          additionalAuthenticationFactor = await options.callbacks.inputBox(`Enter your additional factor or press "Enter" if within your TOTP interval`, `Additional Factor`, true);
+          if (additionalAuthenticationFactor) {
+            connectionObject.password = `${connectionObject.password}:${additionalAuthenticationFactor}`;
           }
         }
       }
@@ -609,7 +610,7 @@ export default class IBMi {
         const hasJavaInstalled = (this.remoteFeatures.jdk21 || this.remoteFeatures.jdk17 || this.remoteFeatures.jdk11 || this.remoteFeatures.jdk80);
         if (hasJavaInstalled) {
           try {
-            this.sqlJob = await mapepire.newJob(this);
+            this.sqlJob = await mapepire.newJob(this, { jdbc: { additionalAuthenticationFactor } as any });
             if (this.sqlJob.id) {
               this.splfUserData = `C4I${this.sqlJob.id.substring(0, this.sqlJob.id.indexOf('/'))}`;
               await this.sqlJob.execute(`CALL QSYS2.QCMDEXC('OVRPRTF FILE(*PRTF) SPOOL(*YES) HOLD(*YES) USRDTA(${this.splfUserData}) SPLFOWN(*CURUSRPRF) OVRSCOPE(*JOB)')`);


### PR DESCRIPTION
### Changes
Previously Code4i <3.0.0 supported MFA for IBM i 7.6, but this broke after 3.0.0 with the introduction of mapepire. As mentioned [here](https://github.com/Mapepire-IBMi/mapepire-server/issues/101#issuecomment-2734407942), mapepire supports MFA by passing the `additionalAuthenticationFactor` JDBC option.

TODO:
- [x] Verify MFA works for mapepire in server mode
- [ ] Verify MFA works for mapepire in single mode

### How to test this PR

To be added

### Checklist
* [ ] have tested my change
* [ ] have created one or more test cases
