### PR TITLE
Fix member name shown in lowercase after copy/rename

### DIFF
--- a/src/ui/views/objectBrowser.ts
+++ b/src/ui/views/objectBrowser.ts
@@ -827,7 +827,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
             }
 
             if (IBMi.connectionManager.get(`autoOpenFile`)) {
-              vscode.commands.executeCommand(`code-for-ibmi.openEditable`, fullPath);
+              vscode.commands.executeCommand(`code-for-ibmi.openEditable`, connection.upperCaseName(fullPath));
             }
 
             if (oldMember.library.toLocaleLowerCase() === memberPath.library.toLocaleLowerCase()) {
@@ -969,7 +969,7 @@ export function initializeObjectBrowser(context: vscode.ExtensionContext) {
       if (newNameOK && newMemberPath) {
         oldMemberTabs.forEach((tab) => {
           vscode.window.tabGroups.close(tab).then(() => {
-            vscode.commands.executeCommand(`code-for-ibmi.openEditable`, newMemberPath);
+            vscode.commands.executeCommand(`code-for-ibmi.openEditable`, connection.upperCaseName(newMemberPath));
           });
         })
       }


### PR DESCRIPTION
### Changes
When copying (`copyMember`) or renaming (`renameMember`) a source member and reopening it automatically, the editor tab used the raw, user-typed name instead of the uppercased QSYS member name. Source member names are always uppercase on IBM i, so typing e.g. `HELLo3` produced a tab titled `HELLo3.RPGLE` until the file was closed and reopened. Both commands now uppercase the path with `connection.upperCaseName()` before reopening, matching what `createMember` already does.

### How to test this PR
1. In the Object Browser, copy or rename a source member using a name typed with lowercase letters (e.g. `hello3`).
2. Confirm the reopened tab title shows the uppercased member name immediately, without needing to close and reopen it.

### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)