### PR TITLE
Add PGMINFO option to command strings in package.jso

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,3 +90,5 @@ Thanks so much to everyone [who has contributed](https://github.com/codefori/vsc
 * [@Frank-Hildebrandt](https://github.com/Frank-Hildebrandt)
 * [@christianlarsen](https://github.com/christianlarsen)
 * [@Balrocj](https://github.com/Balrocj)
+* [@anandsha20](https://github.com/anandsha20)
+

--- a/package.json
+++ b/package.json
@@ -734,7 +734,7 @@
 								"CBL"
 							],
 							"name": "Create Bound COBOL Program (CRTBNDCBL)",
-							"command": "CRTBNDCBL (&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*SOURCE) DBGVIEW(*SOURCE)"
+							"command": "CRTBNDCBL (&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*SOURCE) DBGVIEW(*SOURCE) PGMINFO(*PCML *MODULE)"
 						},
 						{
 							"type": "member",
@@ -743,7 +743,7 @@
 								"CBL"
 							],
 							"name": "Create Module CBLLE (CRTCBLMOD)",
-							"command": "CRTCBLMOD MODULE(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*SOURCE) DBGVIEW(*SOURCE)"
+							"command": "CRTCBLMOD MODULE(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*SOURCE) DBGVIEW(*SOURCE) PGMINFO(*PCML *MODULE)"
 						},
 						{
 							"type": "member",
@@ -751,7 +751,7 @@
 								"RPGLE"
 							],
 							"name": "Create Bound RPG Program (CRTBNDRPG)",
-							"command": "CRTBNDRPG PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT)"
+							"command": "CRTBNDRPG PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT) PGMINFO(*PCML *MODULE)"
 						},
 						{
 							"type": "member",
@@ -791,7 +791,7 @@
 								"RPGLE"
 							],
 							"name": "Create RPG Module (CRTRPGMOD)",
-							"command": "?CRTRPGMOD MODULE(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT)"
+							"command": "?CRTRPGMOD MODULE(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) OPTION(*EVENTF) DBGVIEW(*SOURCE) TGTRLS(*CURRENT) PGMINFO(*PCML *MODULE)"
 						},
 						{
 							"type": "member",


### PR DESCRIPTION
### Changes
Why Needed:
When adding a service program or RPG program to an IWS  server, a PCML file is required. Currently, generating the PCML file is not included by default in the compile commands, which makes it harder to add newly compiled or updated programs to IWS.

Additonal Info:
According to IBM documentation, specifying PGMINFO(*PCML *MODULE) causes the compiler to generate an XML (PCML) description of the program's parameter interface and embed it inside the compiled module object (*MODULE). When that module is later bound into a *PGM or *SRVPGM, the PCML travels with it into that object too.

This change will not cause any issue with non-IWS programs
### How to test this PR
<!-- 
Example:
1. Run the test cases
2. Expand view A and right click on the node
3. Run 'Execute Thing' from the command palette
-->

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [x] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
