### PR TITLE
Use `await` to check IFS shortcuts sequentially

### DIFF
--- a/src/ui/views/ifsBrowser.ts
+++ b/src/ui/views/ifsBrowser.ts
@@ -1,6 +1,6 @@
 import os from "os";
 import path, { dirname, extname } from "path";
-import vscode, { CancellationToken, FileDecoration, FileDecorationProvider, FileType, l10n, ProviderResult, ThemeColor, Uri, window } from "vscode";
+import vscode, { CancellationToken, FileDecorationProvider, FileType, l10n, ThemeColor, Uri, window } from "vscode";
 
 import { existsSync, mkdirSync, rmdirSync } from "fs";
 import IBMi from "../../api/IBMi";
@@ -1146,21 +1146,16 @@ export class ShortcutDecorationProvider implements FileDecorationProvider {
   private readonly _onDidChangeFileDecorations = new vscode.EventEmitter<vscode.Uri | vscode.Uri[] | undefined>();
   readonly onDidChangeFileDecorations = this._onDidChangeFileDecorations.event;
 
-  provideFileDecoration(uri: Uri, token: CancellationToken): ProviderResult<FileDecoration> {
-    if (uri.scheme === 'shortcut') {
-      return instance.getConnection()?.getContent().isDirectory(uri.path).then(isFound => {
-        if (!isFound) {
-          return {
-            badge: '⚠',
-            color: new ThemeColor('errorForeground'),
-            tooltip: l10n.t(`Directory does not exist.`)
-          };
-        }
-        return undefined;
-      });
+  async provideFileDecoration(uri: Uri, token: CancellationToken) {
+    if (uri.scheme === 'shortcut' && !await instance.getConnection()?.getContent().isDirectory(uri.path)) {
+      return {
+        badge: '⚠',
+        color: new ThemeColor('errorForeground'),
+        tooltip: l10n.t(`Directory does not exist.`)
+      };
     }
   }
-  
+
   refresh(uri?: vscode.Uri | vscode.Uri[]) {
     this._onDidChangeFileDecorations.fire(uri);
   }


### PR DESCRIPTION
### Changes
The decorator responsible for warning if an IFS shortcut doesn't exist anymore was not awaiting when running the `isDirectory` method.

That could lead to the SSH connection opening too many channels at once and disrupt other operations happening during the `connected` event.

This PR makes sure the call to `isDirectory` is `awaited` so it doesn't overwhelm the SSH connection.

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
Check the decorator logic still works
1. Create a temporary IFS folder
2. Create a shortcut in the IFS browser for it
3. Delete the folder from a terminal
4. Reconnect
5. The folder must be decorated in red

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change