### PR TITLE
Read server configuration on every connection

### DIFF
--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -190,6 +190,27 @@ export default class IBMi {
     }
   }
 
+  /**
+   * loads the remote configuration files /etc/vscode/settings.json and applies
+   * runs on every connection
+   */
+  private async loadAndApplyRemoteConfigs() {
+    await this.loadRemoteConfigs();
+
+    const remoteConnectionConfig = this.getConfigFile<RemoteConfigFile>(`settings`);
+    if (this.config && remoteConnectionConfig.getState() === `ok`) {
+      const remoteConfig = await remoteConnectionConfig.get();
+
+      if (remoteConfig.codefori) {
+        for (const [key, value] of Object.entries(remoteConfig.codefori)) {
+          if (!CLIENT_ONLY_SETTINGS.has(key) && this.config[key] !== undefined) {
+            this.config[key] = value;
+          }
+        }
+      }
+    }
+  }
+
   get dangerousVariants() {
     return this.variantChars.local !== this.variantChars.local.toLocaleUpperCase();
   };
@@ -600,6 +621,9 @@ export default class IBMi {
         callbacks.message(`warning`, `IBM i ${this.systemVersion} is not supported. Code for IBM i only supports 7.3 and above. Some features may not work correctly.`);
       }
 
+      callbacks.progress({ message: `Loading remote configuration files.` });
+      await this.loadAndApplyRemoteConfigs();
+
       callbacks.progress({ message: `Checking Mapepire status.` });
       const tempDirSet = await this.checkOrCreateTempDirectory();
       if (!tempDirSet) {
@@ -838,24 +862,6 @@ export default class IBMi {
       }
 
       this.appendOutput(`\n`);
-
-      // Load the remote connection configuration and apply it to the connection
-
-      callbacks.progress({ message: `Loading remote configuration files.` });
-      await this.loadRemoteConfigs();
-
-      const remoteConnectionConfig = this.getConfigFile<RemoteConfigFile>(`settings`);
-      if (remoteConnectionConfig.getState() === `ok`) {
-        const remoteConfig = await remoteConnectionConfig.get();
-
-        if (remoteConfig.codefori) {
-          for (const [key, value] of Object.entries(remoteConfig.codefori)) {
-            if (!CLIENT_ONLY_SETTINGS.has(key) && this.config[key] !== undefined) {
-              this.config[key] = value;
-            }
-          }
-        }
-      }
 
       callbacks.progress({
         message: `Checking temporary directory and temporary library configuration.`

--- a/src/api/components/mapepire/index.ts
+++ b/src/api/components/mapepire/index.ts
@@ -67,7 +67,7 @@ export class Mapepire implements IBMiComponent {
 
   async update(connection: IBMi): Promise<SecureComponentState> {
     if (connection.getConfig().mapepireUseServer) {
-      //no upload the remote JAR file in server mode
+      //No need to upload the remote JAR file in server mode
       return { status: "Installed", remoteSignature: Mapepire.SIGNATURE };
     }
 

--- a/src/api/components/mapepire/index.ts
+++ b/src/api/components/mapepire/index.ts
@@ -66,6 +66,11 @@ export class Mapepire implements IBMiComponent {
 
 
   async update(connection: IBMi): Promise<SecureComponentState> {
+    if (connection.getConfig().mapepireUseServer) {
+      //no upload the remote JAR file in server mode
+      return { status: "Installed", remoteSignature: Mapepire.SIGNATURE };
+    }
+
     try {
       if (!this.localAssetPath) {
         throw "Local Mapepire asset not set!";


### PR DESCRIPTION
### Changes
This PR adds the step of reading the server configuration file /etc/vscode/settings.json on every connection, rather than just running **CONNECT AND RELOAD SERVER SETTINGS**.
Additionally, it prevents mapepire files from being uploaded when used in server mode.

### How to test this PR
Connect to a system, try editing the configuration file /etc/vscode/settings.json, reconnect. The change should have been applied without having to reload.

### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
