### PR TITLE
Fix `writeFile` file system API when used on members by other extensions

### DIFF
--- a/src/api/IBMiContent.ts
+++ b/src/api/IBMiContent.ts
@@ -301,7 +301,7 @@ export default class IBMiContent {
    * @param member
    * @param content
    */
-  async uploadMemberContent(library: string, sourceFile: string, member: string, content: string | Uint8Array): Promise<boolean> {
+  async uploadMemberContent(library: string, sourceFile: string, member: string, content: string | Uint8Array, extension?: string): Promise<boolean> {
     library = this.ibmi.upperCaseName(library);
     sourceFile = this.ibmi.upperCaseName(sourceFile);
     member = this.ibmi.upperCaseName(member);
@@ -383,6 +383,14 @@ export default class IBMiContent {
           if (messages.findId("CPIA083")) {
             // TODO: what do we do about this, really?
             // window.showWarningMessage(`${library}/${sourceFile}(${member}) was saved with truncated records!`);
+          } else if (messages.findId("CPC7305")) {
+            // Member was newly created so we need to set the source type
+            if (extension) {
+              await this.ibmi.runCommand({
+                command: `QSYS/CHGPFM FILE(${library}/${sourceFile}) MBR(${member}) SRCTYPE(${extension})`,
+                noLibList: true
+              });
+            }
           }
           return true;
         } else {

--- a/src/api/tests/suites/content.test.ts
+++ b/src/api/tests/suites/content.test.ts
@@ -941,4 +941,26 @@ describe('Content Tests', { concurrent: true }, () => {
     const newLibl = await connection.getContent().getLibraryListFromCommand(`CHGLIBL CURLIB(SYSTOOLS)`);
     expect(newLibl?.currentLibrary).toBe(`SYSTOOLS`);
   });
+
+  it('uploadMemberContent on non-existent member', async () => {
+    const content = connection.getContent();
+    const tempLib = connection.getConfig().tempLibrary;
+    const sourceFile = Tools.makeid(8);
+    const member = Tools.makeid(8);
+
+    try {
+      const createSPF = await connection.runCommand({ command: `QSYS/CRTSRCPF FILE(${tempLib}/${sourceFile}) RCDLEN(112)`, noLibList: true });
+      expect(createSPF.code).toBe(0);
+
+      const uploaded = await content.uploadMemberContent(tempLib, sourceFile, member, `CONTENT`, `RPGLE`);
+      expect(uploaded).toBe(true);
+
+      const [memberInfo] = await content.getMemberList({ library: tempLib, sourceFile, members: member });
+      expect(memberInfo).toBeDefined();
+      expect(memberInfo.name).toBe(member.toUpperCase());
+      expect(memberInfo.extension).toBe(`RPGLE`);
+    } finally {
+      await connection.runCommand({ command: `QSYS/DLTF FILE(${tempLib}/${sourceFile})`, noLibList: true });
+    }
+  });
 });

--- a/src/filesystems/qsys/QSysFs.ts
+++ b/src/filesystems/qsys/QSysFs.ts
@@ -153,6 +153,24 @@ export class QSysFS implements vscode.FileSystemProvider {
         return await connection.getContent().getAttributes(path, "CREATE_TIME", "MODIFY_TIME", "DATA_SIZE");
     }
 
+    private async createMember(connection: IBMi, uri: vscode.Uri, library: string, file: string, member: string, extension: string | undefined): Promise<boolean> {
+        const addMember = await connection.runCommand({
+            command: `QSYS/ADDPFM FILE(${library}/${file}) MBR(${member}) SRCTYPE(${extension || '*NONE'})`,
+            noLibList: true
+        });
+        if (addMember.code === 0) {
+            this.savedAsMembers.add(uri.path);
+            vscode.commands.executeCommand(`code-for-ibmi.refreshObjectBrowser`);
+            return true;
+        } else {
+            const messages = Tools.parseMessages(addMember.stderr);
+            if (!messages.findId(`CPF5812`)) { // CPF5812 - Member already exists
+                throw new FileSystemError(addMember.stderr);
+            }
+            return false;
+        }
+    }
+
     async parseMemberPath(connection: IBMi, path: string) {
         const memberParts = connection.parserMemberPath(path);
         memberParts.asp = memberParts.asp || await connection.getLibraryIAsp(memberParts.library);
@@ -208,28 +226,28 @@ export class QSysFS implements vscode.FileSystemProvider {
             asp = asp || await connection.getLibraryIAsp(library);
 
             if (!content.length) { //Coming from "Save as"
-                const addMember = await connection.runCommand({
-                    command: `QSYS/ADDPFM FILE(${library}/${file}) MBR(${member}) SRCTYPE(${extension || '*NONE'})`,
-                    noLibList: true
-                });
-                if (addMember.code === 0) {
-                    this.savedAsMembers.add(uri.path);
-                    vscode.commands.executeCommand(`code-for-ibmi.refreshObjectBrowser`);
+                const isCreated = await this.createMember(connection, uri, library, file, member, extension);
+                if (isCreated) {
                     return;
-                } else {
-                    const copyMessages = Tools.parseMessages(addMember.stderr);
-                    if (!copyMessages.findId(`CPF5812`)) { // CPF5812 - Member already exists
-                        throw new FileSystemError(addMember.stderr);
-                    }
                 }
             }
 
             this.savedAsMembers.delete(uri.path);
             if (this.extendedMemberSupport) {
-                await this.extendedContent.uploadMemberContentWithDates(uri, content.toString());
+                try {
+                    await this.extendedContent.uploadMemberContentWithDates(uri, content.toString());
+                } catch (error: any) {
+                    if (error?.sqlstate === `42704`) {
+                        // Member doesn't exists so create and try again
+                        await this.createMember(connection, uri, library, file, member, extension);
+                        await this.extendedContent.uploadMemberContentWithDates(uri, content.toString());
+                    } else {
+                        throw error;
+                    }
+                }
             } else {
                 await warnAboutSourceDates();
-                await contentApi.uploadMemberContent(library, file, member, content);
+                await contentApi.uploadMemberContent(library, file, member, content, extension);
             }
         }
         else {


### PR DESCRIPTION
### Changes

In one of our other extensions, we make use of VS Code's file system APIs to read / write to members using Code4i's custom file system provider for QSYS:

```ts
await workspace.fs.writeFile(memberUri, Buffer.from(content, 'utf8'));
```

Previously, when the member does not exist and this API is used, it would fail in 2 scenarios:
1. **Source Dates Enabled**: The member would fail to be created.
2. **Source Dates Disabled**: The member would be created successfully with the content, but it would not have the source type.

This PR now fixes both scenarios.

### How to test this PR

This is not exactly testable using any functionality in Code4i. You can reproduce the original issue and verify the fix using an extension that uses the `writeFile` API on a `uri` with the `member` scheme. You can also use the unit tests to validate that nothing has been broken and the new test properly sets the source type now.

### Checklist
* [x] have tested my change
* [x] have created one or more test cases