### PR TITLE
fix: convert tabs to spaces before SQL escaping to prevent backslash artifacts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,3 +78,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@neerup](https://github.com/neerup)
 * [@Frank-Hildebrandt](https://github.com/Frank-Hildebrandt)
 * [@christianlarsen](https://github.com/christianlarsen)
+* [@Balrocj](https://github.com/Balrocj)

--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -145,7 +145,7 @@ export class ExtendedIBMiContent {
           const recordLength = await this.readRecordLength(connection, alias, overFile);
 
           const decimalSequence = sourceData.length >= 10000;
-          const tabSize = vscode.workspace.getConfiguration(`editor`, uri).get<number>(`tabSize`) || 4;
+          const tabSize = (vscode.window.activeTextEditor?.options.tabSize as number) || 4;
 
           let rows = [],
             sequence = 0;

--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -145,13 +145,14 @@ export class ExtendedIBMiContent {
           const recordLength = await this.readRecordLength(connection, alias, overFile);
 
           const decimalSequence = sourceData.length >= 10000;
+          const tabSize = vscode.workspace.getConfiguration(`editor`, uri).get<number>(`tabSize`) || 4;
 
           let rows = [],
             sequence = 0;
           for (let i = 0; i < sourceData.length; i++) {
             sequence = decimalSequence ? ((i + 1) / 100) : i + 1;
             // Convert tabs to spaces to avoid escaping issues with special characters
-            sourceData[i] = sourceData[i].replace(/\t/g, (_, offset) => ' '.repeat(4 - (offset % 4))).trimEnd();
+            sourceData[i] = sourceData[i].replace(/\t/g, (_, offset) => ' '.repeat(tabSize - (offset % tabSize))).trimEnd();
             if (sourceData[i].length > recordLength) {
               sourceData[i] = sourceData[i].substring(0, recordLength);
             }

--- a/src/filesystems/qsys/extendedContent.ts
+++ b/src/filesystems/qsys/extendedContent.ts
@@ -150,7 +150,8 @@ export class ExtendedIBMiContent {
             sequence = 0;
           for (let i = 0; i < sourceData.length; i++) {
             sequence = decimalSequence ? ((i + 1) / 100) : i + 1;
-            sourceData[i] = sourceData[i].trimEnd();
+            // Convert tabs to spaces to avoid escaping issues with special characters
+            sourceData[i] = sourceData[i].replace(/\t/g, (_, offset) => ' '.repeat(4 - (offset % 4))).trimEnd();
             if (sourceData[i].length > recordLength) {
               sourceData[i] = sourceData[i].substring(0, recordLength);
             }
@@ -237,7 +238,9 @@ function sliceUp(arr: any[], size: number): any[] {
 }
 
 function escapeString(val: string): string {
-  val = val.replace(/[\0\n\r\b\t'\x1a]/g, function (s) {
+  // Note: Tabs are converted to spaces before this function is called (in uploadMemberContentWithDates),
+  // so we don't need to handle them here. This prevents the backslash artifacts in #2463 and #3086.
+  val = val.replace(/[\0\n\r\b'\x1a]/g, function (s) {
     switch (s) {
       case `\0`:
         return `\\0`;


### PR DESCRIPTION
## Problem

When source members containing real TAB characters (e.g. pasted from outside VS Code; Notepad, Copilot among others) 
were saved and reopened, a backslash `\` would appear in place of the TAB character.

Closes #2463
Closes #3086
Closes #3167

## Root Cause

`escapeString()` was converting `\t` (TAB) into `\\t` for the SQL INSERT statement. 
When the member was downloaded again, the revert logic using `includes(\\\t)` was 
fragile and failed to restore it correctly, leaving a visible backslash.

## Fix

Convert TABs to spaces using proper tab-stop alignment (every 4 characters) **before** 
calling `escapeString()`, so `\t` never reaches the SQL escaping logic.

## How to Reproduce

1. Open any source member (e.g. SQLRPGLE)
2. Paste code from outside VS Code (Notepad/Copilot) that contains a real TAB character
3. Save (Ctrl+S), close (Ctrl+W), reopen the file
4. **Before fix:** A backslash `\` appears where the TAB was
5. **After fix:** 4 spaces appear, no backslash 