### PR TITLE
Fixed Mapepire component SQL jobs tracking

### DIFF
--- a/src/api/components/mapepire/index.ts
+++ b/src/api/components/mapepire/index.ts
@@ -20,7 +20,7 @@ export class Mapepire implements IBMiComponent {
   private installPath = "";
   private readonly version: SemanticVersion;
 
-  readonly jobs: Map<string, SQLJob> = new Map;
+  private readonly jobs: Map<string, SQLJob> = new Map;
 
   constructor(localAssetRoot: string, private readonly passwordProvider?: (connectionName: IBMi) => Promise<string | undefined>) {
     this.localAssetPath = path.join(localAssetRoot, SERVER_VERSION_FILE);
@@ -139,7 +139,7 @@ export class Mapepire implements IBMiComponent {
         password,
         rejectUnauthorized: (config.mapepireAllowSelfCert !== true),
         port: config.mapepireServerPort
-      });
+      });      
     }
     else {
       //Single mode over SSH
@@ -159,8 +159,15 @@ export class Mapepire implements IBMiComponent {
       await sshJob.connectSsh(connection, stream);
     }
 
-    // sqlJob.setTraceConfig(`IN_MEM`, `ON`);
-    // sqlJob.enableLocalTrace();
+    this.jobs.set(sqlJob.getUniqueId(), sqlJob);
+
+    let closeJob = sqlJob.close;
+    closeJob = closeJob.bind(sqlJob);
+    sqlJob.close = async () => {
+      this.jobs.delete(sqlJob.getUniqueId());
+      closeJob();
+    }
+
     return sqlJob;
   }
 

--- a/src/api/components/mapepire/sshSqlJob.ts
+++ b/src/api/components/mapepire/sshSqlJob.ts
@@ -8,7 +8,6 @@ import { JobStatus } from "./types";
 export class SSHSQLJob extends SQLJob {
   static application = "<unknown>";
   private channel: ClientChannel | undefined;
-  private onClose?: () => void;
 
   async getSshChannel(mapepire: Mapepire, connection: IBMi, javaPath: string): Promise<ClientChannel> {
     const useExec = await Mapepire.useExec(connection);
@@ -21,9 +20,7 @@ export class SSHSQLJob extends SQLJob {
         if (err) {
           reject(err);
         }
-        mapepire.jobs.set(this.getUniqueId(), this);
-        this.onClose = () => mapepire.jobs.delete(this.uniqueId);
-
+        
         let outString = ``;
 
         stream.stderr.on(`data`, (data: Buffer) => {
@@ -43,7 +40,7 @@ export class SSHSQLJob extends SQLJob {
                 const response: ServerResponse = JSON.parse(thisMsg);
                 this.responseEmitter.emit(response.id, response);
               } catch (e: any) {
-                const error = `Mapepire output error: ${e}\nData: ${thisMsg}`;                  
+                const error = `Mapepire output error: ${e}\nData: ${thisMsg}`;
                 connection.appendOutput(error + "\n");
                 console.log(e);
                 outString = ``;
@@ -80,7 +77,7 @@ export class SSHSQLJob extends SQLJob {
   /**
    * The same as mapepire-js#connect, but with SSH
    */
-  async connectSsh(connection:IBMi, channel: ClientChannel): Promise<ConnectionResult> {
+  async connectSsh(connection: IBMi, channel: ClientChannel): Promise<ConnectionResult> {
     // this.isTracingChannelData = true;
 
     this.channel = channel;
@@ -158,6 +155,5 @@ export class SSHSQLJob extends SQLJob {
     this.channel = undefined;
     this.status = JobStatus.ENDED;
     this.responseEmitter.removeAllListeners();
-    this.onClose?.();
   }
 }


### PR DESCRIPTION
### Changes
<!-- Describe your change here. -->
This PR fixes the tracking of SQL jobs opened by the Mapepire component:
- All jobs are now correctly added to the job Map; only SSH Jobs were added, jobs opened in Websocket mode were not.
- Closing a job will remove it from the job Map; job's `close()` has been overriden to do so

### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->
1. Run the extension in debug mode
2. Put a breakpoint in `src/api/components/mapepire/index.ts` on line `168`
3. Open multiple jobs with the Db2 extension and then close them
4. Check when the breakpoint is reached that the jobs Map doesn't contain that job
5. Check the job is correctly closed on the IBM i

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
