### PR TITLE
Fix source members not saving when clearing all contents

### DIFF
--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -215,6 +215,7 @@ export class QSysFS implements vscode.FileSystemProvider {
                 if (addMember.code === 0) {
                     this.savedAsMembers.add(uri.path);
                     vscode.commands.executeCommand(`code-for-ibmi.refreshObjectBrowser`);
+                    return;
                 } else {
                     const copyMessages = Tools.parseMessages(addMember.stderr);
                     if (!copyMessages.findId(`CPF5812`)) { // CPF5812 - Member already exists
@@ -222,14 +223,13 @@ export class QSysFS implements vscode.FileSystemProvider {
                     }
                 }
             }
-            else {
-                this.savedAsMembers.delete(uri.path);
-                if (this.extendedMemberSupport) {
-                    await this.extendedContent.uploadMemberContentWithDates(uri, content.toString());
-                } else {
-                    await warnAboutSourceDates();
-                    await contentApi.uploadMemberContent(library, file, member, content);
-                }
+
+            this.savedAsMembers.delete(uri.path);
+            if (this.extendedMemberSupport) {
+                await this.extendedContent.uploadMemberContentWithDates(uri, content.toString());
+            } else {
+                await warnAboutSourceDates();
+                await contentApi.uploadMemberContent(library, file, member, content);
             }
         }
         else {


### PR DESCRIPTION
### Changes

Previously if you clear the entire contents of a source member and save, it would appear like the contents was removed. However, if you click the `Refresh File` action on the top right of the editor, you would see the contents come back. Part of the fix for this was in https://github.com/codefori/vscode-ibmi/pull/3156, but now this PR completes the fix.

### How to test this PR
1. Open a source member with some content.
2. Remove all the content.
3. Click the `Refresh File` button in the top right of the editor.
4. Observe that the content is not restored and the file is still empty.
5. Close and re-open the member and again verify the content is not restored.

### Checklist
* [x] have tested my change