### PR TITLE
Add visible-end folding for RPGLE blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,3 +78,4 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@neerup](https://github.com/neerup)
 * [@Frank-Hildebrandt](https://github.com/Frank-Hildebrandt)
 * [@christianlarsen](https://github.com/christianlarsen)
+* [@Balrocj](https://github.com/Balrocj)

--- a/src/api/tests/suites/rpgleFolding.test.ts
+++ b/src/api/tests/suites/rpgleFolding.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { parseBlockFoldingRanges } from '../../../languages/rpgle/foldingRanges';
+
+describe('RPGLE procedure folding', { concurrent: true }, () => {
+  it('keeps end-proc visible when folding a procedure', () => {
+    const source = [
+      'dcl-proc GetCurrentUser;',
+      '  dcl-pi *n varchar(50); end-pi;',
+      '',
+      '  return user;',
+      'end-proc;',
+      ''
+    ];
+
+    expect(parseBlockFoldingRanges(source)).toEqual([
+      {
+        start: 0,
+        end: 3
+      }
+    ]);
+  });
+
+  it('ignores procedures with no foldable body before end-proc', () => {
+    const source = [
+      'dcl-proc EmptyProc;',
+      'end-proc;'
+    ];
+
+    expect(parseBlockFoldingRanges(source)).toEqual([]);
+  });
+
+  it('keeps end-pi visible when folding a procedure interface', () => {
+    const source = [
+      'dcl-pi *n packed(9:2);',
+      '  leftValue packed(9:2) const;',
+      '  rightValue packed(9:2) const;',
+      'end-pi;'
+    ];
+
+    expect(parseBlockFoldingRanges(source)).toEqual([
+      {
+        start: 0,
+        end: 2
+      }
+    ]);
+  });
+
+  it('keeps endif and endsl visible for nested control blocks', () => {
+    const source = [
+      'select;',
+      '  when condition1;',
+      '    if flag;',
+      '      dsply ''A'';',
+      '    endif;',
+      'endsl;'
+    ];
+
+    expect(parseBlockFoldingRanges(source)).toEqual([
+      {
+        start: 0,
+        end: 4
+      },
+      {
+        start: 2,
+        end: 3
+      }
+    ]);
+  });
+
+  it('does not treat sql select as an RPG select block', () => {
+    const source = [
+      'exec sql',
+      '  select current user',
+      '    into :result',
+      '  from sysibm.sysdummy1;',
+      'select;',
+      '  when hasValue;',
+      '    dsply ''ok'';',
+      'endsl;'
+    ];
+
+    expect(parseBlockFoldingRanges(source)).toEqual([
+      {
+        start: 4,
+        end: 6
+      }
+    ]);
+  });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { Deployment } from "./filesystems/local/deployment";
 import { handleEditorsLeftOpened } from "./filesystems/qsys/FSUtils";
 import { instance, loadAllofExtension } from './instantiate';
 import { LocalActionCompletionItemProvider } from "./languages/actions/completion";
+import { registerRpgleProcedureFolding } from "./languages/rpgle/folding";
 import { mergeCommandProfiles } from "./mergeProfiles";
 import { initialise } from "./testing";
 import { CodeForIBMi } from "./typings";
@@ -99,6 +100,7 @@ export async function activate(context: ExtensionContext): Promise<CodeForIBMi> 
     workspace.registerFileSystemProvider(`streamfile`, new IFSFS(), {
       isCaseSensitive: false
     }),
+    registerRpgleProcedureFolding(),
     languages.registerCompletionItemProvider({ language: 'json', pattern: "**/.vscode/actions.json" }, new LocalActionCompletionItemProvider(), "&"),
     window.registerCustomEditorProvider(`code-for-ibmi.editor`, new CustomEditorProvider(), {
       webviewOptions: {

--- a/src/languages/rpgle/folding.ts
+++ b/src/languages/rpgle/folding.ts
@@ -1,0 +1,23 @@
+import * as vscode from "vscode";
+import { parseBlockFoldingRanges } from "./foldingRanges";
+
+const rpgleSelectors: vscode.DocumentSelector = [
+  { language: `rpgle` },
+  { pattern: `**/*.rpgle` },
+  { pattern: `**/*.sqlrpgle` },
+  { pattern: `**/*.rpgleinc` }
+];
+
+class RpgleProcedureFoldingProvider implements vscode.FoldingRangeProvider {
+  provideFoldingRanges(document: vscode.TextDocument): vscode.FoldingRange[] {
+    return parseBlockFoldingRanges(document.getText().split(/\r?\n/))
+      .map(range => new vscode.FoldingRange(range.start, range.end, vscode.FoldingRangeKind.Region));
+  }
+}
+
+export function registerRpgleProcedureFolding(): vscode.Disposable {
+  return vscode.languages.registerFoldingRangeProvider(
+    rpgleSelectors,
+    new RpgleProcedureFoldingProvider()
+  );
+}

--- a/src/languages/rpgle/foldingRanges.ts
+++ b/src/languages/rpgle/foldingRanges.ts
@@ -1,0 +1,130 @@
+export type LineFoldingRange = {
+  start: number;
+  end: number;
+};
+
+type BlockDefinition = {
+  start: string;
+  end: string[];
+};
+
+type OpenBlock = {
+  startLine: number;
+  definition: BlockDefinition;
+};
+
+const blockDefinitions: BlockDefinition[] = [
+  { start: `if`, end: [`endif`, `end`] },
+  { start: `ifeq`, end: [`endif`, `end`] },
+  { start: `ifge`, end: [`endif`, `end`] },
+  { start: `ifgt`, end: [`endif`, `end`] },
+  { start: `ifle`, end: [`endif`, `end`] },
+  { start: `iflt`, end: [`endif`, `end`] },
+  { start: `ifne`, end: [`endif`, `end`] },
+  { start: `dow`, end: [`enddo`, `end`] },
+  { start: `doweq`, end: [`enddo`, `end`] },
+  { start: `dowge`, end: [`enddo`, `end`] },
+  { start: `dowgt`, end: [`enddo`, `end`] },
+  { start: `dowle`, end: [`enddo`, `end`] },
+  { start: `dowlt`, end: [`enddo`, `end`] },
+  { start: `downe`, end: [`enddo`, `end`] },
+  { start: `dou`, end: [`enddo`, `end`] },
+  { start: `doueq`, end: [`enddo`, `end`] },
+  { start: `douge`, end: [`enddo`, `end`] },
+  { start: `dougt`, end: [`enddo`, `end`] },
+  { start: `doule`, end: [`enddo`, `end`] },
+  { start: `doult`, end: [`enddo`, `end`] },
+  { start: `doune`, end: [`enddo`, `end`] },
+  { start: `do`, end: [`enddo`, `end`] },
+  { start: `select`, end: [`endsl`, `end`] },
+  { start: `for`, end: [`endfor`, `end`] },
+  { start: `for-each`, end: [`endfor`, `end`] },
+  { start: `begsr`, end: [`endsr`] },
+  { start: `monitor`, end: [`endmon`] },
+  { start: `dcl-ds`, end: [`end-ds`] },
+  { start: `dcl-proc`, end: [`end-proc`] },
+  { start: `dcl-pr`, end: [`end-pr`] },
+  { start: `dcl-pi`, end: [`end-pi`] }
+];
+
+const startDefinitionByToken = new Map(blockDefinitions.map(definition => [definition.start, definition]));
+const closingTokens = new Set(blockDefinitions.flatMap(definition => definition.end));
+
+function getLeadingToken(line: string): string | undefined {
+  const trimmedLine = line.trim();
+
+  if (!trimmedLine || trimmedLine.startsWith(`//`)) {
+    return undefined;
+  }
+
+  const tokenMatch = trimmedLine.match(/^[a-z][a-z0-9-]*/i);
+  return tokenMatch?.[0].toLowerCase();
+}
+
+function findMatchingOpenBlock(openBlocks: OpenBlock[], closingToken: string): OpenBlock | undefined {
+  const lastOpenBlock = openBlocks[openBlocks.length - 1];
+
+  if (lastOpenBlock?.definition.end.includes(closingToken)) {
+    return openBlocks.pop();
+  }
+
+  return undefined;
+}
+
+export function parseBlockFoldingRanges(lines: string[]): LineFoldingRange[] {
+  const ranges: LineFoldingRange[] = [];
+  const openBlocks: OpenBlock[] = [];
+  let inExecSqlBlock = false;
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
+    const trimmedLine = line.trim().toLowerCase();
+
+    if (inExecSqlBlock) {
+      if (trimmedLine.includes(`;`)) {
+        inExecSqlBlock = false;
+      }
+
+      continue;
+    }
+
+    if (/^exec\s+sql\b/i.test(trimmedLine)) {
+      if (!trimmedLine.includes(`;`)) {
+        inExecSqlBlock = true;
+      }
+
+      continue;
+    }
+
+    const token = getLeadingToken(line);
+
+    if (!token) {
+      continue;
+    }
+
+    const openingDefinition = startDefinitionByToken.get(token);
+
+    if (openingDefinition) {
+      openBlocks.push({
+        startLine: lineIndex,
+        definition: openingDefinition
+      });
+      continue;
+    }
+
+    if (closingTokens.has(token)) {
+      const openBlock = findMatchingOpenBlock(openBlocks, token);
+
+      if (openBlock && lineIndex - 1 > openBlock.startLine) {
+        ranges.push({
+          start: openBlock.startLine,
+          end: lineIndex - 1
+        });
+      }
+    }
+  }
+
+  return ranges.sort((left, right) => left.start - right.start || left.end - right.end);
+}
+
+export const parseProcedureFoldingRanges = parseBlockFoldingRanges;


### PR DESCRIPTION
### Changes
Add a custom folding range provider for RPGLE blocks so collapsed regions keep the closing line visible when possible.

closes codefori/vscode-rpgle#586

This includes support for common RPGLE block pairs such as:
- `dcl-proc` / `end-proc`
- `dcl-pi` / `end-pi`
- `dcl-pr` / `end-pr`
- `dcl-ds` / `end-ds`
- `if*` / `endif`
- `do*`, `dou*`, `dow*` / `enddo`
- `for`, `for-each` / `endfor`
- `select` / `endsl`
- `monitor` / `endmon`
- `begsr` / `endsr`

The provider also avoids treating embedded SQL `select` statements as RPG `select` blocks.

This implementation is designed to keep closing lines like `end-proc`, `end-pi`, `endif`, and `endsl` visible when collapsing non-empty blocks. Empty two-line blocks are not folded in this mode, since VS Code folding ranges require at least one interior line to collapse.

### How to test this PR
1. Launch the extension in the Extension Development Host.
2. Open an `.rpgle` or `.sqlrpgle` source member or local file.
3. Collapse procedures, interfaces, and control-flow blocks.
4. Verify that the closing line remains visible for non-empty blocks.
5. Verify that embedded SQL blocks do not create false `select` folding ranges.
6. Verify that empty two-line blocks such as `dcl-pi ...` immediately followed by `end-pi;` are not folded in this mode.

### Checklist
* [x] have tested my change
* [x] have created one or more test cases
* [ ] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)