### PR TITLE
Create helper for check routine signature

### DIFF
--- a/package.json
+++ b/package.json
@@ -3501,7 +3501,8 @@
 		"webpack": "webpack --mode development",
 		"webpack-dev": "webpack --mode development --watch",
 		"types": "npx -p typescript tsc ./src/extension.ts --declaration --allowJs --emitDeclarationOnly --outDir types --esModuleInterop -t es2022 --moduleResolution node --resolveJsonModule",
-		"postinstall": "npx tsx tools/downloadMapepire"
+		"postinstall": "npx tsx tools/downloadMapepire",
+		"sqlsignature": "npx tsx tools/sqlSignature"
 	},
 	"devDependencies": {
 		"@octokit/rest": "22.0.1",

--- a/src/api/IBMi.ts
+++ b/src/api/IBMi.ts
@@ -1240,6 +1240,8 @@ export default class IBMi {
   }
 
   async disconnect() {
+    await this.sqlJob?.close();
+
     if (this.client?.connection) {
       await (await this.getComponent<Mapepire>(Mapepire.ID))?.endJobs();
       //Close the connection and triggers its 'end' event

--- a/src/api/tests/connection.ts
+++ b/src/api/tests/connection.ts
@@ -69,7 +69,8 @@ export async function newConnection(reloadSettings?: boolean) {
 
   const conn = new IBMi();
 
-  const mapepire = new Mapepire(path.join(__dirname, `..`, `..`, `..`, `dist`));
+  //The password is required when connecting to a Mapepire Server (mapepireUseServer)
+  const mapepire = new Mapepire(path.join(__dirname, `..`, `..`, `..`, `dist`), async () => ENV_CREDS.password);
 
   const testingId = `testing`;
   extensionComponentRegistry.registerComponent(testingId, mapepire);

--- a/tools/sqlSignature.ts
+++ b/tools/sqlSignature.ts
@@ -1,0 +1,109 @@
+import { existsSync, readFileSync } from "fs";
+import path from "path";
+
+type RoutineType = "PROCEDURE" | "FUNCTION";
+
+const ENV_FILE = path.join(__dirname, `..`, `src`, `api`, `tests`, `.env`);
+
+function usage() {
+  console.log([
+    ``,
+    `Usage: npx tsx tools/sqlSignature <library>/<name> [PROCEDURE|FUNCTION]`,
+    ``,
+    `  <library>/<name>  the routine to look up; a dot also works (MYLIB.MYPROC).`,
+    `                    Names are uppercased unless "quoted".`,
+    `  [type]            when omitted, PROCEDURE and FUNCTION are both tried.`,
+    ``,
+    `Connection settings are read from ${path.relative(process.cwd(), ENV_FILE)}`,
+    `(same VITE_* variables as the test suite) or from the environment.`,
+    ``,
+  ].join(`\n`));
+}
+
+/**
+ * The connection helper reads its credentials from VITE_* variables when it's
+ * imported, so the test .env has to be in the environment before that happens.
+ */
+function loadEnv() {
+  if (!existsSync(ENV_FILE)) {
+    return;
+  }
+
+  for (const line of readFileSync(ENV_FILE, `utf-8`).split(/\r?\n/)) {
+    const variable = /^\s*([\w.-]+)\s*=\s*(.*?)\s*$/.exec(line);
+    if (variable) {
+      const [, key, value] = variable;
+      if (process.env[key] === undefined && value) {
+        process.env[key] = value.replace(/^["'](.*)["']$/, `$1`);
+      }
+    }
+  }
+}
+
+function parseName(part: string) {
+  const delimited = /^"(.+)"$/.exec(part);
+  return delimited ? delimited[1] : part.toUpperCase();
+}
+
+function parseTarget(target: string) {
+  const [library, name, ...rest] = target.split(/[\/.]/);
+  if (library && name && !rest.length) {
+    return { library: parseName(library), name: parseName(name) };
+  }
+}
+
+async function work() {
+  const [target, type] = process.argv.slice(2);
+  if (!target || target === `-h` || target === `--help`) {
+    usage();
+    process.exitCode = target ? 0 : 1;
+    return;
+  }
+
+  const routine = parseTarget(target);
+  if (!routine) {
+    console.log(`Invalid object name: ${target}`);
+    usage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const types: RoutineType[] = [`PROCEDURE`, `FUNCTION`];
+  if (type) {
+    const wanted = type.toUpperCase() as RoutineType;
+    if (!types.includes(wanted)) {
+      console.log(`Invalid type: ${type}. Expected PROCEDURE or FUNCTION.`);
+      process.exitCode = 1;
+      return;
+    }
+    types.splice(0, types.length, wanted);
+  }
+
+  loadEnv();
+
+  const { newConnection, disposeConnection } = await import(`../src/api/tests/connection`);
+
+  console.log(`Connecting to ${process.env.VITE_SERVER}...`);
+  const connection = await newConnection();
+  try {
+    const content = connection.getContent();
+    let found = false;
+    for (const routineType of types) {
+      const signature = await content.getSQLRoutineSignature(routine.library, routine.name, routineType);
+      if (signature) {
+        found = true;
+        console.log(`${routineType} ${routine.library}.${routine.name} => ${signature}`);
+      }
+    }
+
+    if (!found) {
+      console.log(`No ${types.join(` or `)} named ${routine.library}.${routine.name} found.`);
+      process.exitCode = 1;
+    }
+  }
+  finally {
+    await disposeConnection(connection);
+  }
+}
+
+work();


### PR DESCRIPTION
### Changes
This PR add an helper to get signature from a FUNCTION or a PROCEDURE using test defined environment.

### How to test this PR
1. Ensure you have src\api\tests\.env properly filled
2. Run from the basepath this command: `npx tsx tools/sqlSignature CODE4I.VALIDATE_STATEMENT0002`, it will return you the correct signature to be hardcoded:
<img width="955" height="62" alt="image" src="https://github.com/user-attachments/assets/d1f98b09-80a8-4dd1-bc55-4c9e6b4eadc0" />


### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
