### PR TITLE
Fix #2105: show specific error when running an Action on a read only target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,3 +77,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@phpdave](https://github.com/phpdave)
 * [@neerup](https://github.com/neerup)
 * [@Frank-Hildebrandt](https://github.com/Frank-Hildebrandt)
+* [@christianlarsen](https://github.com/christianlarsen)

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -631,6 +631,11 @@ export async function runAction(instance: Instance, uris: vscode.Uri | vscode.Ur
         message: actionMessage
       };
     }
+    else if (targets.some(t => t.protected)) {
+      actionMessage = l10n.t(`Action cannot be applied on a read only target.`);
+      vscode.window.showErrorMessage(actionMessage);
+      return { success: false, output: [], message: actionMessage };
+    }
     else {
       actionMessage = l10n.t(`No suitable actions found for {0} - {1}`, scheme, targets.map(t => t.extension).filter(Tools.distinct).join(", "));
       vscode.window.showErrorMessage(actionMessage);


### PR DESCRIPTION
### Changes
Shows a specific error message when an Action can't run because the target (member/streamfile/object) is protected or opened in read-only mode, instead of the generic "No suitable actions found" message.

This was originally fixed in #2241, but the fix was lost during the CompileTools refactor in ce5ac12c (Jan 2025) when this logic moved from `CompileTools.ts` to `src/ui/actions.ts` — the `isProtected` branch wasn't carried over.

Fixes #2105

### How to test this PR
1. Connect with `readOnlyMode` enabled (or open a member/file explicitly as read-only)
2. Try to run an Action on it
3. Confirm the error now says the target is read only, instead of "No suitable actions found"

### Checklist
- [x] have tested my change
- [ ] have created one or more test cases
- [ ] updated relevant documentation
- [x] Remove any/all `console.log`s I added
- [ ] have added myself to the contributors' list in CONTRIBUTING.md